### PR TITLE
chore: release v0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ coverage/
 .env
 .env.local
 
+# proptest regression files
+**/*.proptest-regressions
+
 # Conformance test artifacts
 tests/conformance/java-sdk-v1/target/
 tests/conformance/java-sdk-v2/target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/mandrean/ferrokinesis/compare/v0.1.2...v0.2.0) - 2026-03-19
+
+### Added
+
+- add ARN format regex validation ([#111](https://github.com/mandrean/ferrokinesis/pull/111))
+- add TLS/HTTPS support behind `tls` feature flag ([#109](https://github.com/mandrean/ferrokinesis/pull/109))
+- add KCL v1 integration test ([#106](https://github.com/mandrean/ferrokinesis/pull/106))
+- add SubscribeToShard end-to-end SDK tests ([#107](https://github.com/mandrean/ferrokinesis/pull/107))
+- add CBOR ↔ JSON equivalence tests and fix byte string handling ([#88](https://github.com/mandrean/ferrokinesis/pull/88))
+- add Goose load test for kinesalite comparison ([#84](https://github.com/mandrean/ferrokinesis/pull/84))
+- add retention period enforcement with TTL-based record trimming ([#87](https://github.com/mandrean/ferrokinesis/pull/87))
+- add multi-language SDK conformance test suite ([#83](https://github.com/mandrean/ferrokinesis/pull/83))
+- enforce 5 MB PutRecords batch limit and add stress tests ([#82](https://github.com/mandrean/ferrokinesis/pull/82))
+- add criterion benchmark suite with CI regression gate ([#80](https://github.com/mandrean/ferrokinesis/pull/80))
+- add configurable shard iterator TTL ([#40](https://github.com/mandrean/ferrokinesis/pull/40)) ([#77](https://github.com/mandrean/ferrokinesis/pull/77))
+- add health check endpoints and CLI subcommand ([#72](https://github.com/mandrean/ferrokinesis/pull/72))
+- configurable AWS account ID and region via CLI flags and config file ([#79](https://github.com/mandrean/ferrokinesis/pull/79))
+- add configurable request body size limit ([#45](https://github.com/mandrean/ferrokinesis/pull/45)) ([#64](https://github.com/mandrean/ferrokinesis/pull/64))
+
+### Fixed
+
+- assert error before cancelling subscribeToShard subscription ([#118](https://github.com/mandrean/ferrokinesis/pull/118))
+- error response conformance audit ([#89](https://github.com/mandrean/ferrokinesis/pull/89))
+- return Kinesis-shaped error responses for 413 body size rejections ([#90](https://github.com/mandrean/ferrokinesis/pull/90))
+- add fake SigV4 auth headers to Docker smoke test ([#81](https://github.com/mandrean/ferrokinesis/pull/81))
+
+### Other
+
+- document case count rationale and feature gate note for property tests
+- address PR #117 review feedback on property tests
+- address PR #117 review feedback on property tests
+- add property-based tests with proptest ([#21](https://github.com/mandrean/ferrokinesis/pull/21))
+- prevent Java SDK v2 subscribeToShard test from hanging ([#116](https://github.com/mandrean/ferrokinesis/pull/116))
+- simplify conformance dependency caching ([#115](https://github.com/mandrean/ferrokinesis/pull/115))
+- add concurrent stress tests and race condition detection ([#105](https://github.com/mandrean/ferrokinesis/pull/105))
+- Add CLAUDE.md with architecture, patterns, and build commands ([#108](https://github.com/mandrean/ferrokinesis/pull/108))
+- add shard splitting and merging correctness tests ([#110](https://github.com/mandrean/ferrokinesis/pull/110))
+- adopt thiserror for typed error handling ([#78](https://github.com/mandrean/ferrokinesis/pull/78))
+- harden Docker image and add Trivy security scanning ([#46](https://github.com/mandrean/ferrokinesis/pull/46)) ([#66](https://github.com/mandrean/ferrokinesis/pull/66))
+- add Docker smoke test before image push ([#28](https://github.com/mandrean/ferrokinesis/pull/28)) ([#63](https://github.com/mandrean/ferrokinesis/pull/63))
+- add cargo-audit and cargo-deny for supply chain security ([#47](https://github.com/mandrean/ferrokinesis/pull/47)) ([#65](https://github.com/mandrean/ferrokinesis/pull/65))
+- pin Rust toolchain and add SHA256 checksums to releases ([#48](https://github.com/mandrean/ferrokinesis/pull/48)) ([#67](https://github.com/mandrean/ferrokinesis/pull/67))
+
 ## [0.1.2](https://github.com/mandrean/ferrokinesis/compare/v0.1.1...v0.1.2) - 2026-03-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrokinesis"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "aes",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1117,7 @@ dependencies = [
  "md-5",
  "num-bigint",
  "num-traits",
+ "proptest",
  "rand",
  "rcgen",
  "redb",
@@ -2322,6 +2338,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,6 +2371,12 @@ dependencies = [
  "idna",
  "psl-types",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2385,6 +2426,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -2636,6 +2686,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3308,6 +3370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,6 +3451,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ cbc = "0.1"
 ciborium = "0.2"
 criterion = { version = "0.5", features = ["async_tokio"] }
 num-bigint = "0.4"
+proptest = "1"
 reqwest = { version = "0.12", features = ["json"] }
 tempfile = "3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrokinesis"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 description = "A local AWS Kinesis mock server for testing, written in Rust"
 license = "MIT"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,7 +6,20 @@ use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::{Value, json};
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::net::TcpListener;
+
+static PROP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a unique stream name for property tests. Each call returns a distinct
+/// name, safe to use across concurrent test functions.
+pub fn unique_stream_name(prefix: &str) -> String {
+    format!(
+        "{}-{}",
+        prefix,
+        PROP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
 
 pub const AMZ_JSON: &str = "application/x-amz-json-1.1";
 pub const AMZ_CBOR: &str = "application/x-amz-cbor-1.1";

--- a/tests/prop_batch_operations.rs
+++ b/tests/prop_batch_operations.rs
@@ -1,0 +1,187 @@
+mod common;
+use common::*;
+
+use num_bigint::BigUint;
+use proptest::prelude::*;
+use proptest::test_runner::{Config, TestRunner};
+use serde_json::json;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_stream_name() -> String {
+    format!("prop-batch-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+/// P13: PutRecords response count equals request count, with zero failures.
+/// P14: Every response record has a valid ShardId and SequenceNumber.
+#[test]
+fn prop_batch_response_count_and_fields() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let stream_name = unique_stream_name();
+    rt.block_on(server.create_stream(&stream_name, 4));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    runner
+        .run(&(1u32..=50), |batch_size| {
+            let body = rt.block_on(async {
+                let records: Vec<serde_json::Value> = (0..batch_size)
+                    .map(|i| {
+                        json!({
+                            "Data": "dGVzdA==",
+                            "PartitionKey": format!("key-{}", i),
+                        })
+                    })
+                    .collect();
+
+                let res = server
+                    .request(
+                        "PutRecords",
+                        &json!({
+                            "StreamName": stream_name,
+                            "Records": records,
+                        }),
+                    )
+                    .await;
+                assert_eq!(res.status(), 200);
+                let body: serde_json::Value = res.json().await.unwrap();
+                body
+            });
+
+            // P13: Response count == request count
+            let response_records = body["Records"].as_array().unwrap();
+            prop_assert_eq!(
+                response_records.len(),
+                batch_size as usize,
+                "response record count {} != request count {}",
+                response_records.len(),
+                batch_size
+            );
+
+            // P13: FailedRecordCount == 0
+            let failed = body["FailedRecordCount"].as_u64().unwrap();
+            prop_assert_eq!(
+                failed,
+                0,
+                "FailedRecordCount is {} for batch of {}",
+                failed,
+                batch_size
+            );
+
+            // P14: Every record has valid ShardId and SequenceNumber
+            for (i, rec) in response_records.iter().enumerate() {
+                let shard_id = rec["ShardId"].as_str().unwrap();
+                prop_assert!(
+                    shard_id.starts_with("shardId-"),
+                    "record {} has invalid ShardId: {:?}",
+                    i,
+                    shard_id
+                );
+
+                let seq_num = rec["SequenceNumber"].as_str().unwrap();
+                prop_assert!(!seq_num.is_empty(), "record {} has empty SequenceNumber", i);
+            }
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P15: PutRecords with ExplicitHashKey routes each record to the correct shard.
+#[test]
+fn prop_batch_explicit_hash_key_routing() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let shard_count = 4u32;
+    let stream_name = unique_stream_name();
+    rt.block_on(server.create_stream(&stream_name, shard_count));
+
+    // Get shard hash ranges
+    let shard_ranges: Vec<(String, BigUint, BigUint)> = rt.block_on(async {
+        let desc = server.describe_stream(&stream_name).await;
+        desc["StreamDescription"]["Shards"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| {
+                let id = s["ShardId"].as_str().unwrap().to_string();
+                let start: BigUint = s["HashKeyRange"]["StartingHashKey"]
+                    .as_str()
+                    .unwrap()
+                    .parse()
+                    .unwrap();
+                let end: BigUint = s["HashKeyRange"]["EndingHashKey"]
+                    .as_str()
+                    .unwrap()
+                    .parse()
+                    .unwrap();
+                (id, start, end)
+            })
+            .collect()
+    });
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    // Generate a small batch of hash keys
+    let strategy = proptest::collection::vec(any::<u128>(), 1..=10);
+
+    runner
+        .run(&strategy, |hash_keys| {
+            let response_records = rt.block_on(async {
+                let records: Vec<serde_json::Value> = hash_keys
+                    .iter()
+                    .map(|hk| {
+                        json!({
+                            "Data": "dGVzdA==",
+                            "PartitionKey": "ignored",
+                            "ExplicitHashKey": hk.to_string(),
+                        })
+                    })
+                    .collect();
+
+                let res = server
+                    .request(
+                        "PutRecords",
+                        &json!({
+                            "StreamName": stream_name,
+                            "Records": records,
+                        }),
+                    )
+                    .await;
+                assert_eq!(res.status(), 200);
+                let body: serde_json::Value = res.json().await.unwrap();
+                body["Records"].as_array().unwrap().clone()
+            });
+
+            for (i, hk) in hash_keys.iter().enumerate() {
+                let returned_shard = response_records[i]["ShardId"].as_str().unwrap();
+                let hk_big = BigUint::from(*hk);
+
+                let expected_shard = shard_ranges
+                    .iter()
+                    .find(|(_, start, end)| hk_big >= *start && hk_big <= *end)
+                    .map(|(id, _, _)| id.as_str());
+
+                prop_assert_eq!(
+                    Some(returned_shard),
+                    expected_shard,
+                    "record {} with ExplicitHashKey {} routed to wrong shard",
+                    i,
+                    hk
+                );
+            }
+
+            Ok(())
+        })
+        .unwrap();
+}

--- a/tests/prop_batch_operations.rs
+++ b/tests/prop_batch_operations.rs
@@ -1,3 +1,5 @@
+// Case count rationale: 50 cases — batch PutRecords with variable-size payloads
+// involve multiple server round-trips per case.
 mod common;
 use common::*;
 

--- a/tests/prop_batch_operations.rs
+++ b/tests/prop_batch_operations.rs
@@ -5,13 +5,6 @@ use num_bigint::BigUint;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestRunner};
 use serde_json::json;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn unique_stream_name() -> String {
-    format!("prop-batch-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
-}
 
 /// P13: PutRecords response count equals request count, with zero failures.
 /// P14: Every response record has a valid ShardId and SequenceNumber.
@@ -20,7 +13,7 @@ fn prop_batch_response_count_and_fields() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let server = rt.block_on(TestServer::new());
 
-    let stream_name = unique_stream_name();
+    let stream_name = unique_stream_name("prop-batch");
     rt.block_on(server.create_stream(&stream_name, 4));
 
     let mut runner = TestRunner::new(Config {
@@ -100,7 +93,7 @@ fn prop_batch_explicit_hash_key_routing() {
     let server = rt.block_on(TestServer::new());
 
     let shard_count = 4u32;
-    let stream_name = unique_stream_name();
+    let stream_name = unique_stream_name("prop-batch");
     rt.block_on(server.create_stream(&stream_name, shard_count));
 
     // Get shard hash ranges

--- a/tests/prop_cbor_json_equivalence.rs
+++ b/tests/prop_cbor_json_equivalence.rs
@@ -5,13 +5,6 @@ use ferrokinesis::store::StoreOptions;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestRunner};
 use serde_json::json;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn unique_stream_name() -> String {
-    format!("prop-cbor-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
-}
 
 /// Volatile keys that differ between separate JSON and CBOR requests
 /// (because each is a distinct write producing a different sequence number).
@@ -23,7 +16,7 @@ fn prop_put_record_cbor_json_equivalent() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let server = rt.block_on(TestServer::new());
 
-    let stream_name = unique_stream_name();
+    let stream_name = unique_stream_name("prop-cbor");
     rt.block_on(server.create_stream(&stream_name, 4));
 
     let mut runner = TestRunner::new(Config {
@@ -83,9 +76,9 @@ fn prop_describe_stream_cbor_json_equivalent() {
 
     runner
         .run(&"[a-zA-Z0-9_.\\-]{1,50}", |name_prefix| {
-            let stream_name = format!("{}-{}", name_prefix, unique_stream_name());
+            let stream_name = format!("{}-{}", name_prefix, unique_stream_name("prop-cbor"));
             let stream_name = if stream_name.len() > 128 {
-                stream_name[..128].to_string()
+                stream_name.chars().take(128).collect::<String>()
             } else {
                 stream_name
             };
@@ -112,7 +105,7 @@ fn prop_put_records_cbor_json_equivalent() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let server = rt.block_on(TestServer::new());
 
-    let stream_name = unique_stream_name();
+    let stream_name = unique_stream_name("prop-cbor");
     rt.block_on(server.create_stream(&stream_name, 4));
 
     let mut runner = TestRunner::new(Config {

--- a/tests/prop_cbor_json_equivalence.rs
+++ b/tests/prop_cbor_json_equivalence.rs
@@ -1,0 +1,178 @@
+mod common;
+use common::*;
+
+use ferrokinesis::store::StoreOptions;
+use proptest::prelude::*;
+use proptest::test_runner::{Config, TestRunner};
+use serde_json::json;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_stream_name() -> String {
+    format!("prop-cbor-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+/// Volatile keys that differ between separate JSON and CBOR requests
+/// (because each is a distinct write producing a different sequence number).
+const VOLATILE_KEYS: &[&str] = &["SequenceNumber"];
+
+/// P16: PutRecord via JSON and CBOR produce structurally equivalent responses.
+#[test]
+fn prop_put_record_cbor_json_equivalent() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let stream_name = unique_stream_name();
+    rt.block_on(server.create_stream(&stream_name, 4));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    let strategy = "[a-zA-Z0-9_.\\-]{1,64}";
+
+    runner
+        .run(&strategy, |partition_key| {
+            let (json_body, cbor_body) = rt.block_on(async {
+                let req = json!({
+                    "StreamName": stream_name,
+                    "Data": "dGVzdA==",
+                    "PartitionKey": partition_key,
+                });
+                let ((json_status, json_body), (cbor_status, cbor_body)) =
+                    server.request_both("PutRecord", &req).await;
+                assert_eq!(json_status, 200);
+                assert_eq!(cbor_status, 200);
+                (json_body, cbor_body)
+            });
+
+            // ShardId must be identical (same routing for same partition key)
+            prop_assert_eq!(
+                json_body["ShardId"].as_str(),
+                cbor_body["ShardId"].as_str(),
+                "ShardId mismatch for partition key {:?}",
+                partition_key
+            );
+
+            // Structural equivalence ignoring sequence numbers
+            assert_values_equivalent(&json_body, &cbor_body, VOLATILE_KEYS);
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P17: DescribeStream is fully equivalent via JSON and CBOR.
+#[test]
+fn prop_describe_stream_cbor_json_equivalent() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 200,
+        ..Default::default()
+    }));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    runner
+        .run(&"[a-zA-Z0-9_.\\-]{1,50}", |name_prefix| {
+            let stream_name = format!("{}-{}", name_prefix, unique_stream_name());
+            let stream_name = if stream_name.len() > 128 {
+                stream_name[..128].to_string()
+            } else {
+                stream_name
+            };
+
+            let (json_body, cbor_body) = rt.block_on(async {
+                server.create_stream(&stream_name, 1).await;
+                let ((json_status, json_body), (cbor_status, cbor_body)) = server
+                    .request_both("DescribeStream", &json!({"StreamName": stream_name}))
+                    .await;
+                assert_eq!(json_status, 200);
+                assert_eq!(cbor_status, 200);
+                (json_body, cbor_body)
+            });
+
+            assert_values_equivalent(&json_body, &cbor_body, &[]);
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P18: PutRecords batch responses are equivalent via JSON and CBOR.
+#[test]
+fn prop_put_records_cbor_json_equivalent() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let stream_name = unique_stream_name();
+    rt.block_on(server.create_stream(&stream_name, 4));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    let strategy = (1u32..=10, "[a-zA-Z0-9_.\\-]{1,64}");
+
+    runner
+        .run(&strategy, |(batch_size, partition_key)| {
+            let (json_body, cbor_body) = rt.block_on(async {
+                let records: Vec<serde_json::Value> = (0..batch_size)
+                    .map(|i| {
+                        json!({
+                            "Data": "dGVzdA==",
+                            "PartitionKey": format!("{}-{}", partition_key, i),
+                        })
+                    })
+                    .collect();
+
+                let req = json!({
+                    "StreamName": stream_name,
+                    "Records": records,
+                });
+
+                let ((json_status, json_body), (cbor_status, cbor_body)) =
+                    server.request_both("PutRecords", &req).await;
+                assert_eq!(json_status, 200);
+                assert_eq!(cbor_status, 200);
+                (json_body, cbor_body)
+            });
+
+            // FailedRecordCount should be identical
+            prop_assert_eq!(
+                &json_body["FailedRecordCount"],
+                &cbor_body["FailedRecordCount"],
+                "FailedRecordCount mismatch"
+            );
+
+            // Record count should match
+            let json_records = json_body["Records"].as_array().unwrap();
+            let cbor_records = cbor_body["Records"].as_array().unwrap();
+            prop_assert_eq!(
+                json_records.len(),
+                cbor_records.len(),
+                "response record count mismatch"
+            );
+
+            // Each record's ShardId should match (same routing)
+            for (i, (jr, cr)) in json_records.iter().zip(cbor_records.iter()).enumerate() {
+                prop_assert_eq!(
+                    jr["ShardId"].as_str(),
+                    cr["ShardId"].as_str(),
+                    "ShardId mismatch at record {}",
+                    i
+                );
+            }
+
+            Ok(())
+        })
+        .unwrap();
+}

--- a/tests/prop_cbor_json_equivalence.rs
+++ b/tests/prop_cbor_json_equivalence.rs
@@ -1,3 +1,5 @@
+// Case count rationale: 50 cases — each iteration does paired JSON + CBOR requests,
+// doubling the server round-trips compared to single-format tests.
 mod common;
 use common::*;
 

--- a/tests/prop_data_roundtrip.rs
+++ b/tests/prop_data_roundtrip.rs
@@ -15,8 +15,8 @@ fn prop_data_roundtrip_integrity() {
 
     // Single shard with fixed partition key so we can retrieve records via a known
     // shard iterator. Cross-shard routing is tested in prop_shard_routing.rs.
-    let stream_name = "prop-data-rt";
-    rt.block_on(server.create_stream(stream_name, 1));
+    let stream_name = unique_stream_name("prop-data-rt");
+    rt.block_on(server.create_stream(&stream_name, 1));
 
     let mut runner = TestRunner::new(Config {
         cases: 50,
@@ -93,8 +93,8 @@ fn prop_partition_key_roundtrip() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let server = rt.block_on(TestServer::new());
 
-    let stream_name = "prop-pk-rt";
-    rt.block_on(server.create_stream(stream_name, 1));
+    let stream_name = unique_stream_name("prop-pk-rt");
+    rt.block_on(server.create_stream(&stream_name, 1));
 
     let mut runner = TestRunner::new(Config {
         cases: 50,

--- a/tests/prop_data_roundtrip.rs
+++ b/tests/prop_data_roundtrip.rs
@@ -1,3 +1,5 @@
+// Case count rationale: 50 cases — each iteration does PutRecord + GetRecords with
+// shard iterator setup, making these the most expensive tests per case.
 mod common;
 use common::*;
 

--- a/tests/prop_data_roundtrip.rs
+++ b/tests/prop_data_roundtrip.rs
@@ -13,6 +13,8 @@ fn prop_data_roundtrip_integrity() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let server = rt.block_on(TestServer::new());
 
+    // Single shard with fixed partition key so we can retrieve records via a known
+    // shard iterator. Cross-shard routing is tested in prop_shard_routing.rs.
     let stream_name = "prop-data-rt";
     rt.block_on(server.create_stream(stream_name, 1));
 

--- a/tests/prop_data_roundtrip.rs
+++ b/tests/prop_data_roundtrip.rs
@@ -1,0 +1,147 @@
+mod common;
+use common::*;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use proptest::prelude::*;
+use proptest::test_runner::{Config, TestRunner};
+use serde_json::json;
+
+/// P9: PutRecord → GetRecords round-trip preserves data integrity.
+#[test]
+fn prop_data_roundtrip_integrity() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let stream_name = "prop-data-rt";
+    rt.block_on(server.create_stream(stream_name, 1));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    // Generate arbitrary byte sequences 1..=4096, then base64-encode
+    let strategy = proptest::collection::vec(any::<u8>(), 1..=4096);
+
+    runner
+        .run(&strategy, |raw_bytes| {
+            let encoded = STANDARD.encode(&raw_bytes);
+
+            let records = rt.block_on(async {
+                // Put the record
+                let put_res = server
+                    .request(
+                        "PutRecord",
+                        &json!({
+                            "StreamName": stream_name,
+                            "Data": encoded,
+                            "PartitionKey": "roundtrip-key",
+                        }),
+                    )
+                    .await;
+                assert_eq!(put_res.status(), 200);
+                let put_body: serde_json::Value = put_res.json().await.unwrap();
+                let seq_num = put_body["SequenceNumber"].as_str().unwrap().to_string();
+
+                // Get an iterator at the exact sequence number
+                let iter_res = server
+                    .request(
+                        "GetShardIterator",
+                        &json!({
+                            "StreamName": stream_name,
+                            "ShardId": "shardId-000000000000",
+                            "ShardIteratorType": "AT_SEQUENCE_NUMBER",
+                            "StartingSequenceNumber": seq_num,
+                        }),
+                    )
+                    .await;
+                assert_eq!(iter_res.status(), 200);
+                let iter_body: serde_json::Value = iter_res.json().await.unwrap();
+                let iterator = iter_body["ShardIterator"].as_str().unwrap();
+
+                let rec_body = server.get_records(iterator).await;
+                rec_body["Records"].as_array().unwrap().clone()
+            });
+
+            prop_assert!(
+                !records.is_empty(),
+                "no records returned for data of length {}",
+                raw_bytes.len()
+            );
+
+            // The first record should match our data
+            let returned_data = records[0]["Data"].as_str().unwrap();
+            let returned_bytes = STANDARD.decode(returned_data).unwrap();
+            prop_assert_eq!(
+                &returned_bytes,
+                &raw_bytes,
+                "data mismatch for input of length {}",
+                raw_bytes.len()
+            );
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P10: PartitionKey round-trips correctly through PutRecord → GetRecords.
+#[test]
+fn prop_partition_key_roundtrip() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let stream_name = "prop-pk-rt";
+    rt.block_on(server.create_stream(stream_name, 1));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    runner
+        .run(&"[a-zA-Z0-9_.\\-]{1,256}", |partition_key| {
+            let returned_pk = rt.block_on(async {
+                let put_res = server
+                    .request(
+                        "PutRecord",
+                        &json!({
+                            "StreamName": stream_name,
+                            "Data": "dGVzdA==",
+                            "PartitionKey": partition_key,
+                        }),
+                    )
+                    .await;
+                assert_eq!(put_res.status(), 200);
+                let put_body: serde_json::Value = put_res.json().await.unwrap();
+                let seq_num = put_body["SequenceNumber"].as_str().unwrap().to_string();
+
+                let iter_res = server
+                    .request(
+                        "GetShardIterator",
+                        &json!({
+                            "StreamName": stream_name,
+                            "ShardId": "shardId-000000000000",
+                            "ShardIteratorType": "AT_SEQUENCE_NUMBER",
+                            "StartingSequenceNumber": seq_num,
+                        }),
+                    )
+                    .await;
+                assert_eq!(iter_res.status(), 200);
+                let iter_body: serde_json::Value = iter_res.json().await.unwrap();
+                let iterator = iter_body["ShardIterator"].as_str().unwrap();
+
+                let rec_body = server.get_records(iterator).await;
+                let records = rec_body["Records"].as_array().unwrap();
+                records[0]["PartitionKey"].as_str().unwrap().to_string()
+            });
+
+            prop_assert_eq!(
+                &returned_pk,
+                &partition_key,
+                "partition key mismatch on round-trip"
+            );
+            Ok(())
+        })
+        .unwrap();
+}

--- a/tests/prop_hash_space_coverage.rs
+++ b/tests/prop_hash_space_coverage.rs
@@ -1,0 +1,120 @@
+mod common;
+
+use ferrokinesis::sequence::partition_key_to_hash_key;
+use num_bigint::BigUint;
+use num_traits::One;
+use proptest::prelude::*;
+use proptest::test_runner::{Config, TestRunner};
+
+/// Reproduce the shard hash formula from create_stream.rs:47-58
+fn compute_shard_ranges(shard_count: u32) -> Vec<(BigUint, BigUint)> {
+    let pow_128 = BigUint::one() << 128;
+    let shard_hash = &pow_128 / BigUint::from(shard_count);
+    let mut ranges = Vec::with_capacity(shard_count as usize);
+    for i in 0..shard_count {
+        let start = &shard_hash * BigUint::from(i);
+        let end = if i < shard_count - 1 {
+            &shard_hash * BigUint::from(i + 1) - BigUint::one()
+        } else {
+            &pow_128 - BigUint::one()
+        };
+        ranges.push((start, end));
+    }
+    ranges
+}
+
+/// P1: For any shard count in [1, 200], hash ranges partition [0, 2^128-1]
+/// with no gaps, no overlaps, and every shard is non-degenerate.
+#[test]
+fn prop_hash_space_fully_partitioned() {
+    let pow_128 = BigUint::one() << 128;
+    let max_hash = &pow_128 - BigUint::one();
+
+    let mut runner = TestRunner::new(Config {
+        cases: 200,
+        ..Config::default()
+    });
+
+    runner
+        .run(&(1u32..=200), |shard_count| {
+            let ranges = compute_shard_ranges(shard_count);
+
+            // First shard starts at 0
+            prop_assert_eq!(&ranges[0].0, &BigUint::ZERO);
+
+            // Last shard ends at 2^128 - 1
+            prop_assert_eq!(&ranges[ranges.len() - 1].1, &max_hash);
+
+            // Every shard is non-degenerate (start <= end)
+            for (i, (start, end)) in ranges.iter().enumerate() {
+                prop_assert!(
+                    start <= end,
+                    "shard {} is degenerate: start={} > end={}",
+                    i,
+                    start,
+                    end
+                );
+            }
+
+            // Adjacent shards are contiguous: end[i] + 1 == start[i+1]
+            for i in 0..ranges.len() - 1 {
+                let expected_next_start = &ranges[i].1 + BigUint::one();
+                prop_assert_eq!(
+                    &ranges[i + 1].0,
+                    &expected_next_start,
+                    "gap or overlap between shard {} and {}: end[{}]={}, start[{}]={}",
+                    i,
+                    i + 1,
+                    i,
+                    ranges[i].1,
+                    i + 1,
+                    ranges[i + 1].0,
+                );
+            }
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P2: MD5 hash of any partition key is within [0, 2^128).
+#[test]
+fn prop_md5_hash_in_range() {
+    let pow_128 = BigUint::one() << 128;
+
+    let mut runner = TestRunner::new(Config {
+        cases: 256,
+        ..Config::default()
+    });
+
+    runner
+        .run(&"[\\PC]{1,256}", |pk| {
+            let hash = partition_key_to_hash_key(&pk);
+            prop_assert!(
+                hash < pow_128,
+                "hash {} for partition key {:?} is >= 2^128",
+                hash,
+                pk
+            );
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P3: partition_key_to_hash_key is deterministic.
+#[test]
+fn prop_hash_deterministic() {
+    let mut runner = TestRunner::new(Config {
+        cases: 256,
+        ..Config::default()
+    });
+
+    runner
+        .run(&"[\\PC]{1,256}", |pk| {
+            let h1 = partition_key_to_hash_key(&pk);
+            let h2 = partition_key_to_hash_key(&pk);
+            prop_assert_eq!(h1, h2, "non-deterministic hash for key {:?}", pk);
+            Ok(())
+        })
+        .unwrap();
+}

--- a/tests/prop_hash_space_coverage.rs
+++ b/tests/prop_hash_space_coverage.rs
@@ -1,3 +1,8 @@
+// Case count rationale: 256 cases for pure hash/math tests — no server round-trip,
+// so they're cheap (~ms each). Higher counts give better coverage of the input space.
+//
+// If the property test suite grows beyond ~5s, consider gating behind a `proptest`
+// Cargo feature so CI can control when to run them.
 mod common;
 
 use ferrokinesis::sequence::partition_key_to_hash_key;

--- a/tests/prop_hash_space_coverage.rs
+++ b/tests/prop_hash_space_coverage.rs
@@ -25,56 +25,46 @@ fn compute_shard_ranges(shard_count: u32) -> Vec<(BigUint, BigUint)> {
 
 /// P1: For any shard count in [1, 200], hash ranges partition [0, 2^128-1]
 /// with no gaps, no overlaps, and every shard is non-degenerate.
+/// This is exhaustive (not sampling-based), so a plain loop is used.
 #[test]
 fn prop_hash_space_fully_partitioned() {
     let pow_128 = BigUint::one() << 128;
     let max_hash = &pow_128 - BigUint::one();
 
-    let mut runner = TestRunner::new(Config {
-        cases: 200,
-        ..Config::default()
-    });
+    for shard_count in 1..=200u32 {
+        let ranges = compute_shard_ranges(shard_count);
 
-    runner
-        .run(&(1u32..=200), |shard_count| {
-            let ranges = compute_shard_ranges(shard_count);
+        // First shard starts at 0
+        assert_eq!(&ranges[0].0, &BigUint::ZERO);
 
-            // First shard starts at 0
-            prop_assert_eq!(&ranges[0].0, &BigUint::ZERO);
+        // Last shard ends at 2^128 - 1
+        assert_eq!(&ranges[ranges.len() - 1].1, &max_hash);
 
-            // Last shard ends at 2^128 - 1
-            prop_assert_eq!(&ranges[ranges.len() - 1].1, &max_hash);
+        // Every shard is non-degenerate (start <= end)
+        for (i, (start, end)) in ranges.iter().enumerate() {
+            assert!(
+                start <= end,
+                "shard_count={shard_count}: shard {i} is degenerate: start={start} > end={end}",
+            );
+        }
 
-            // Every shard is non-degenerate (start <= end)
-            for (i, (start, end)) in ranges.iter().enumerate() {
-                prop_assert!(
-                    start <= end,
-                    "shard {} is degenerate: start={} > end={}",
-                    i,
-                    start,
-                    end
-                );
-            }
-
-            // Adjacent shards are contiguous: end[i] + 1 == start[i+1]
-            for i in 0..ranges.len() - 1 {
-                let expected_next_start = &ranges[i].1 + BigUint::one();
-                prop_assert_eq!(
-                    &ranges[i + 1].0,
-                    &expected_next_start,
-                    "gap or overlap between shard {} and {}: end[{}]={}, start[{}]={}",
-                    i,
-                    i + 1,
-                    i,
-                    ranges[i].1,
-                    i + 1,
-                    ranges[i + 1].0,
-                );
-            }
-
-            Ok(())
-        })
-        .unwrap();
+        // Adjacent shards are contiguous: end[i] + 1 == start[i+1]
+        for i in 0..ranges.len() - 1 {
+            let expected_next_start = &ranges[i].1 + BigUint::one();
+            assert_eq!(
+                &ranges[i + 1].0,
+                &expected_next_start,
+                "shard_count={}: gap or overlap between shard {} and {}: end[{}]={}, start[{}]={}",
+                shard_count,
+                i,
+                i + 1,
+                i,
+                ranges[i].1,
+                i + 1,
+                ranges[i + 1].0,
+            );
+        }
+    }
 }
 
 /// P2: MD5 hash of any partition key is within [0, 2^128).

--- a/tests/prop_sequence_ordering.rs
+++ b/tests/prop_sequence_ordering.rs
@@ -1,3 +1,5 @@
+// Case count rationale: 50 cases — each iteration does multiple PutRecord/PutRecords
+// calls plus GetRecords, so lower count keeps total runtime reasonable.
 mod common;
 use common::*;
 

--- a/tests/prop_sequence_ordering.rs
+++ b/tests/prop_sequence_ordering.rs
@@ -5,13 +5,6 @@ use ferrokinesis::store::StoreOptions;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestRunner};
 use serde_json::json;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn unique_stream_name() -> String {
-    format!("prop-seq-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
-}
 
 /// P11: Sequential PutRecord calls produce strictly increasing sequence numbers.
 #[test]
@@ -32,7 +25,7 @@ fn prop_sequential_puts_increasing_sequence_numbers() {
 
     runner
         .run(&(2u32..=20), |record_count| {
-            let stream_name = unique_stream_name();
+            let stream_name = unique_stream_name("prop-seq");
 
             let seq_nums: Vec<String> = rt.block_on(async {
                 server.create_stream(&stream_name, 1).await;
@@ -56,8 +49,8 @@ fn prop_sequential_puts_increasing_sequence_numbers() {
                 seqs
             });
 
-            // Sequence numbers should be strictly increasing (lexicographic order
-            // matches numeric order for these fixed-format hex strings)
+            // Sequence numbers are decimal bigints with fixed-width formatting,
+            // so lexicographic ordering matches numeric ordering.
             for i in 0..seq_nums.len() - 1 {
                 prop_assert!(
                     seq_nums[i] < seq_nums[i + 1],
@@ -93,7 +86,7 @@ fn prop_batch_sequence_numbers_increasing() {
 
     runner
         .run(&(2u32..=50), |batch_size| {
-            let stream_name = unique_stream_name();
+            let stream_name = unique_stream_name("prop-seq");
 
             let seq_nums: Vec<String> = rt.block_on(async {
                 server.create_stream(&stream_name, 1).await;

--- a/tests/prop_sequence_ordering.rs
+++ b/tests/prop_sequence_ordering.rs
@@ -2,6 +2,7 @@ mod common;
 use common::*;
 
 use ferrokinesis::store::StoreOptions;
+use num_bigint::BigUint;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestRunner};
 use serde_json::json;
@@ -49,15 +50,18 @@ fn prop_sequential_puts_increasing_sequence_numbers() {
                 seqs
             });
 
-            // Sequence numbers are decimal bigints with fixed-width formatting,
-            // so lexicographic ordering matches numeric ordering.
-            for i in 0..seq_nums.len() - 1 {
+            let parsed: Vec<BigUint> = seq_nums
+                .iter()
+                .map(|s| s.parse::<BigUint>().unwrap())
+                .collect();
+
+            for i in 0..parsed.len() - 1 {
                 prop_assert!(
-                    seq_nums[i] < seq_nums[i + 1],
-                    "sequence number ordering violated at index {}: {:?} >= {:?}",
+                    parsed[i] < parsed[i + 1],
+                    "sequence number ordering violated at index {}: {} >= {}",
                     i,
-                    seq_nums[i],
-                    seq_nums[i + 1]
+                    parsed[i],
+                    parsed[i + 1]
                 );
             }
 
@@ -122,13 +126,18 @@ fn prop_batch_sequence_numbers_increasing() {
 
             prop_assert_eq!(seq_nums.len(), batch_size as usize);
 
-            for i in 0..seq_nums.len() - 1 {
+            let parsed: Vec<BigUint> = seq_nums
+                .iter()
+                .map(|s| s.parse::<BigUint>().unwrap())
+                .collect();
+
+            for i in 0..parsed.len() - 1 {
                 prop_assert!(
-                    seq_nums[i] < seq_nums[i + 1],
-                    "batch sequence ordering violated at index {}: {:?} >= {:?}",
+                    parsed[i] < parsed[i + 1],
+                    "batch sequence ordering violated at index {}: {} >= {}",
                     i,
-                    seq_nums[i],
-                    seq_nums[i + 1]
+                    parsed[i],
+                    parsed[i + 1]
                 );
             }
 

--- a/tests/prop_sequence_ordering.rs
+++ b/tests/prop_sequence_ordering.rs
@@ -1,0 +1,145 @@
+mod common;
+use common::*;
+
+use ferrokinesis::store::StoreOptions;
+use proptest::prelude::*;
+use proptest::test_runner::{Config, TestRunner};
+use serde_json::json;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_stream_name() -> String {
+    format!("prop-seq-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+/// P11: Sequential PutRecord calls produce strictly increasing sequence numbers.
+#[test]
+fn prop_sequential_puts_increasing_sequence_numbers() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 200,
+        ..Default::default()
+    }));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    runner
+        .run(&(2u32..=20), |record_count| {
+            let stream_name = unique_stream_name();
+
+            let seq_nums: Vec<String> = rt.block_on(async {
+                server.create_stream(&stream_name, 1).await;
+
+                let mut seqs = Vec::with_capacity(record_count as usize);
+                for _ in 0..record_count {
+                    let res = server
+                        .request(
+                            "PutRecord",
+                            &json!({
+                                "StreamName": stream_name,
+                                "Data": "dGVzdA==",
+                                "PartitionKey": "same-key",
+                            }),
+                        )
+                        .await;
+                    assert_eq!(res.status(), 200);
+                    let body: serde_json::Value = res.json().await.unwrap();
+                    seqs.push(body["SequenceNumber"].as_str().unwrap().to_string());
+                }
+                seqs
+            });
+
+            // Sequence numbers should be strictly increasing (lexicographic order
+            // matches numeric order for these fixed-format hex strings)
+            for i in 0..seq_nums.len() - 1 {
+                prop_assert!(
+                    seq_nums[i] < seq_nums[i + 1],
+                    "sequence number ordering violated at index {}: {:?} >= {:?}",
+                    i,
+                    seq_nums[i],
+                    seq_nums[i + 1]
+                );
+            }
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P12: Within a PutRecords batch, sequence numbers on the same shard are
+/// strictly increasing.
+#[test]
+fn prop_batch_sequence_numbers_increasing() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 200,
+        ..Default::default()
+    }));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    runner
+        .run(&(2u32..=50), |batch_size| {
+            let stream_name = unique_stream_name();
+
+            let seq_nums: Vec<String> = rt.block_on(async {
+                server.create_stream(&stream_name, 1).await;
+
+                let records: Vec<serde_json::Value> = (0..batch_size)
+                    .map(|_| {
+                        json!({
+                            "Data": "dGVzdA==",
+                            "PartitionKey": "same-key",
+                        })
+                    })
+                    .collect();
+
+                let res = server
+                    .request(
+                        "PutRecords",
+                        &json!({
+                            "StreamName": stream_name,
+                            "Records": records,
+                        }),
+                    )
+                    .await;
+                assert_eq!(res.status(), 200);
+                let body: serde_json::Value = res.json().await.unwrap();
+
+                body["Records"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|r| r["SequenceNumber"].as_str().unwrap().to_string())
+                    .collect()
+            });
+
+            prop_assert_eq!(seq_nums.len(), batch_size as usize);
+
+            for i in 0..seq_nums.len() - 1 {
+                prop_assert!(
+                    seq_nums[i] < seq_nums[i + 1],
+                    "batch sequence ordering violated at index {}: {:?} >= {:?}",
+                    i,
+                    seq_nums[i],
+                    seq_nums[i + 1]
+                );
+            }
+
+            Ok(())
+        })
+        .unwrap();
+}

--- a/tests/prop_shard_routing.rs
+++ b/tests/prop_shard_routing.rs
@@ -6,13 +6,6 @@ use num_bigint::BigUint;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestRunner};
 use serde_json::json;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn unique_stream_name(prefix: &str) -> String {
-    format!("{}-{}", prefix, COUNTER.fetch_add(1, Ordering::Relaxed))
-}
 
 /// Extract the numeric shard index from a shard ID like "shardId-000000000042"
 fn shard_index(shard_id: &str) -> u64 {

--- a/tests/prop_shard_routing.rs
+++ b/tests/prop_shard_routing.rs
@@ -1,3 +1,5 @@
+// Case count rationale: 100 cases — each test creates streams and does PutRecord calls,
+// so moderate count balances coverage against server round-trip cost.
 mod common;
 use common::*;
 

--- a/tests/prop_shard_routing.rs
+++ b/tests/prop_shard_routing.rs
@@ -1,0 +1,214 @@
+mod common;
+use common::*;
+
+use ferrokinesis::store::StoreOptions;
+use num_bigint::BigUint;
+use proptest::prelude::*;
+use proptest::test_runner::{Config, TestRunner};
+use serde_json::json;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_stream_name(prefix: &str) -> String {
+    format!("{}-{}", prefix, COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+/// Extract the numeric shard index from a shard ID like "shardId-000000000042"
+fn shard_index(shard_id: &str) -> u64 {
+    shard_id
+        .strip_prefix("shardId-")
+        .unwrap()
+        .parse::<u64>()
+        .unwrap()
+}
+
+/// P6: Every partition key routes to a valid shard within [0, N).
+#[test]
+fn prop_partition_key_routes_to_valid_shard() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 200,
+        ..Default::default()
+    }));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 100,
+        ..Config::default()
+    });
+
+    // Create streams with different shard counts up front
+    let stream_names: Vec<(String, u32)> = (1..=10)
+        .map(|n| {
+            let name = unique_stream_name("prop-route");
+            rt.block_on(server.create_stream(&name, n));
+            (name, n)
+        })
+        .collect();
+
+    let strategy = (0..10usize, "[a-zA-Z0-9_.\\-]{1,256}");
+
+    runner
+        .run(&strategy, |(stream_idx, partition_key)| {
+            let (stream_name, shard_count) = &stream_names[stream_idx];
+
+            let shard_id = rt.block_on(async {
+                let res = server
+                    .request(
+                        "PutRecord",
+                        &json!({
+                            "StreamName": stream_name,
+                            "Data": "dGVzdA==",
+                            "PartitionKey": partition_key,
+                        }),
+                    )
+                    .await;
+                assert_eq!(res.status(), 200);
+                let body: serde_json::Value = res.json().await.unwrap();
+                body["ShardId"].as_str().unwrap().to_string()
+            });
+
+            let idx = shard_index(&shard_id);
+            prop_assert!(
+                idx < *shard_count as u64,
+                "shard index {} out of range [0, {}) for partition key {:?}",
+                idx,
+                shard_count,
+                partition_key
+            );
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P7: ExplicitHashKey overrides partition key hashing and routes to the
+/// shard whose hash range contains the explicit key.
+#[test]
+fn prop_explicit_hash_key_routes_correctly() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let shard_count = 4u32;
+    let stream_name = unique_stream_name("prop-ehk");
+    rt.block_on(server.create_stream(&stream_name, shard_count));
+
+    // Get shard hash ranges
+    let shard_ranges: Vec<(String, BigUint, BigUint)> = rt.block_on(async {
+        let desc = server.describe_stream(&stream_name).await;
+        desc["StreamDescription"]["Shards"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| {
+                let id = s["ShardId"].as_str().unwrap().to_string();
+                let start: BigUint = s["HashKeyRange"]["StartingHashKey"]
+                    .as_str()
+                    .unwrap()
+                    .parse()
+                    .unwrap();
+                let end: BigUint = s["HashKeyRange"]["EndingHashKey"]
+                    .as_str()
+                    .unwrap()
+                    .parse()
+                    .unwrap();
+                (id, start, end)
+            })
+            .collect()
+    });
+
+    let mut runner = TestRunner::new(Config {
+        cases: 100,
+        ..Config::default()
+    });
+
+    // Generate hash keys as u128 then convert to string
+    runner
+        .run(&any::<u128>(), |hash_key_val| {
+            let hash_key_str = hash_key_val.to_string();
+
+            let returned_shard_id = rt.block_on(async {
+                let res = server
+                    .request(
+                        "PutRecord",
+                        &json!({
+                            "StreamName": stream_name,
+                            "Data": "dGVzdA==",
+                            "PartitionKey": "ignored",
+                            "ExplicitHashKey": hash_key_str,
+                        }),
+                    )
+                    .await;
+                assert_eq!(res.status(), 200);
+                let body: serde_json::Value = res.json().await.unwrap();
+                body["ShardId"].as_str().unwrap().to_string()
+            });
+
+            let hash_key_big = BigUint::from(hash_key_val);
+            let expected_shard = shard_ranges
+                .iter()
+                .find(|(_, start, end)| hash_key_big >= *start && hash_key_big <= *end)
+                .map(|(id, _, _)| id.clone());
+
+            prop_assert_eq!(
+                Some(returned_shard_id.clone()),
+                expected_shard,
+                "explicit hash key {} routed to {} but expected range match",
+                hash_key_str,
+                returned_shard_id
+            );
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P8: Same partition key always routes to the same shard (determinism).
+#[test]
+fn prop_same_partition_key_same_shard() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let stream_name = unique_stream_name("prop-determ");
+    rt.block_on(server.create_stream(&stream_name, 4));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 100,
+        ..Config::default()
+    });
+
+    runner
+        .run(&"[a-zA-Z0-9_.\\-]{1,256}", |partition_key| {
+            let (shard1, shard2) = rt.block_on(async {
+                let req = json!({
+                    "StreamName": stream_name,
+                    "Data": "dGVzdA==",
+                    "PartitionKey": partition_key,
+                });
+                let r1 = server.request("PutRecord", &req).await;
+                assert_eq!(r1.status(), 200);
+                let b1: serde_json::Value = r1.json().await.unwrap();
+
+                let r2 = server.request("PutRecord", &req).await;
+                assert_eq!(r2.status(), 200);
+                let b2: serde_json::Value = r2.json().await.unwrap();
+
+                (
+                    b1["ShardId"].as_str().unwrap().to_string(),
+                    b2["ShardId"].as_str().unwrap().to_string(),
+                )
+            });
+
+            prop_assert_eq!(
+                shard1,
+                shard2,
+                "partition key {:?} routed to different shards",
+                partition_key
+            );
+            Ok(())
+        })
+        .unwrap();
+}

--- a/tests/prop_stream_name_validation.rs
+++ b/tests/prop_stream_name_validation.rs
@@ -1,0 +1,100 @@
+mod common;
+use common::*;
+
+use ferrokinesis::store::StoreOptions;
+use proptest::prelude::*;
+use proptest::test_runner::{Config, TestRunner};
+use serde_json::json;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_suffix() -> String {
+    format!("{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+/// P4: Valid stream names (matching [a-zA-Z0-9_.-]{1,128}) are accepted.
+#[test]
+fn prop_valid_stream_names_accepted() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 200,
+        ..Default::default()
+    }));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 100,
+        ..Config::default()
+    });
+
+    runner
+        .run(&"[a-zA-Z0-9_.\\-]{1,50}", |name_prefix| {
+            let stream_name = format!("{}-{}", name_prefix, unique_suffix());
+            // Truncate to 128 chars max
+            let stream_name = if stream_name.len() > 128 {
+                stream_name[..128].to_string()
+            } else {
+                stream_name
+            };
+
+            let status = rt.block_on(async {
+                let res = server
+                    .request(
+                        "CreateStream",
+                        &json!({"StreamName": stream_name, "ShardCount": 1}),
+                    )
+                    .await;
+                res.status().as_u16()
+            });
+
+            prop_assert_eq!(
+                status,
+                200,
+                "valid stream name {:?} was rejected",
+                stream_name
+            );
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P5: Invalid stream names are rejected with 400.
+#[test]
+fn prop_invalid_stream_names_rejected() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let mut runner = TestRunner::new(Config {
+        cases: 100,
+        ..Config::default()
+    });
+
+    let invalid_names = prop_oneof![
+        // Empty string
+        Just(String::new()),
+        // Too long (129-200 chars of valid characters)
+        "[a-zA-Z0-9_.\\-]{129,200}",
+        // Contains characters outside [a-zA-Z0-9_.-]
+        "[a-zA-Z0-9_.\\-]{0,10}[!@#$%^&*()+=\\[\\]{}|;:',<>?/~`][a-zA-Z0-9_.\\-]{0,10}",
+    ];
+
+    runner
+        .run(&invalid_names, |name| {
+            let status = rt.block_on(async {
+                let res = server
+                    .request(
+                        "CreateStream",
+                        &json!({"StreamName": name, "ShardCount": 1}),
+                    )
+                    .await;
+                res.status().as_u16()
+            });
+
+            prop_assert_eq!(status, 400, "invalid stream name {:?} was accepted", name);
+            Ok(())
+        })
+        .unwrap();
+}

--- a/tests/prop_stream_name_validation.rs
+++ b/tests/prop_stream_name_validation.rs
@@ -67,16 +67,16 @@ fn prop_invalid_stream_names_rejected() {
 
     let invalid_names = prop_oneof![
         // Empty string
-        Just(String::new()),
+        1 => Just(String::new()),
         // Too long (129-200 chars of valid characters)
-        "[a-zA-Z0-9_.\\-]{129,200}",
+        10 => "[a-zA-Z0-9_.\\-]{129,200}".prop_map(String::from),
         // Contains characters outside [a-zA-Z0-9_.-]
-        "[a-zA-Z0-9_.\\-]{0,10}[!@#$%^&*()+=\\[\\]{}|;:',<>?/~`][a-zA-Z0-9_.\\-]{0,10}",
+        10 => "[a-zA-Z0-9_.\\-]{0,10}[!@#$%^&*()+=\\[\\]{}|;:',<>?/~`][a-zA-Z0-9_.\\-]{0,10}".prop_map(String::from),
         // Whitespace characters
-        "[a-zA-Z0-9_.\\-]{1,10}[\\t\\n\\r ][a-zA-Z0-9_.\\-]{1,10}",
+        10 => "[a-zA-Z0-9_.\\-]{1,10}[\\t\\n\\r ][a-zA-Z0-9_.\\-]{1,10}".prop_map(String::from),
         // Control characters and null bytes
-        Just("test\x00stream".to_string()),
-        Just("test\tstream".to_string()),
+        1 => Just("test\x00stream".to_string()),
+        1 => Just("test\tstream".to_string()),
     ];
 
     runner

--- a/tests/prop_stream_name_validation.rs
+++ b/tests/prop_stream_name_validation.rs
@@ -5,13 +5,6 @@ use ferrokinesis::store::StoreOptions;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestRunner};
 use serde_json::json;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn unique_suffix() -> String {
-    format!("{}", COUNTER.fetch_add(1, Ordering::Relaxed))
-}
 
 /// P4: Valid stream names (matching [a-zA-Z0-9_.-]{1,128}) are accepted.
 #[test]
@@ -32,10 +25,10 @@ fn prop_valid_stream_names_accepted() {
 
     runner
         .run(&"[a-zA-Z0-9_.\\-]{1,50}", |name_prefix| {
-            let stream_name = format!("{}-{}", name_prefix, unique_suffix());
+            let stream_name = unique_stream_name(&name_prefix);
             // Truncate to 128 chars max
             let stream_name = if stream_name.len() > 128 {
-                stream_name[..128].to_string()
+                stream_name.chars().take(128).collect::<String>()
             } else {
                 stream_name
             };
@@ -79,6 +72,11 @@ fn prop_invalid_stream_names_rejected() {
         "[a-zA-Z0-9_.\\-]{129,200}",
         // Contains characters outside [a-zA-Z0-9_.-]
         "[a-zA-Z0-9_.\\-]{0,10}[!@#$%^&*()+=\\[\\]{}|;:',<>?/~`][a-zA-Z0-9_.\\-]{0,10}",
+        // Whitespace characters
+        "[a-zA-Z0-9_.\\-]{1,10}[\\t\\n\\r ][a-zA-Z0-9_.\\-]{1,10}",
+        // Control characters and null bytes
+        Just("test\x00stream".to_string()),
+        Just("test\tstream".to_string()),
     ];
 
     runner

--- a/tests/prop_stream_name_validation.rs
+++ b/tests/prop_stream_name_validation.rs
@@ -1,3 +1,5 @@
+// Case count rationale: 100 cases — CreateStream calls are cheap but involve
+// server round-trips, so moderate count balances coverage and speed.
 mod common;
 use common::*;
 


### PR DESCRIPTION



## 🤖 New release

* `ferrokinesis`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `ferrokinesis` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field KinesisError.error_type in /tmp/.tmp4WAQyQ/ferrokinesis/src/error.rs:7
  field StoreOptions.iterator_ttl_seconds in /tmp/.tmp4WAQyQ/ferrokinesis/src/store.rs:32
  field StoreOptions.retention_check_interval_secs in /tmp/.tmp4WAQyQ/ferrokinesis/src/store.rs:33
  field StoreOptions.aws_account_id in /tmp/.tmp4WAQyQ/ferrokinesis/src/store.rs:34
  field StoreOptions.aws_region in /tmp/.tmp4WAQyQ/ferrokinesis/src/store.rs:35

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field __type of struct KinesisError, previously in file /tmp/.tmpFLIo6P/ferrokinesis/src/error.rs:6
  field message_upper of struct KinesisError, previously in file /tmp/.tmpFLIo6P/ferrokinesis/src/error.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/mandrean/ferrokinesis/compare/v0.1.2...v0.2.0) - 2026-03-19

### Added

- add ARN format regex validation ([#111](https://github.com/mandrean/ferrokinesis/pull/111))
- add TLS/HTTPS support behind `tls` feature flag ([#109](https://github.com/mandrean/ferrokinesis/pull/109))
- add KCL v1 integration test ([#106](https://github.com/mandrean/ferrokinesis/pull/106))
- add SubscribeToShard end-to-end SDK tests ([#107](https://github.com/mandrean/ferrokinesis/pull/107))
- add CBOR ↔ JSON equivalence tests and fix byte string handling ([#88](https://github.com/mandrean/ferrokinesis/pull/88))
- add Goose load test for kinesalite comparison ([#84](https://github.com/mandrean/ferrokinesis/pull/84))
- add retention period enforcement with TTL-based record trimming ([#87](https://github.com/mandrean/ferrokinesis/pull/87))
- add multi-language SDK conformance test suite ([#83](https://github.com/mandrean/ferrokinesis/pull/83))
- enforce 5 MB PutRecords batch limit and add stress tests ([#82](https://github.com/mandrean/ferrokinesis/pull/82))
- add criterion benchmark suite with CI regression gate ([#80](https://github.com/mandrean/ferrokinesis/pull/80))
- add configurable shard iterator TTL ([#40](https://github.com/mandrean/ferrokinesis/pull/40)) ([#77](https://github.com/mandrean/ferrokinesis/pull/77))
- add health check endpoints and CLI subcommand ([#72](https://github.com/mandrean/ferrokinesis/pull/72))
- configurable AWS account ID and region via CLI flags and config file ([#79](https://github.com/mandrean/ferrokinesis/pull/79))
- add configurable request body size limit ([#45](https://github.com/mandrean/ferrokinesis/pull/45)) ([#64](https://github.com/mandrean/ferrokinesis/pull/64))

### Fixed

- assert error before cancelling subscribeToShard subscription ([#118](https://github.com/mandrean/ferrokinesis/pull/118))
- error response conformance audit ([#89](https://github.com/mandrean/ferrokinesis/pull/89))
- return Kinesis-shaped error responses for 413 body size rejections ([#90](https://github.com/mandrean/ferrokinesis/pull/90))
- add fake SigV4 auth headers to Docker smoke test ([#81](https://github.com/mandrean/ferrokinesis/pull/81))

### Other

- document case count rationale and feature gate note for property tests
- address PR #117 review feedback on property tests
- address PR #117 review feedback on property tests
- add property-based tests with proptest ([#21](https://github.com/mandrean/ferrokinesis/pull/21))
- prevent Java SDK v2 subscribeToShard test from hanging ([#116](https://github.com/mandrean/ferrokinesis/pull/116))
- simplify conformance dependency caching ([#115](https://github.com/mandrean/ferrokinesis/pull/115))
- add concurrent stress tests and race condition detection ([#105](https://github.com/mandrean/ferrokinesis/pull/105))
- Add CLAUDE.md with architecture, patterns, and build commands ([#108](https://github.com/mandrean/ferrokinesis/pull/108))
- add shard splitting and merging correctness tests ([#110](https://github.com/mandrean/ferrokinesis/pull/110))
- adopt thiserror for typed error handling ([#78](https://github.com/mandrean/ferrokinesis/pull/78))
- harden Docker image and add Trivy security scanning ([#46](https://github.com/mandrean/ferrokinesis/pull/46)) ([#66](https://github.com/mandrean/ferrokinesis/pull/66))
- add Docker smoke test before image push ([#28](https://github.com/mandrean/ferrokinesis/pull/28)) ([#63](https://github.com/mandrean/ferrokinesis/pull/63))
- add cargo-audit and cargo-deny for supply chain security ([#47](https://github.com/mandrean/ferrokinesis/pull/47)) ([#65](https://github.com/mandrean/ferrokinesis/pull/65))
- pin Rust toolchain and add SHA256 checksums to releases ([#48](https://github.com/mandrean/ferrokinesis/pull/48)) ([#67](https://github.com/mandrean/ferrokinesis/pull/67))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).