### PR TITLE
ci: add `cargo test --doc` to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Test
         run: cargo test
+      - name: Doc tests
+        run: cargo test --doc
       - name: Lint (TLS)
         run: cargo clippy --features tls -- -D warnings
       - name: Test (TLS)


### PR DESCRIPTION
## Summary

- Adds a `cargo test --doc` step to CI so doc-test examples (`no_run` blocks) are compiled on every PR, preventing silent bit-rot.

Closes #92 — the remaining items from that issue don't apply:
- No unit tests in `src/` to migrate (all 53+ tests are integration tests in `tests/`)
- `examples/` already has multi-language SDK conformance coverage

## Test plan

- [x] `cargo test --doc` passes locally (4 doc tests)
- [ ] CI passes with the new step