### PR TITLE
Add CLAUDE.md with architecture, patterns, and build commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ A local AWS Kinesis emulator written in Rust (edition 2024). Aims to exactly mat
 
 HTTP POST → `src/server.rs` parses `X-Amz-Target` header → `Operation` enum → deserialize JSON/CBOR body → `check_types()` validates field types → `check_validations()` validates constraints → `dispatch()` routes to `src/actions/*.rs::execute()` → `Store` (redb) → JSON/CBOR response.
 
+**Exception:** `SubscribeToShard` bypasses `dispatch()` and uses `execute_streaming()` for HTTP/2 event-stream responses.
+
 ## Action handler contract
 
 All 39 handlers follow the same signature and pattern:
@@ -83,8 +85,8 @@ cargo cov-html                      # alias: llvm-cov --open (HTML report)
 
 ## Do-not-touch zones
 
-- **`src/sequence.rs`** (324 LOC) — bigint sequence number logic ported from kinesalite. Modify with extreme care.
-- **`src/shard_iterator.rs`** (114 LOC) — AES-256-CBC encrypted iterator tokens with hardcoded keys matching kinesalite.
+- **`src/sequence.rs`** — bigint sequence number logic ported from kinesalite. Modify with extreme care.
+- **`src/shard_iterator.rs`** — AES-256-CBC encrypted iterator tokens with hardcoded keys matching kinesalite.
 
 ## Conformance tests
 


### PR DESCRIPTION
## Summary

- Add comprehensive `CLAUDE.md` at the repo root covering architecture lifecycle, action handler contract, four-site checklist for new operations, constants discipline, type safety rules, error message casing quirk, testing contract, build commands, do-not-touch zones, and commit conventions
- Every Claude session reads this automatically, eliminating repeated codebase exploration

Closes #95

## Test plan

- [x] Verify all section details are accurate against current codebase
- [ ] Confirm Claude Code picks up the file in new sessions