### PR TITLE
fix: correct SHA256SUMS generation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          find . -type f | sort | xargs sha256sum | sed "s|.*/||" > SHA256SUMS
+          find . -type f -not -name SHA256SUMS | sort | xargs sha256sum | sed "s|  .*/|  |" > SHA256SUMS
       - name: Upload release assets
         run: |
           TAG="${{ github.event.release.tag_name }}"


### PR DESCRIPTION
## Summary
- The `sed` command in the checksum generation step was stripping the hash along with the directory prefix, producing broken SHA256SUMS files for every release
- `sed "s|.*/||"` greedily matches everything up to the last `/`, consuming the hash + spaces
- Fixed to `sed "s|  .*/|  |"` which anchors on the two-space separator that `sha256sum` outputs between hash and filename
- Also excludes `SHA256SUMS` from the `find` to avoid self-inclusion

## Test plan
- [ ] Trigger a release and verify SHA256SUMS contains valid `<hash>  <filename>` lines
- [ ] Verify checksums match: `sha256sum -c SHA256SUMS`