### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/mandrean/ferrokinesis/compare/v0.1.0...v0.1.1) - 2026-03-17
+
+### Added
+
+- Add cross-compiled binary releases for 6 platforms
+
+### Other
+
+- Fix clippy warnings (collapsible-if, allows for structural patterns)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrokinesis"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrokinesis"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "A local AWS Kinesis mock server for testing, written in Rust"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `ferrokinesis`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/mandrean/ferrokinesis/compare/v0.1.0...v0.1.1) - 2026-03-17

### Added

- Add cross-compiled binary releases for 6 platforms

### Other

- Fix clippy warnings (collapsible-if, allows for structural patterns)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).