### PR TITLE
fix: assert error before cancelling subscribeToShard subscription

### DIFF
--- a/tests/conformance/java-sdk-v2/src/test/java/ferrokinesis/conformance/KinesisV2ConformanceTest.java
+++ b/tests/conformance/java-sdk-v2/src/test/java/ferrokinesis/conformance/KinesisV2ConformanceTest.java
@@ -210,8 +210,8 @@ public class KinesisV2ConformanceTest {
         CompletableFuture<Void> subscription =
                 asyncClient.subscribeToShard(subscribeRequest, responseHandler);
         assertTrue(latch.await(10, TimeUnit.SECONDS), "Timed out waiting for events");
-        subscription.cancel(true);
         assertNull(error.get(), "Event stream error: " + error.get());
+        subscription.cancel(true);
         assertFalse(receivedRecords.isEmpty(), "Should have received at least one record");
 
         // Verify record data


### PR DESCRIPTION
## Summary
- Follows up on #116 — `cancel(true)` triggers `FutureCancelledException` which gets caught by the `onError` handler, causing the `assertNull(error.get())` to fail
- Fix: move the error assertion before `cancel()` so we verify no real errors occurred during streaming, then cancel the subscription

## Test plan
- [ ] Java SDK v2 conformance tests pass