### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/mandrean/ferrokinesis/compare/v0.1.2...v0.2.0) - 2026-03-19
+
+### Added
+
+- add ARN format regex validation ([#111](https://github.com/mandrean/ferrokinesis/pull/111))
+- add TLS/HTTPS support behind `tls` feature flag ([#109](https://github.com/mandrean/ferrokinesis/pull/109))
+- add KCL v1 integration test ([#106](https://github.com/mandrean/ferrokinesis/pull/106))
+- add SubscribeToShard end-to-end SDK tests ([#107](https://github.com/mandrean/ferrokinesis/pull/107))
+- add CBOR ↔ JSON equivalence tests and fix byte string handling ([#88](https://github.com/mandrean/ferrokinesis/pull/88))
+- add Goose load test for kinesalite comparison ([#84](https://github.com/mandrean/ferrokinesis/pull/84))
+- add retention period enforcement with TTL-based record trimming ([#87](https://github.com/mandrean/ferrokinesis/pull/87))
+- add multi-language SDK conformance test suite ([#83](https://github.com/mandrean/ferrokinesis/pull/83))
+- enforce 5 MB PutRecords batch limit and add stress tests ([#82](https://github.com/mandrean/ferrokinesis/pull/82))
+- add criterion benchmark suite with CI regression gate ([#80](https://github.com/mandrean/ferrokinesis/pull/80))
+- add configurable shard iterator TTL ([#40](https://github.com/mandrean/ferrokinesis/pull/40)) ([#77](https://github.com/mandrean/ferrokinesis/pull/77))
+- add health check endpoints and CLI subcommand ([#72](https://github.com/mandrean/ferrokinesis/pull/72))
+- configurable AWS account ID and region via CLI flags and config file ([#79](https://github.com/mandrean/ferrokinesis/pull/79))
+- add configurable request body size limit ([#45](https://github.com/mandrean/ferrokinesis/pull/45)) ([#64](https://github.com/mandrean/ferrokinesis/pull/64))
+
+### Fixed
+
+- assert error before cancelling subscribeToShard subscription ([#118](https://github.com/mandrean/ferrokinesis/pull/118))
+- error response conformance audit ([#89](https://github.com/mandrean/ferrokinesis/pull/89))
+- return Kinesis-shaped error responses for 413 body size rejections ([#90](https://github.com/mandrean/ferrokinesis/pull/90))
+- add fake SigV4 auth headers to Docker smoke test ([#81](https://github.com/mandrean/ferrokinesis/pull/81))
+
+### Other
+
+- add property-based tests with proptest ([#123](https://github.com/mandrean/ferrokinesis/pull/123))
+- prevent Java SDK v2 subscribeToShard test from hanging ([#116](https://github.com/mandrean/ferrokinesis/pull/116))
+- simplify conformance dependency caching ([#115](https://github.com/mandrean/ferrokinesis/pull/115))
+- add concurrent stress tests and race condition detection ([#105](https://github.com/mandrean/ferrokinesis/pull/105))
+- Add CLAUDE.md with architecture, patterns, and build commands ([#108](https://github.com/mandrean/ferrokinesis/pull/108))
+- add shard splitting and merging correctness tests ([#110](https://github.com/mandrean/ferrokinesis/pull/110))
+- adopt thiserror for typed error handling ([#78](https://github.com/mandrean/ferrokinesis/pull/78))
+- harden Docker image and add Trivy security scanning ([#46](https://github.com/mandrean/ferrokinesis/pull/46)) ([#66](https://github.com/mandrean/ferrokinesis/pull/66))
+- add Docker smoke test before image push ([#28](https://github.com/mandrean/ferrokinesis/pull/28)) ([#63](https://github.com/mandrean/ferrokinesis/pull/63))
+- add cargo-audit and cargo-deny for supply chain security ([#47](https://github.com/mandrean/ferrokinesis/pull/47)) ([#65](https://github.com/mandrean/ferrokinesis/pull/65))
+- pin Rust toolchain and add SHA256 checksums to releases ([#48](https://github.com/mandrean/ferrokinesis/pull/48)) ([#67](https://github.com/mandrean/ferrokinesis/pull/67))
+
 ## [0.1.2](https://github.com/mandrean/ferrokinesis/compare/v0.1.1...v0.1.2) - 2026-03-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrokinesis"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "aes",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrokinesis"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 description = "A local AWS Kinesis mock server for testing, written in Rust"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `ferrokinesis`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `ferrokinesis` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field KinesisError.error_type in /tmp/.tmpfCRwXF/ferrokinesis/src/error.rs:7
  field StoreOptions.iterator_ttl_seconds in /tmp/.tmpfCRwXF/ferrokinesis/src/store.rs:32
  field StoreOptions.retention_check_interval_secs in /tmp/.tmpfCRwXF/ferrokinesis/src/store.rs:33
  field StoreOptions.aws_account_id in /tmp/.tmpfCRwXF/ferrokinesis/src/store.rs:34
  field StoreOptions.aws_region in /tmp/.tmpfCRwXF/ferrokinesis/src/store.rs:35

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field __type of struct KinesisError, previously in file /tmp/.tmpEikywi/ferrokinesis/src/error.rs:6
  field message_upper of struct KinesisError, previously in file /tmp/.tmpEikywi/ferrokinesis/src/error.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/mandrean/ferrokinesis/compare/v0.1.2...v0.2.0) - 2026-03-19

### Added

- add ARN format regex validation ([#111](https://github.com/mandrean/ferrokinesis/pull/111))
- add TLS/HTTPS support behind `tls` feature flag ([#109](https://github.com/mandrean/ferrokinesis/pull/109))
- add KCL v1 integration test ([#106](https://github.com/mandrean/ferrokinesis/pull/106))
- add SubscribeToShard end-to-end SDK tests ([#107](https://github.com/mandrean/ferrokinesis/pull/107))
- add CBOR ↔ JSON equivalence tests and fix byte string handling ([#88](https://github.com/mandrean/ferrokinesis/pull/88))
- add Goose load test for kinesalite comparison ([#84](https://github.com/mandrean/ferrokinesis/pull/84))
- add retention period enforcement with TTL-based record trimming ([#87](https://github.com/mandrean/ferrokinesis/pull/87))
- add multi-language SDK conformance test suite ([#83](https://github.com/mandrean/ferrokinesis/pull/83))
- enforce 5 MB PutRecords batch limit and add stress tests ([#82](https://github.com/mandrean/ferrokinesis/pull/82))
- add criterion benchmark suite with CI regression gate ([#80](https://github.com/mandrean/ferrokinesis/pull/80))
- add configurable shard iterator TTL ([#40](https://github.com/mandrean/ferrokinesis/pull/40)) ([#77](https://github.com/mandrean/ferrokinesis/pull/77))
- add health check endpoints and CLI subcommand ([#72](https://github.com/mandrean/ferrokinesis/pull/72))
- configurable AWS account ID and region via CLI flags and config file ([#79](https://github.com/mandrean/ferrokinesis/pull/79))
- add configurable request body size limit ([#45](https://github.com/mandrean/ferrokinesis/pull/45)) ([#64](https://github.com/mandrean/ferrokinesis/pull/64))

### Fixed

- assert error before cancelling subscribeToShard subscription ([#118](https://github.com/mandrean/ferrokinesis/pull/118))
- error response conformance audit ([#89](https://github.com/mandrean/ferrokinesis/pull/89))
- return Kinesis-shaped error responses for 413 body size rejections ([#90](https://github.com/mandrean/ferrokinesis/pull/90))
- add fake SigV4 auth headers to Docker smoke test ([#81](https://github.com/mandrean/ferrokinesis/pull/81))

### Other

- add property-based tests with proptest ([#123](https://github.com/mandrean/ferrokinesis/pull/123))
- prevent Java SDK v2 subscribeToShard test from hanging ([#116](https://github.com/mandrean/ferrokinesis/pull/116))
- simplify conformance dependency caching ([#115](https://github.com/mandrean/ferrokinesis/pull/115))
- add concurrent stress tests and race condition detection ([#105](https://github.com/mandrean/ferrokinesis/pull/105))
- Add CLAUDE.md with architecture, patterns, and build commands ([#108](https://github.com/mandrean/ferrokinesis/pull/108))
- add shard splitting and merging correctness tests ([#110](https://github.com/mandrean/ferrokinesis/pull/110))
- adopt thiserror for typed error handling ([#78](https://github.com/mandrean/ferrokinesis/pull/78))
- harden Docker image and add Trivy security scanning ([#46](https://github.com/mandrean/ferrokinesis/pull/46)) ([#66](https://github.com/mandrean/ferrokinesis/pull/66))
- add Docker smoke test before image push ([#28](https://github.com/mandrean/ferrokinesis/pull/28)) ([#63](https://github.com/mandrean/ferrokinesis/pull/63))
- add cargo-audit and cargo-deny for supply chain security ([#47](https://github.com/mandrean/ferrokinesis/pull/47)) ([#65](https://github.com/mandrean/ferrokinesis/pull/65))
- pin Rust toolchain and add SHA256 checksums to releases ([#48](https://github.com/mandrean/ferrokinesis/pull/48)) ([#67](https://github.com/mandrean/ferrokinesis/pull/67))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).