### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/mandrean/ferrokinesis/compare/v0.5.0...v0.6.0) - 2026-03-24
+
+### Added
+
+- *(wasm)* Add GitHub Pages browser demo ([#193](https://github.com/mandrean/ferrokinesis/pull/193))
+- Add experimental WASI TCP listener binary ([#192](https://github.com/mandrean/ferrokinesis/pull/192))
+- Add WASM wrapper and runtime split ([#191](https://github.com/mandrean/ferrokinesis/pull/191))
+
+### Fixed
+
+- exclude ferrokinesis-wasm from release-plz publishing
+
+### Other
+
+- Add cross-format CBOR/JSON property tests ([#194](https://github.com/mandrean/ferrokinesis/pull/194))
+- eliminate BigUint heap allocations on write hot path ([#190](https://github.com/mandrean/ferrokinesis/pull/190))
+- use v{version} format for GitHub release name ([#188](https://github.com/mandrean/ferrokinesis/pull/188))
+
 ## [0.5.0](https://github.com/mandrean/ferrokinesis/compare/v0.4.0...v0.5.0) - 2026-03-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrokinesis"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes",
  "async-stream",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "ferrokinesis-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes",
  "base64",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "ferrokinesis-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "axum",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "crates/ferrokinesis-core", "crates/ferrokinesis-wasm"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"
@@ -72,7 +72,7 @@ replay = ["server", "dep:reqwest"]
 tls = ["server", "dep:axum-server", "dep:rcgen", "dep:rustls"]
 
 [dependencies]
-ferrokinesis-core = { path = "crates/ferrokinesis-core", version = "0.5.0" }
+ferrokinesis-core = { path = "crates/ferrokinesis-core", version = "0.6.0" }
 backon = { version = "1.6", default-features = false, features = ["tokio-sleep"], optional = true }
 aws-config = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "credentials-process"] }
 aws-credential-types = { version = "1", optional = true }


### PR DESCRIPTION



## 🤖 New release

* `ferrokinesis-core`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `ferrokinesis`: 0.5.0 -> 0.6.0 (✓ API compatible changes)

### ⚠ `ferrokinesis-core` breaking changes

```text
--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field HashKeyRange.start_cached in /tmp/.tmp8gEiic/ferrokinesis/crates/ferrokinesis-core/src/types.rs:435
  field HashKeyRange.end_cached in /tmp/.tmp8gEiic/ferrokinesis/crates/ferrokinesis-core/src/types.rs:438
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `ferrokinesis`

<blockquote>

## [0.6.0](https://github.com/mandrean/ferrokinesis/compare/v0.5.0...v0.6.0) - 2026-03-24

### Added

- *(wasm)* Add GitHub Pages browser demo ([#193](https://github.com/mandrean/ferrokinesis/pull/193))
- Add experimental WASI TCP listener binary ([#192](https://github.com/mandrean/ferrokinesis/pull/192))
- Add WASM wrapper and runtime split ([#191](https://github.com/mandrean/ferrokinesis/pull/191))

### Fixed

- exclude ferrokinesis-wasm from release-plz publishing

### Other

- Add cross-format CBOR/JSON property tests ([#194](https://github.com/mandrean/ferrokinesis/pull/194))
- eliminate BigUint heap allocations on write hot path ([#190](https://github.com/mandrean/ferrokinesis/pull/190))
- use v{version} format for GitHub release name ([#188](https://github.com/mandrean/ferrokinesis/pull/188))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).