### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/mandrean/ferrokinesis/compare/v0.2.1...v0.3.0) - 2026-03-20
+
+### Added
+
+- structured & configurable logging via tracing ecosystem ([#159](https://github.com/mandrean/ferrokinesis/pull/159))
+- add --host flag to health-check subcommand ([#136](https://github.com/mandrean/ferrokinesis/pull/136))
+- add constants enforcement hook for action handlers ([#135](https://github.com/mandrean/ferrokinesis/pull/135))
+- add graceful shutdown for plain HTTP serve path ([#126](https://github.com/mandrean/ferrokinesis/pull/126))
+
+### Other
+
+- centralize config defaults and add example config ([#162](https://github.com/mandrean/ferrokinesis/pull/162))
+- add `cargo test --doc` to CI ([#161](https://github.com/mandrean/ferrokinesis/pull/161))
+- update README to reflect current feature set ([#139](https://github.com/mandrean/ferrokinesis/pull/139))
+- zero-copy record path optimization ([#132](https://github.com/mandrean/ferrokinesis/pull/132))
+- add inline comments explaining protocol quirks and invariants ([#137](https://github.com/mandrean/ferrokinesis/pull/137))
+- add rustdoc coverage and #![warn(missing_docs)] ([#138](https://github.com/mandrean/ferrokinesis/pull/138))
+- add property-based tests for sequence roundtrip and error paths ([#130](https://github.com/mandrean/ferrokinesis/pull/130))
+- expand conformance tests to cover all supported Kinesis operations ([#128](https://github.com/mandrean/ferrokinesis/pull/128))
+- move SDK examples from README to examples/ directory ([#131](https://github.com/mandrean/ferrokinesis/pull/131))
+- add CODEOWNERS ([#127](https://github.com/mandrean/ferrokinesis/pull/127))
+
 ## [0.2.1](https://github.com/mandrean/ferrokinesis/compare/v0.1.2...v0.2.1) - 2026-03-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrokinesis"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrokinesis"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 description = "A local AWS Kinesis mock server for testing, written in Rust"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `ferrokinesis`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `ferrokinesis` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FileConfig.log_level in /tmp/.tmpF5KIDI/ferrokinesis/src/config.rs:79
  field FileConfig.access_log in /tmp/.tmpF5KIDI/ferrokinesis/src/config.rs:82

--- failure enum_now_doc_hidden: pub enum is now #[doc(hidden)] ---

Description:
A pub enum is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_now_doc_hidden.ron

Failed in:
  enum SequenceError in file /tmp/.tmpF5KIDI/ferrokinesis/src/sequence.rs:6
  enum FieldType in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/mod.rs:21
  enum ShardIteratorError in file /tmp/.tmpF5KIDI/ferrokinesis/src/shard_iterator.rs:7

--- failure function_now_doc_hidden: pub function is now #[doc(hidden)] ---

Description:
A pub function is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_now_doc_hidden.ron

Failed in:
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/add_tags_to_stream.rs:6
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/untag_resource.rs:6
  function update_stream_mode in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:474
  function describe_stream_summary in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:53
  function sweep_once in file /tmp/.tmpF5KIDI/ferrokinesis/src/retention.rs:12
  function increment_sequence in file /tmp/.tmpF5KIDI/ferrokinesis/src/sequence.rs:250
  function disable_enhanced_monitoring in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:373
  function base64_decoded_len in file /tmp/.tmpF5KIDI/ferrokinesis/src/util.rs:10
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/put_record.rs:11
  function split_shard in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:278
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/list_streams.rs:6
  function delete_resource_policy in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:503
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/describe_stream.rs:6
  function put_record in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:101
  function resolve_shard_id in file /tmp/.tmpF5KIDI/ferrokinesis/src/sequence.rs:274
  function register_stream_consumer in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:417
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/get_shard_iterator.rs:11
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/delete_stream.rs:7
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/split_shard.rs:11
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/get_records.rs:10
  function encode_subscribe_event in file /tmp/.tmpF5KIDI/ferrokinesis/src/event_stream.rs:6
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/update_shard_count.rs:11
  function list_tags_for_resource in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:540
  function get_shard_iterator in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:178
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/tag_resource.rs:6
  function list_stream_consumers in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:436
  function delete_stream in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:32
  function to_lower_first in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/mod.rs:11
  function parse_sequence in file /tmp/.tmpF5KIDI/ferrokinesis/src/sequence.rs:39
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/create_stream.rs:18
  function encode_exception in file /tmp/.tmpF5KIDI/ferrokinesis/src/event_stream.rs:44
  function decode_shard_iterator in file /tmp/.tmpF5KIDI/ferrokinesis/src/shard_iterator.rs:83
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/merge_shards.rs:11
  function update_max_record_size in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:593
  function check_validations in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/mod.rs:366
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/disable_enhanced_monitoring.rs:6
  function list_tags_for_stream in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:242
  function put_resource_policy in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:492
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/list_stream_consumers.rs:6
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/describe_limits.rs:5
  function list_streams in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:57
  function shard_ix_to_hex in file /tmp/.tmpF5KIDI/ferrokinesis/src/sequence.rs:262
  function start_stream_encryption in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:377
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/get_resource_policy.rs:6
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/delete_resource_policy.rs:6
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/remove_tags_from_stream.rs:6
  function increase_stream_retention_period in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:298
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/update_max_record_size.rs:7
  function tag_resource in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:507
  function put_records in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:127
  function partition_key_to_hash_key in file /tmp/.tmpF5KIDI/ferrokinesis/src/sequence.rs:287
  function execute_streaming in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/subscribe_to_shard.rs:21
  function deregister_stream_consumer in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:424
  function subscribe_to_shard in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:544
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/list_tags_for_stream.rs:6
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/put_records.rs:17
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/describe_stream_summary.rs:6
  function add_tags_to_stream in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:209
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/list_shards.rs:6
  function update_shard_count in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:454
  function describe_stream in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:36
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/describe_account_settings.rs:6
  function run_reaper in file /tmp/.tmpF5KIDI/ferrokinesis/src/retention.rs:4
  function stringify_sequence in file /tmp/.tmpF5KIDI/ferrokinesis/src/sequence.rs:171
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/stop_stream_encryption.rs:7
  function enable_enhanced_monitoring in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:357
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/decrease_stream_retention_period.rs:6
  function current_time_ms in file /tmp/.tmpF5KIDI/ferrokinesis/src/util.rs:2
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/update_stream_warm_throughput.rs:7
  function update_account_settings in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:606
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/register_stream_consumer.rs:8
  function merge_shards in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:256
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/update_account_settings.rs:6
  function get_resource_policy in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:499
  function list_shards in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:73
  function shard_id_name in file /tmp/.tmpF5KIDI/ferrokinesis/src/sequence.rs:266
  function stop_stream_encryption in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:397
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/enable_enhanced_monitoring.rs:16
  function decrease_stream_retention_period in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:311
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/list_tags_for_resource.rs:6
  function untag_resource in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:524
  function check_types in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/mod.rs:141
  function get_records in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:162
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/describe_stream_consumer.rs:6
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/increase_stream_retention_period.rs:6
  function describe_stream_consumer in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:432
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/deregister_stream_consumer.rs:7
  function create_stream in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:19
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/start_stream_encryption.rs:7
  function encode_initial_response in file /tmp/.tmpF5KIDI/ferrokinesis/src/event_stream.rs:27
  function create_shard_iterator in file /tmp/.tmpF5KIDI/ferrokinesis/src/shard_iterator.rs:43
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/update_stream_mode.rs:7
  function update_stream_warm_throughput in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:576
  function execute in file /tmp/.tmpF5KIDI/ferrokinesis/src/actions/put_resource_policy.rs:6
  function remove_tags_from_stream in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/rules.rs:226

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  ferrokinesis::store::Store::put_record takes 1 generic types instead of 0, in /tmp/.tmpF5KIDI/ferrokinesis/src/store.rs:413
  ferrokinesis::store::Store::put_records_batch takes 1 generic types instead of 0, in /tmp/.tmpF5KIDI/ferrokinesis/src/store.rs:427

--- failure pub_module_level_const_now_doc_hidden: pub module-level const is now #[doc(hidden)] ---

Description:
A public const is now marked #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_now_doc_hidden.ron

Failed in:
  KEY_ID in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:37
  RESOURCE_IN_USE in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:4
  SHARD_TO_SPLIT in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:56
  SHARD_COUNT in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:29
  TARGET_SHARD_COUNT in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:48
  CONTENT_TYPE_CBOR in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:17
  SHARD_ITERATOR_TRIM_HORIZON in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:73
  SHARD_LEVEL_METRICS in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:40
  SERIALIZATION_EXCEPTION in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:7
  ADJACENT_SHARD_TO_MERGE in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:59
  MAX_RESULTS in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:32
  TIMESTAMP in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:51
  STREAM_ARN in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:24
  SHARD_ITERATOR_AFTER_SEQUENCE_NUMBER in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:76
  RECORDS in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:43
  INCOMPLETE_SIGNATURE in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:10
  MINIMUM_THROUGHPUT_BILLING_COMMITMENT in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:62
  TAG_KEYS in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:35
  INVALID_ARGUMENT in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:2
  EXCLUSIVE_START_TAG_KEY in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:54
  CONSUMER_ARN in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:27
  SEQUENCE_NUMBER_FOR_ORDERING in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:46
  ACCESS_DENIED in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:13
  STREAM_MODE_PROVISIONED in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:69
  ENCRYPTION_TYPE in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:38
  LIMIT_EXCEEDED in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:5
  NEW_STARTING_HASH_KEY in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:57
  PARTITION_KEY in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:30
  STREAM_MODE_DETAILS in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:49
  KINESIS_API in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:20
  SHARD_ITERATOR_LATEST in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:74
  SHARD_ITERATOR in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:41
  VALIDATION_EXCEPTION in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:8
  MAX_RECORD_SIZE_IN_KIB in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:60
  NEXT_TOKEN in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:33
  EXCLUSIVE_START_STREAM_NAME in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:52
  RESOURCE_ARN in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:25
  SHARD_ITERATOR_AT_TIMESTAMP in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:77
  DATA in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:44
  MISSING_AUTH_TOKEN in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:11
  ENCRYPTION_KMS in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:65
  POLICY in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:36
  RESOURCE_NOT_FOUND in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:3
  STARTING_POSITION in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:55
  SHARD_ID in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:28
  STARTING_SEQUENCE_NUMBER in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:47
  CONTENT_TYPE_JSON in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:16
  STREAM_MODE_ON_DEMAND in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:70
  RETENTION_PERIOD_HOURS in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:39
  EXPIRED_ITERATOR in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:6
  SHARD_TO_MERGE in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:58
  LIMIT in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:31
  SCALING_TYPE in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:50
  STREAM_NAME in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:23
  SHARD_ITERATOR_AT_SEQUENCE_NUMBER in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:75
  SHARD_ITERATOR_TYPE in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:42
  UNKNOWN_OPERATION in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:9
  WARM_THROUGHPUT_MIBPS in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:61
  TAGS in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:34
  EXCLUSIVE_START_SHARD_ID in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:53
  CONSUMER_NAME in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:26
  EXPLICIT_HASH_KEY in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:45
  INVALID_SIGNATURE in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:12
  ENCRYPTION_NONE in file /tmp/.tmpF5KIDI/ferrokinesis/src/constants.rs:66

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct ferrokinesis::types::OutputRecord, previously in file /tmp/.tmpyIT2BW/ferrokinesis/src/types.rs:154

--- failure struct_now_doc_hidden: pub struct is now #[doc(hidden)] ---

Description:
A pub struct is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_now_doc_hidden.ron

Failed in:
  struct FieldDef in file /tmp/.tmpF5KIDI/ferrokinesis/src/validation/mod.rs:43
  struct SeqObj in file /tmp/.tmpF5KIDI/ferrokinesis/src/sequence.rs:25

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field seq_ix of struct Stream, previously in file /tmp/.tmpyIT2BW/ferrokinesis/src/types.rs:100
  field tags of struct Stream, previously in file /tmp/.tmpyIT2BW/ferrokinesis/src/types.rs:102
  field key_id of struct Stream, previously in file /tmp/.tmpyIT2BW/ferrokinesis/src/types.rs:104
  field warm_throughput_mibps of struct Stream, previously in file /tmp/.tmpyIT2BW/ferrokinesis/src/types.rs:106
  field max_record_size_kib of struct Stream, previously in file /tmp/.tmpyIT2BW/ferrokinesis/src/types.rs:108

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field Stream.seq_ix in file /tmp/.tmpF5KIDI/ferrokinesis/src/types.rs:135
  field Stream.tags in file /tmp/.tmpF5KIDI/ferrokinesis/src/types.rs:135
  field Stream.key_id in file /tmp/.tmpF5KIDI/ferrokinesis/src/types.rs:135
  field Stream.warm_throughput_mibps in file /tmp/.tmpF5KIDI/ferrokinesis/src/types.rs:135
  field Stream.max_record_size_kib in file /tmp/.tmpF5KIDI/ferrokinesis/src/types.rs:135
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/mandrean/ferrokinesis/compare/v0.2.1...v0.3.0) - 2026-03-20

### Added

- structured & configurable logging via tracing ecosystem ([#159](https://github.com/mandrean/ferrokinesis/pull/159))
- add --host flag to health-check subcommand ([#136](https://github.com/mandrean/ferrokinesis/pull/136))
- add constants enforcement hook for action handlers ([#135](https://github.com/mandrean/ferrokinesis/pull/135))
- add graceful shutdown for plain HTTP serve path ([#126](https://github.com/mandrean/ferrokinesis/pull/126))

### Other

- centralize config defaults and add example config ([#162](https://github.com/mandrean/ferrokinesis/pull/162))
- add `cargo test --doc` to CI ([#161](https://github.com/mandrean/ferrokinesis/pull/161))
- update README to reflect current feature set ([#139](https://github.com/mandrean/ferrokinesis/pull/139))
- zero-copy record path optimization ([#132](https://github.com/mandrean/ferrokinesis/pull/132))
- add inline comments explaining protocol quirks and invariants ([#137](https://github.com/mandrean/ferrokinesis/pull/137))
- add rustdoc coverage and #![warn(missing_docs)] ([#138](https://github.com/mandrean/ferrokinesis/pull/138))
- add property-based tests for sequence roundtrip and error paths ([#130](https://github.com/mandrean/ferrokinesis/pull/130))
- expand conformance tests to cover all supported Kinesis operations ([#128](https://github.com/mandrean/ferrokinesis/pull/128))
- move SDK examples from README to examples/ directory ([#131](https://github.com/mandrean/ferrokinesis/pull/131))
- add CODEOWNERS ([#127](https://github.com/mandrean/ferrokinesis/pull/127))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).