### PR TITLE
ci: use semantic-rs binary for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,10 @@ jobs:
         if: steps.guard.outputs.skip == 'false'
       - name: Install semantic-rs
         if: steps.guard.outputs.skip == 'false'
-        run: cargo install --git https://github.com/mandrean/semantic-rs --locked
+        run: |
+          curl -fsSL https://github.com/mandrean/semantic-rs/releases/download/v2.0.2/semantic-rs-linux-amd64 \
+            -o /usr/local/bin/semantic-rs
+          chmod +x /usr/local/bin/semantic-rs
       - name: Configure git
         if: steps.guard.outputs.skip == 'false'
         run: |


### PR DESCRIPTION
## Summary

- Replaces `release-plz` with `semantic-rs` for automated versioning and releases
- Downloads the `semantic-rs` binary from GitHub Releases (v2.0.2) in CI
- Skips the release job if the last commit was already a release commit

## Test plan

- [ ] Merge to main and verify the release job runs end-to-end