### PR TITLE
fix: return Kinesis-shaped error responses for 413 body size rejections

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod util;
 pub mod validation;
 
 use axum::Router;
+use axum::middleware;
 use axum::routing::{any, get};
 use store::{Store, StoreOptions};
 
@@ -24,7 +25,8 @@ pub fn create_app(options: StoreOptions) -> (Router, Store) {
         .route("/_health/live", get(health::live))
         .route("/_health/ready", get(health::ready))
         .fallback(any(server::handler))
-        .with_state(store.clone());
+        .with_state(store.clone())
+        .layer(middleware::from_fn(server::kinesis_413_middleware));
 
     if options.retention_check_interval_secs > 0 {
         let reaper_store = store.clone();

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,12 +4,11 @@ use crate::store::Store;
 use crate::validation;
 use crate::validation::rules;
 use axum::body::Bytes;
-use axum::extract::State;
+use axum::extract::{Request, State};
 use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use serde_json::{Value, json};
-
-const MAX_REQUEST_BYTES: usize = 7 * 1024 * 1024;
 
 pub async fn handler(
     method: Method,
@@ -113,11 +112,6 @@ pub async fn handler(
             &json!({"__type": error_type}),
             400,
         );
-    }
-
-    if body.len() > MAX_REQUEST_BYTES {
-        response_headers.insert("Transfer-Encoding", "chunked".parse().unwrap());
-        return (StatusCode::from_u16(413).unwrap(), response_headers, "").into_response();
     }
 
     if !content_valid {
@@ -463,6 +457,56 @@ fn send_xml_error_code(extra_headers: &HeaderMap, error_type: &str, status_code:
         StatusCode::from_u16(status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
         headers,
         body,
+    )
+        .into_response()
+}
+
+/// Middleware that intercepts bare 413 responses (from axum's `DefaultBodyLimit`)
+/// and replaces them with Kinesis-shaped `SerializationException` error bodies.
+pub async fn kinesis_413_middleware(request: Request, next: Next) -> Response {
+    let content_type = request
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_owned();
+
+    let response = next.run(request).await;
+
+    if response.status() != StatusCode::PAYLOAD_TOO_LARGE {
+        return response;
+    }
+
+    let error = json!({
+        "__type": constants::SERIALIZATION_EXCEPTION,
+        "Message": "Request body is too large"
+    });
+
+    let response_content_type = if content_type == constants::CONTENT_TYPE_JSON {
+        constants::CONTENT_TYPE_JSON
+    } else {
+        constants::CONTENT_TYPE_CBOR
+    };
+
+    let body_bytes = if response_content_type == constants::CONTENT_TYPE_CBOR {
+        let mut buf = Vec::new();
+        let _ = ciborium::into_writer(&error, &mut buf);
+        buf
+    } else {
+        serde_json::to_vec(&error).unwrap_or_default()
+    };
+
+    (
+        StatusCode::PAYLOAD_TOO_LARGE,
+        [
+            ("Content-Type", response_content_type.to_owned()),
+            ("Content-Length", body_bytes.len().to_string()),
+        ],
+        body_bytes,
     )
         .into_response()
 }

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -479,9 +479,20 @@ async fn incomplete_signature_missing_signed_headers() {
 
 #[tokio::test]
 async fn server_body_too_large_returns_413() {
-    let server = TestServer::new().await;
+    let limit = 7 * 1024 * 1024;
+    let server = TestServer::with_body_limit(
+        ferrokinesis::store::StoreOptions {
+            create_stream_ms: 0,
+            delete_stream_ms: 0,
+            update_stream_ms: 0,
+            shard_limit: 50,
+            ..Default::default()
+        },
+        limit,
+    )
+    .await;
 
-    let huge_body = vec![b'x'; 7 * 1024 * 1024 + 1];
+    let huge_body = vec![b'x'; limit + 1];
 
     let mut headers = HeaderMap::new();
     headers.insert("Content-Type", HeaderValue::from_static(AMZ_JSON));
@@ -501,7 +512,10 @@ async fn server_body_too_large_returns_413() {
     let res = server
         .raw_request(Method::POST, "/", headers, huge_body)
         .await;
-    assert_eq!(res.status(), 413);
+    let (status, body) = decode_body(res).await;
+    assert_eq!(status, 413);
+    assert_eq!(body["__type"], "SerializationException");
+    assert!(body["Message"].as_str().is_some());
 }
 
 #[tokio::test]

--- a/tests/request_body_limit.rs
+++ b/tests/request_body_limit.rs
@@ -3,6 +3,7 @@ mod common;
 use common::*;
 use ferrokinesis::store::StoreOptions;
 use reqwest::Method;
+use reqwest::header::HeaderValue;
 
 fn default_options() -> StoreOptions {
     StoreOptions {
@@ -26,7 +27,10 @@ async fn custom_limit_rejects_body_one_byte_over() {
         .raw_request(Method::POST, "/", signed_headers(), body)
         .await;
 
-    assert_eq!(res.status(), 413);
+    let (status, body) = decode_body(res).await;
+    assert_eq!(status, 413);
+    assert_eq!(body["__type"], "SerializationException");
+    assert!(body["Message"].as_str().is_some());
 }
 
 #[tokio::test]
@@ -69,7 +73,10 @@ async fn custom_limit_rejects_large_body_well_over_limit() {
         .raw_request(Method::POST, "/", signed_headers(), body)
         .await;
 
-    assert_eq!(res.status(), 413);
+    let (status, body) = decode_body(res).await;
+    assert_eq!(status, 413);
+    assert_eq!(body["__type"], "SerializationException");
+    assert!(body["Message"].as_str().is_some());
 }
 
 // --- Default 7 MB limit (matching --max-request-body-mb default) ---
@@ -84,7 +91,10 @@ async fn default_7mb_limit_rejects_body_over_7mb() {
         .raw_request(Method::POST, "/", signed_headers(), body)
         .await;
 
-    assert_eq!(res.status(), 413);
+    let (status, body) = decode_body(res).await;
+    assert_eq!(status, 413);
+    assert_eq!(body["__type"], "SerializationException");
+    assert!(body["Message"].as_str().is_some());
 }
 
 #[tokio::test]
@@ -111,11 +121,10 @@ async fn larger_limit_allows_body_rejected_by_smaller_limit() {
     let res = small_server
         .raw_request(Method::POST, "/", signed_headers(), body.clone())
         .await;
-    assert_eq!(
-        res.status(),
-        413,
-        "512-byte limit must reject 800-byte body"
-    );
+
+    let (status, err_body) = decode_body(res).await;
+    assert_eq!(status, 413, "512-byte limit must reject 800-byte body");
+    assert_eq!(err_body["__type"], "SerializationException");
 
     let large_server = TestServer::with_body_limit(default_options(), 1024).await;
     let res = large_server
@@ -141,7 +150,10 @@ async fn limit_conversion_1mb_rejects_body_of_1mb_plus_1() {
         .raw_request(Method::POST, "/", signed_headers(), body)
         .await;
 
-    assert_eq!(res.status(), 413);
+    let (status, body) = decode_body(res).await;
+    assert_eq!(status, 413);
+    assert_eq!(body["__type"], "SerializationException");
+    assert!(body["Message"].as_str().is_some());
 }
 
 #[tokio::test]
@@ -155,4 +167,56 @@ async fn limit_conversion_1mb_accepts_body_of_exactly_1mb() {
         .await;
 
     assert_ne!(res.status(), 413);
+}
+
+// --- Content-type negotiation for 413 error responses ---
+
+#[tokio::test]
+async fn custom_limit_returns_json_error_for_json_request() {
+    let limit = 512;
+    let server = TestServer::with_body_limit(default_options(), limit).await;
+
+    let mut headers = signed_headers();
+    headers.insert("Content-Type", HeaderValue::from_static(AMZ_JSON));
+
+    let body = vec![b'x'; limit + 1];
+    let res = server.raw_request(Method::POST, "/", headers, body).await;
+
+    let ct = res
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(ct, AMZ_JSON);
+
+    let (status, body) = decode_body(res).await;
+    assert_eq!(status, 413);
+    assert_eq!(body["__type"], "SerializationException");
+}
+
+#[tokio::test]
+async fn custom_limit_returns_cbor_error_for_cbor_request() {
+    let limit = 512;
+    let server = TestServer::with_body_limit(default_options(), limit).await;
+
+    let mut headers = signed_headers();
+    headers.insert("Content-Type", HeaderValue::from_static(AMZ_CBOR));
+
+    let body = vec![b'x'; limit + 1];
+    let res = server.raw_request(Method::POST, "/", headers, body).await;
+
+    let ct = res
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(ct, AMZ_CBOR);
+
+    let (status, body) = decode_body(res).await;
+    assert_eq!(status, 413);
+    assert_eq!(body["__type"], "SerializationException");
 }


### PR DESCRIPTION
## Summary
- Add `kinesis_413_middleware` that intercepts bare 413 responses from axum's `DefaultBodyLimit` and replaces them with Kinesis-shaped `SerializationException` error bodies (JSON or CBOR based on request Content-Type)
- Remove redundant `MAX_REQUEST_BYTES` constant and manual body size check in the handler (dead code when the axum layer is active)
- Update all 413-related tests to assert the error shape, add 2 new content-type negotiation tests

Closes #45

## Test plan
- [x] `cargo fmt --check` — passes
- [x] `cargo clippy --all-targets` — passes
- [x] `cargo test --test request_body_limit` — all 11 tests pass (5 updated + 2 new + 4 unchanged)
- [x] `cargo test --test connection` — `server_body_too_large_returns_413` passes with error shape assertion
- [x] `cargo test --test stress` — existing per-operation limit tests unaffected
- [x] `cargo test` — full suite green (347 tests)