### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/mandrean/ferrokinesis/compare/v0.4.0...v0.5.0) - 2026-03-20
+
+### Added
+
+- use aws-config credential provider chain in mirror ([#180](https://github.com/mandrean/ferrokinesis/pull/180))
+
+### Fixed
+
+- reorder Docker tags so GHCR shows version in install instruction
+- use correct release-plz field name git_tag_name
+- move tag_name_template to [workspace] level
+- use v{version} tag format for ferrokinesis releases
+
+### Other
+
+- per-shard lock-free concurrent store (replace redb) ([#184](https://github.com/mandrean/ferrokinesis/pull/184))
+- single-pass CBOR serialization via BlobAwareValue ([#185](https://github.com/mandrean/ferrokinesis/pull/185))
+- move capture write into put_record/put_records handlers ([#179](https://github.com/mandrean/ferrokinesis/pull/179))
+
 ## [0.4.0](https://github.com/mandrean/ferrokinesis/compare/ferrokinesis-v0.3.0...ferrokinesis-v0.4.0) - 2026-03-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrokinesis"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes",
  "async-stream",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "ferrokinesis-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "crates/ferrokinesis-core"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"
@@ -34,7 +34,7 @@ replay = ["dep:reqwest"]
 tls = ["dep:axum-server", "dep:rcgen", "dep:rustls"]
 
 [dependencies]
-ferrokinesis-core = { path = "crates/ferrokinesis-core", version = "0.4.0" }
+ferrokinesis-core = { path = "crates/ferrokinesis-core", version = "0.5.0" }
 async-stream = "0.3"
 backon = { version = "1.6", default-features = false, features = ["tokio-sleep"], optional = true }
 aws-config = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "credentials-process"] }


### PR DESCRIPTION



## 🤖 New release

* `ferrokinesis-core`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `ferrokinesis`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `ferrokinesis-core` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  ferrokinesis_core::types::StreamBuilder::new now takes 5 parameters instead of 6, in /tmp/.tmpaIjqpd/ferrokinesis/crates/ferrokinesis-core/src/types.rs:291
```

### ⚠ `ferrokinesis` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Store::with_streams_write, previously in file /tmp/.tmpFknKhX/ferrokinesis/src/store.rs:354
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `ferrokinesis`

<blockquote>

## [0.5.0](https://github.com/mandrean/ferrokinesis/compare/v0.4.0...v0.5.0) - 2026-03-20

### Added

- use aws-config credential provider chain in mirror ([#180](https://github.com/mandrean/ferrokinesis/pull/180))

### Fixed

- reorder Docker tags so GHCR shows version in install instruction
- use correct release-plz field name git_tag_name
- move tag_name_template to [workspace] level
- use v{version} tag format for ferrokinesis releases

### Other

- per-shard lock-free concurrent store (replace redb) ([#184](https://github.com/mandrean/ferrokinesis/pull/184))
- single-pass CBOR serialization via BlobAwareValue ([#185](https://github.com/mandrean/ferrokinesis/pull/185))
- move capture write into put_record/put_records handlers ([#179](https://github.com/mandrean/ferrokinesis/pull/179))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).