### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/mandrean/ferrokinesis/compare/ferrokinesis-v0.3.0...ferrokinesis-v0.4.0) - 2026-03-20
+
+### Added
+
+- add transparent traffic mirroring to real AWS ([#165](https://github.com/mandrean/ferrokinesis/pull/165))
+- add stream capture and replay ([#163](https://github.com/mandrean/ferrokinesis/pull/163))
+- add TRACE-level logging to all action handlers ([#168](https://github.com/mandrean/ferrokinesis/pull/168))
+
+### Fixed
+
+- correct SHA256SUMS generation in release workflow ([#173](https://github.com/mandrean/ferrokinesis/pull/173))
+- split release workflow so artifacts only build on actual releases ([#164](https://github.com/mandrean/ferrokinesis/pull/164))
+
+### Other
+
+- add KCL 2.x enhanced fan-out integration test ([#141](https://github.com/mandrean/ferrokinesis/pull/141))
+- unify workspace versioning and suppress spurious ferrokinesis-core releases ([#176](https://github.com/mandrean/ferrokinesis/pull/176))
+- extract ferrokinesis-core no_std crate ([#166](https://github.com/mandrean/ferrokinesis/pull/166))
+
 ### Other
 
 - bump `ferrokinesis-core` from `0.1.0` → `0.3.0` to align with workspace version (intentional jump; no intermediate releases)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrokinesis"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes",
  "async-stream",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "ferrokinesis-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "crates/ferrokinesis-core"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `ferrokinesis-core`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `ferrokinesis`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `ferrokinesis` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FileConfig.capture in /tmp/.tmpl216qs/ferrokinesis/src/config.rs:82
  field FileConfig.scrub in /tmp/.tmpl216qs/ferrokinesis/src/config.rs:84
  field FileConfig.mirror in /tmp/.tmpl216qs/ferrokinesis/src/config.rs:87

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum ferrokinesis::types::ShardIteratorType, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:108
  enum ferrokinesis::types::StreamStatus, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:15
  enum ferrokinesis::actions::Operation, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/actions/mod.rs:100
  enum ferrokinesis::types::EncryptionType, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:80
  enum ferrokinesis::types::StreamMode, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:95
  enum ferrokinesis::types::ConsumerStatus, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:40

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  ferrokinesis::server::handler now takes 6 parameters instead of 5, in /tmp/.tmpl216qs/ferrokinesis/src/server.rs:57

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct ferrokinesis::types::HashKeyRange, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:202
  struct ferrokinesis::types::ResponseRecord, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:262
  struct ferrokinesis::types::Shard, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:182
  struct ferrokinesis::types::StoredRecordRef, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:246
  struct ferrokinesis::types::Stream, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:135
  struct ferrokinesis::error::KinesisError, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/error.rs:27
  struct ferrokinesis::types::EnhancedMonitoring, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:174
  struct ferrokinesis::types::StreamModeDetails, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:124
  struct ferrokinesis::types::SequenceNumberRange, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:212
  struct ferrokinesis::error::KinesisErrorResponse, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/error.rs:64
  struct ferrokinesis::types::Consumer, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:62
  struct ferrokinesis::types::StoredRecord, previously in file /tmp/.tmpOUwxE3/ferrokinesis/src/types.rs:231
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `ferrokinesis`

<blockquote>

## [0.4.0](https://github.com/mandrean/ferrokinesis/compare/ferrokinesis-v0.3.0...ferrokinesis-v0.4.0) - 2026-03-20

### Added

- add transparent traffic mirroring to real AWS ([#165](https://github.com/mandrean/ferrokinesis/pull/165))
- add stream capture and replay ([#163](https://github.com/mandrean/ferrokinesis/pull/163))
- add TRACE-level logging to all action handlers ([#168](https://github.com/mandrean/ferrokinesis/pull/168))

### Fixed

- correct SHA256SUMS generation in release workflow ([#173](https://github.com/mandrean/ferrokinesis/pull/173))
- split release workflow so artifacts only build on actual releases ([#164](https://github.com/mandrean/ferrokinesis/pull/164))

### Other

- add KCL 2.x enhanced fan-out integration test ([#141](https://github.com/mandrean/ferrokinesis/pull/141))
- unify workspace versioning and suppress spurious ferrokinesis-core releases ([#176](https://github.com/mandrean/ferrokinesis/pull/176))
- extract ferrokinesis-core no_std crate ([#166](https://github.com/mandrean/ferrokinesis/pull/166))

### Other

- bump `ferrokinesis-core` from `0.1.0` → `0.3.0` to align with workspace version (intentional jump; no intermediate releases)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).