### PR TITLE
ci: add Docker smoke test before image push (#28)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@v4
       - name: Get version from Cargo.toml
@@ -105,19 +110,39 @@ jobs:
           mv docker-context/amd64/ferrokinesis-linux-amd64 docker-context/amd64/ferrokinesis
           mv docker-context/arm64/ferrokinesis-linux-arm64 docker-context/arm64/ferrokinesis
           chmod +x docker-context/*/ferrokinesis
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+          buildkitd-config-inline: |
+            [registry."localhost:5000"]
+              http = true
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-
+            type=raw,value=v${{ steps.version.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.version }}
+      - name: Build multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker-context
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: localhost:5000/ferrokinesis:smoke
+          labels: ${{ steps.meta.outputs.labels }}
       - name: Smoke test
         run: |
-          # Build a local linux/amd64-only image for smoke testing (no push)
-          docker buildx build \
-            --platform linux/amd64 \
-            --build-arg TARGETARCH=amd64 \
-            --load \
-            --tag ferrokinesis-smoke:test \
-            --file ./Dockerfile \
-            docker-context
+          # Pull from local registry (gets native amd64 on the GHA runner)
+          docker pull localhost:5000/ferrokinesis:smoke
 
           # Start the container
-          docker run -d --name ferrokinesis-smoke -p 4567:4567 ferrokinesis-smoke:test
+          docker run -d --name ferrokinesis-smoke -p 4567:4567 localhost:5000/ferrokinesis:smoke
 
           # Wait for the service to be ready
           curl --retry 10 --retry-delay 1 --retry-connrefused --silent --fail \
@@ -144,33 +169,21 @@ jobs:
 
           # Cleanup
           docker stop ferrokinesis-smoke && docker rm ferrokinesis-smoke
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=latest
-            type=sha,prefix=sha-
-            type=raw,value=v${{ steps.version.outputs.version }}
-            type=raw,value=${{ steps.version.outputs.version }}
-      - name: Build and push multi-arch image
-        uses: docker/build-push-action@v6
-        with:
-          context: docker-context
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Push to GHCR
+        run: |
+          TAG_ARGS=""
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && TAG_ARGS="$TAG_ARGS --tag $tag"
+          done <<< "$TAGS"
+          docker buildx imagetools create $TAG_ARGS localhost:5000/ferrokinesis:smoke
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
 
   publish:
     name: Publish


### PR DESCRIPTION
## Summary

- Adds a **Docker smoke test** in the `docker` CI job that validates the image before pushing to GHCR.
- Uses a **local Docker registry** (`registry:2` service container) so the multi-arch image is built only **once** — no duplicate builds.
- The flow: build multi-arch (`linux/amd64` + `linux/arm64`) → push to local registry → smoke test → copy to GHCR via `docker buildx imagetools create`.
- Smoke test pulls from the local registry, starts the container on port 4567, and runs two Kinesis API checks (`CreateStream` + `ListStreams`), asserting the response contains `"smoke-test"`.
- Fails the pipeline if any curl call returns a non-zero exit code.

Closes #28