### PR TITLE
fix: use v{version} format for GitHub release name

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,7 @@
 # Use simple v{version} tag format instead of the workspace default {crate_name}-v{version}
 # so that the release.yml workflow (which gates on startsWith tag 'v') picks it up correctly.
 git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"
 
 [[package]]
 name = "ferrokinesis-core"


### PR DESCRIPTION
## Summary
- Add `git_release_name = "v{{ version }}"` to `release-plz.toml` so GitHub release titles use `v0.5.0` instead of `ferrokinesis-v0.5.0`
- The existing v0.5.0 release was already renamed via `gh release edit`

## Test plan
- [x] Verified current v0.5.0 release name is now `v0.5.0` via `gh release view v0.5.0 --json name`
- [ ] After next release, verify both tag and release name use `v{version}` format