### PR TITLE
ci: simplify conformance dependency caching

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -125,19 +125,15 @@ jobs:
           distribution: temurin
           java-version: "11"
           cache: maven
+          cache-dependency-path: ${{ matrix.dir }}/pom.xml
 
       - name: Setup Python
         if: matrix.lang == 'python'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
-      - name: Cache pip
-        if: matrix.lang == 'python'
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: pip-conformance-${{ hashFiles('tests/conformance/python-boto3/requirements.txt') }}
+          cache: pip
+          cache-dependency-path: ${{ matrix.dir }}/requirements.txt
 
       - name: Install dependencies
         if: matrix.setup != ''


### PR DESCRIPTION
## Summary
- Replace the separate `actions/cache@v4` step for Python pip with `setup-python`'s built-in `cache: pip` option, gaining automatic restore-key fallbacks
- Add explicit `cache-dependency-path` to `setup-java` for more precise Maven cache keys

All 5 SDK test suites now use the same consistent pattern: built-in caching via their respective `setup-*` actions with `cache-dependency-path`.

## Test plan
- [ ] Verify conformance workflow passes on all 5 SDKs
- [ ] Check "Setup Python" step logs show cache restore
- [ ] Check "Setup Java" step logs show cache restore with pom.xml-specific key