### PR TITLE
fix: add fake SigV4 auth headers to Docker smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,13 +146,18 @@ jobs:
 
           # Wait for the service to be ready
           curl --retry 10 --retry-delay 1 --retry-connrefused --silent --fail \
-            http://localhost:4567/ || true
+            http://localhost:4567/_health || true
+
+          # Fake AWS SigV4 auth headers (signature is not validated by the mock)
+          AUTH='AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=fakesignature'
 
           # CreateStream
           curl --silent --fail --show-error \
             -X POST http://localhost:4567/ \
             -H 'Content-Type: application/x-amz-json-1.1' \
             -H 'X-Amz-Target: Kinesis_20131202.CreateStream' \
+            -H "Authorization: $AUTH" \
+            -H 'X-Amz-Date: 20260101T000000Z' \
             -d '{"StreamName":"smoke-test","ShardCount":1}'
 
           # Wait briefly for the stream to become available
@@ -163,6 +168,8 @@ jobs:
             -X POST http://localhost:4567/ \
             -H 'Content-Type: application/x-amz-json-1.1' \
             -H 'X-Amz-Target: Kinesis_20131202.ListStreams' \
+            -H "Authorization: $AUTH" \
+            -H 'X-Amz-Date: 20260101T000000Z' \
             -d '{}')
           echo "ListStreams response: $RESPONSE"
           echo "$RESPONSE" | grep -q "smoke-test"


### PR DESCRIPTION
## Summary

- The auth validation added in #79 (configurable account/region) requires an `Authorization` header on all API requests
- The Docker smoke test predated that change and sent no auth headers, causing `CreateStream` and `ListStreams` to return `400 MissingAuthenticationTokenException`
- Adds fake-but-structurally-valid AWS SigV4 auth headers to the smoke test curl calls (signature is not validated by the mock)
- Also fixes the readiness probe: `GET /` returns 403 for non-POST; switched to `GET /_health` which returns 200 when the server is up

## Test plan

- [ ] CI Docker job passes on this branch
- [ ] `Smoke test` step succeeds: CreateStream returns 200, ListStreams response contains `smoke-test`