### PR TITLE
test: prevent Java SDK v2 subscribeToShard test from hanging

### DIFF
--- a/tests/conformance/java-sdk-v2/src/test/java/ferrokinesis/conformance/KinesisV2ConformanceTest.java
+++ b/tests/conformance/java-sdk-v2/src/test/java/ferrokinesis/conformance/KinesisV2ConformanceTest.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -206,8 +207,10 @@ public class KinesisV2ConformanceTest {
                 })
                 .build();
 
-        asyncClient.subscribeToShard(subscribeRequest, responseHandler).join();
+        CompletableFuture<Void> subscription =
+                asyncClient.subscribeToShard(subscribeRequest, responseHandler);
         assertTrue(latch.await(10, TimeUnit.SECONDS), "Timed out waiting for events");
+        subscription.cancel(true);
         assertNull(error.get(), "Event stream error: " + error.get());
         assertFalse(receivedRecords.isEmpty(), "Should have received at least one record");
 


### PR DESCRIPTION
## Summary
- The `subscribeToShard` test called `.join()` on the `CompletableFuture`, which blocks until the server closes the event stream (5-minute `MAX_SUBSCRIPTION_MS` timeout)
- The 10-second `latch.await()` timeout on the next line was unreachable because `.join()` blocks first
- Fix: wait on the latch (fires when events arrive), then `cancel()` the subscription

## Test plan
- [ ] Java SDK v2 conformance job completes in seconds instead of 5+ minutes
- [ ] All other conformance tests still pass