### PR TITLE
feat: add CBOR ↔ JSON equivalence tests and fix byte string handling

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -411,7 +411,8 @@ fn send_json_response(
     let body_bytes = if content_type == constants::CONTENT_TYPE_CBOR {
         // Convert to ciborium::Value so Blob fields (Data) become CBOR byte strings
         // (major type 2) instead of text strings, matching real AWS Kinesis behavior.
-        let json_val = serde_json::to_value(data).unwrap_or(Value::Null);
+        let json_val =
+            serde_json::to_value(data).expect("response type must be serializable to JSON");
         let cbor_val = json_to_cbor_with_blob_bytes(&json_val);
         let mut buf = Vec::new();
         let _ = ciborium::into_writer(&cbor_val, &mut buf);
@@ -537,6 +538,10 @@ fn send_error_response(
 /// Convert ciborium::Value to serde_json::Value.
 /// CBOR byte strings (major type 2) are converted to base64-encoded strings,
 /// so the rest of the pipeline can treat all data uniformly.
+///
+/// Exposed for integration tests (`tests/common/mod.rs` needs to decode CBOR
+/// responses the same way the server does). Not part of the public API.
+#[doc(hidden)]
 pub fn cbor_to_json(val: &ciborium::Value) -> Value {
     match val {
         ciborium::Value::Null => Value::Null,
@@ -545,12 +550,14 @@ pub fn cbor_to_json(val: &ciborium::Value) -> Value {
             let n: i128 = (*n).into();
             if let Ok(i) = i64::try_from(n) {
                 Value::Number(serde_json::Number::from(i))
-            // Fallback: i128 values outside i64 range lose precision when cast to f64.
-            // Theoretical for Kinesis (all integers fit in i64), but handles CBOR edge cases.
-            } else if let Some(num) = serde_json::Number::from_f64(n as f64) {
-                Value::Number(num)
             } else {
-                Value::Null
+                // Fallback: i128 values outside i64 range lose precision when cast to f64.
+                // Theoretical for Kinesis (all integers fit in i64), but handles CBOR edge cases.
+                #[allow(clippy::cast_precision_loss)]
+                let f = n as f64;
+                serde_json::Number::from_f64(f)
+                    .map(Value::Number)
+                    .unwrap_or(Value::Null)
             }
         }
         ciborium::Value::Float(f) => serde_json::Number::from_f64(*f)
@@ -587,6 +594,11 @@ const BLOB_FIELD_KEYS: &[&str] = &["Data"];
 
 /// Convert serde_json::Value to ciborium::Value for CBOR response serialization.
 /// Values under known Blob keys are decoded from base64 and emitted as CBOR byte strings.
+///
+/// Note: `tests/common/mod.rs` has a similar `json_to_cbor_with_bytes` that uses
+/// explicit path-based replacement (e.g. `"Records.*.Data"`) for constructing test
+/// requests. This function uses key-name matching because the server doesn't know
+/// the request path at serialization time.
 fn json_to_cbor_with_blob_bytes(val: &Value) -> ciborium::Value {
     json_to_cbor_impl(val, false)
 }

--- a/tests/cbor_json_equivalence.rs
+++ b/tests/cbor_json_equivalence.rs
@@ -446,6 +446,7 @@ async fn cross_put_records_cbor_get_json() {
             {"Data": b64, "PartitionKey": "pk1"},
         ],
     });
+    // "Records.*.Data" — wildcard iterates each array element, replacing Data with Bytes
     let resp = server
         .cbor_request_raw_data("PutRecords", &payload, "Records.*.Data", raw)
         .await;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -281,8 +281,12 @@ pub fn signed_headers() -> HeaderMap {
 }
 
 /// Convert a serde_json::Value to ciborium::Value, replacing the field at
-/// `data_field_path` (e.g., "Data" or "Records.*.Data") with CBOR Bytes.
+/// `data_field_path` with CBOR Bytes. Path syntax: dot-separated segments where
+/// `*` is a wildcard that iterates array elements (e.g. `"Data"`, `"Records.*.Data"`).
 /// `raw_data` is the raw bytes for that field.
+///
+/// Unlike the server-side `json_to_cbor_with_blob_bytes` (which matches by key name
+/// at any depth), this uses explicit paths so tests can precisely target fields.
 pub fn json_to_cbor_with_bytes(
     val: &Value,
     data_field_path: &str,


### PR DESCRIPTION
## Summary

Closes #22

- **Fix CBOR byte string parsing**: Request-side CBOR deserialization now uses `ciborium::Value` instead of `serde_json::Value`, so CBOR byte strings (major type 2) from SDK v2 clients are correctly converted to base64 strings. Previously, `ciborium::from_reader::<serde_json::Value>` would error with "invalid type: byte array" when receiving true CBOR byte strings.
- **Fix CBOR byte string serialization**: Response-side CBOR serialization now converts known Blob fields (`Data`) from base64 text strings back to CBOR byte strings (major type 2), matching real AWS Kinesis behavior. Previously, all strings were emitted as CBOR text strings (major type 3).
- **Add 23 equivalence tests** across 4 groups: read-only operations (5), write operations (5), cross-format data round-trips (7), and error responses (5).

## Test plan

- [x] `cargo test --test cbor_json_equivalence` — all 23 new tests pass
- [x] `cargo test` — full suite passes with no regressions
- [ ] Verify SDK v2 conformance tests still pass (Java/Go/Rust)