### PR TITLE
test: add shard splitting and merging correctness tests

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -123,6 +123,18 @@ impl TestServer {
             .unwrap()
     }
 
+    /// Poll until stream status is ACTIVE (or panic after timeout).
+    pub async fn wait_for_stream_active(&self, name: &str) {
+        for _ in 0..20 {
+            let desc = self.describe_stream(name).await;
+            if desc["StreamDescription"]["StreamStatus"].as_str() == Some("ACTIVE") {
+                return;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        }
+        panic!("stream {name} did not become ACTIVE within timeout");
+    }
+
     /// Helper: create a stream and wait for it to become active
     pub async fn create_stream(&self, name: &str, shard_count: u32) {
         let res = self
@@ -133,9 +145,7 @@ impl TestServer {
             .await;
         assert_eq!(res.status(), 200, "Failed to create stream {name}");
 
-        // With create_stream_ms=0, should be immediately active
-        // but give a small buffer for the tokio task to run
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        self.wait_for_stream_active(name).await;
     }
 
     /// Helper: describe a stream

--- a/tests/split_merge_shards.rs
+++ b/tests/split_merge_shards.rs
@@ -439,7 +439,7 @@ async fn split_at_midpoint(server: &TestServer, name: &str) -> (String, Vec<Valu
         )
         .await;
     assert_eq!(res.status(), 200);
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    server.wait_for_stream_active(name).await;
 
     let desc = server.describe_stream(name).await;
     let shards = desc["StreamDescription"]["Shards"]
@@ -509,7 +509,7 @@ async fn split_shard_asymmetric_hash_ranges() {
         )
         .await;
     assert_eq!(res.status(), 200);
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    server.wait_for_stream_active(name).await;
 
     let desc = server.describe_stream(name).await;
     let shards = desc["StreamDescription"]["Shards"].as_array().unwrap();
@@ -565,7 +565,7 @@ async fn merge_shards_partial_range_with_lineage() {
         )
         .await;
     assert_eq!(res.status(), 200);
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    server.wait_for_stream_active(name).await;
 
     let desc = server.describe_stream(name).await;
     let shards = desc["StreamDescription"]["Shards"].as_array().unwrap();
@@ -684,7 +684,7 @@ async fn merge_shards_ending_sequence_numbers_valid() {
         )
         .await;
     assert_eq!(res.status(), 200);
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    server.wait_for_stream_active(name).await;
 
     let desc = server.describe_stream(name).await;
     let shards = desc["StreamDescription"]["Shards"].as_array().unwrap();
@@ -774,7 +774,7 @@ async fn put_record_routes_to_merged_shard_after_merge() {
         )
         .await;
     assert_eq!(res.status(), 200);
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    server.wait_for_stream_active(name).await;
 
     let desc = server.describe_stream(name).await;
     let shards = desc["StreamDescription"]["Shards"].as_array().unwrap();
@@ -1139,7 +1139,7 @@ async fn split_child_shard_creates_third_generation() {
         )
         .await;
     assert_eq!(res.status(), 200);
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    server.wait_for_stream_active(name).await;
 
     let desc = server.describe_stream(name).await;
     let shards = desc["StreamDescription"]["Shards"].as_array().unwrap();
@@ -1193,17 +1193,17 @@ async fn split_child_shard_creates_third_generation() {
     // Verify record routing to grandchildren
     let gc1_id = shards[3]["ShardId"].as_str().unwrap();
     let gc2_id = shards[4]["ShardId"].as_str().unwrap();
+    let child2_start_str = child2_start.to_string();
+    let child2_mid_str = child2_mid.to_string();
 
-    let r1 =
-        put_record_with_hash_key(&server, name, "dGVzdA==", "pk1", &child2_start.to_string()).await;
+    let r1 = put_record_with_hash_key(&server, name, "dGVzdA==", "pk1", &child2_start_str).await;
     assert_eq!(
         r1["ShardId"].as_str().unwrap(),
         gc1_id,
         "hash key at child2_start should route to grandchild 1"
     );
 
-    let r2 =
-        put_record_with_hash_key(&server, name, "dGVzdA==", "pk2", &child2_mid.to_string()).await;
+    let r2 = put_record_with_hash_key(&server, name, "dGVzdA==", "pk2", &child2_mid_str).await;
     assert_eq!(
         r2["ShardId"].as_str().unwrap(),
         gc2_id,
@@ -1249,7 +1249,7 @@ async fn merged_child_shard_serves_records_from_both_parents() {
         )
         .await;
     assert_eq!(res.status(), 200);
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    server.wait_for_stream_active(name).await;
 
     // Put a record to the merged child
     put_record_with_hash_key(&server, name, "bWVyZ2Vk", "pk2", "0").await;


### PR DESCRIPTION
## Summary

Closes #31

Adds 14 comprehensive correctness tests for `SplitShard` and `MergeShards` operations, covering eight previously untested areas:

- **Exact child hash key ranges** — Verifies child shards get precise `[start, NewStartingHashKey-1]` and `[NewStartingHashKey, end]` ranges, including edge cases (asymmetric split at minimum valid point)
- **Partial merge hash range** — Merges 2 of 3 shards and verifies the combined range is partial, not full hash space
- **Parent EndingSequenceNumber validity** — Asserts closing sequence numbers are lexicographically greater than all record sequence numbers
- **Record routing after resharding** — Verifies `PutRecord` with `ExplicitHashKey` routes to the correct child shard after split, and to the merged shard after merge
- **Exact shard lineage** — Asserts precise `ParentShardId` and `AdjacentParentShardId` values (not just existence)
- **Iterator continuity across shard boundaries** — Tests TRIM_HORIZON, AT_SEQUENCE_NUMBER, AFTER_SEQUENCE_NUMBER, and LATEST on closed parent shards; verifies null `NextShardIterator` exhaustion signal (KCL compatibility); confirms child shards receive and serve records normally
- **Re-split (third-generation lineage)** — Splits a child shard to verify grandchild hash ranges and parent references
- **Merged child record serving** — Verifies the merged child shard serves post-merge records while parents retain pre-merge records

### Coverage Matrix

| Acceptance Criterion | Tests |
|---------------------|-------|
| SplitShard creates correct child hash key ranges | `split_shard_exact_child_hash_ranges`, `split_shard_asymmetric_hash_ranges` |
| MergeShards creates correct combined hash key range | `merge_shards_partial_range_with_lineage` |
| Parent shards close with correct ending sequence number | `split_shard_ending_sequence_number_valid`, `merge_shards_ending_sequence_numbers_valid` |
| Records route to correct child shard after split | `put_record_routes_to_correct_child_after_split`, `put_record_routes_to_merged_shard_after_merge` |
| Shard lineage fields are populated correctly | `split_shard_exact_child_hash_ranges`, `merge_shards_partial_range_with_lineage` |
| Iterator types work across shard boundaries | `parent_shard_records_readable_after_split`, `closed_parent_at_after_sequence_number_iterators`, `closed_parent_returns_null_next_shard_iterator`, `child_shards_receive_and_serve_records_after_split` |
| LATEST iterator on closed parent returns empty | `closed_parent_latest_iterator_returns_empty` |
| Re-split creates correct third-generation lineage | `split_child_shard_creates_third_generation` |
| Merged child serves records from both parents | `merged_child_shard_serves_records_from_both_parents` |

## Test plan

- [x] All 26 split/merge tests pass (`cargo test --test split_merge_shards`)
- [x] Full test suite passes
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean