### PR TITLE
perf: eliminate BigUint heap allocations on write hot path

### DIFF
--- a/crates/ferrokinesis-core/src/sequence.rs
+++ b/crates/ferrokinesis-core/src/sequence.rs
@@ -2,7 +2,14 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use num_bigint::BigUint;
-use num_traits::{Num, One, ToPrimitive, Zero};
+use num_traits::{Num, One, Zero};
+
+/// Maximum sequence sub-index value (`i64::MAX` as `u64`).
+///
+/// Used as the seq_ix when constructing closing sequence numbers for split/merge
+/// operations. This ensures no future record could produce a sequence number ≥
+/// the ending sequence, making the shard-closed invariant unconditionally safe.
+pub const MAX_SEQ_IX: u64 = 0x7FFF_FFFF_FFFF_FFFF;
 
 /// Errors from parsing or resolving sequence numbers and shard IDs.
 #[derive(Debug, thiserror::Error)]
@@ -32,7 +39,7 @@ pub enum SequenceError {
 #[derive(Debug, Clone)]
 pub struct SeqObj {
     pub shard_create_time: u64,
-    pub seq_ix: Option<BigUint>,
+    pub seq_ix: Option<u64>,
     pub byte1: Option<String>,
     pub seq_time: Option<u64>,
     pub seq_rand: Option<String>,
@@ -129,9 +136,7 @@ pub fn parse_sequence(seq: &str) -> Result<SeqObj, SequenceError> {
 
             Ok(SeqObj {
                 shard_create_time: shard_create_secs * 1000,
-                seq_ix: Some(
-                    BigUint::from_str_radix(seq_ix_hex, 16).unwrap_or_else(|_| BigUint::zero()),
-                ),
+                seq_ix: Some(u64::from_str_radix(seq_ix_hex, 16).unwrap_or(0)),
                 byte1: Some(hex[27..29].to_string()),
                 seq_time: Some(seq_time),
                 seq_rand: None,
@@ -147,9 +152,7 @@ pub fn parse_sequence(seq: &str) -> Result<SeqObj, SequenceError> {
 
             Ok(SeqObj {
                 shard_create_time: shard_create_secs * 1000,
-                seq_ix: Some(BigUint::from(
-                    u64::from_str_radix(&hex[36..38], 16).unwrap_or(0),
-                )),
+                seq_ix: Some(u64::from_str_radix(&hex[36..38], 16).unwrap_or(0)),
                 byte1: Some(hex[11..13].to_string()),
                 seq_time: Some(u64::from_str_radix(&hex[13..22], 16).unwrap_or(0) * 1000),
                 seq_rand: Some(hex[22..36].to_string()),
@@ -181,80 +184,103 @@ pub fn parse_sequence(seq: &str) -> Result<SeqObj, SequenceError> {
     }
 }
 
+const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
+
+/// Write `val` as a zero-padded lowercase hex string of exactly `width` nibbles
+/// into `buf`. `buf.len()` must equal `width`.
+fn write_hex_u64(buf: &mut [u8], val: u64, width: usize) {
+    debug_assert_eq!(buf.len(), width);
+    for i in 0..width {
+        buf[i] = HEX_CHARS[((val >> ((width - 1 - i) * 4)) & 0xF) as usize];
+    }
+}
+
+/// Write `val` as a zero-padded lowercase hex string of exactly `width` nibbles.
+fn write_hex_u32(buf: &mut [u8], val: u32, width: usize) {
+    debug_assert_eq!(buf.len(), width);
+    for i in 0..width {
+        buf[i] = HEX_CHARS[((val >> ((width - 1 - i) * 4)) & 0xF) as usize];
+    }
+}
+
+/// Copy exactly `width` ASCII hex bytes from `src` into `buf`, right-aligned
+/// and zero-padded if `src` is shorter.
+fn write_hex_str(buf: &mut [u8], src: &str, width: usize) {
+    debug_assert_eq!(buf.len(), width);
+    let src_bytes = src.as_bytes();
+    let src_len = src_bytes.len().min(width);
+    let pad = width - src_len;
+    buf[..pad].fill(b'0');
+    buf[pad..].copy_from_slice(&src_bytes[src_bytes.len() - src_len..]);
+}
+
 /// Serialize a [`SeqObj`] back into its decimal sequence number string.
 pub fn stringify_sequence(obj: &SeqObj) -> String {
     match obj.version {
         0 | 2 if obj.version == 0 => {
-            let shard_create_hex = format!("{:09x}", obj.shard_create_time / 1000)
-                .chars()
-                .rev()
-                .take(9)
-                .collect::<String>()
-                .chars()
-                .rev()
-                .collect::<String>();
-            let byte1 = obj.byte1.as_deref().unwrap_or("00");
-            let seq_rand = obj.seq_rand.as_deref().unwrap_or("0000000000000000");
-            let shard_ix_hex = format!("{:08x}", obj.shard_ix as u32);
-            let shard_ix_short = &shard_ix_hex[shard_ix_hex.len() - 4..];
+            // v0 hex layout: "1" + shard_create(9) + byte1(2) + seq_rand(16) + shard_ix(4) = 32
+            let mut buf = [b'0'; 32];
+            buf[0] = b'1';
+            write_hex_u64(&mut buf[1..10], obj.shard_create_time / 1000, 9);
+            write_hex_str(&mut buf[10..12], obj.byte1.as_deref().unwrap_or("00"), 2);
+            write_hex_str(
+                &mut buf[12..28],
+                obj.seq_rand.as_deref().unwrap_or("0000000000000000"),
+                16,
+            );
+            write_hex_u32(&mut buf[28..32], obj.shard_ix as u32, 4);
 
-            let hex_str = format!("1{shard_create_hex}{byte1}{seq_rand}{shard_ix_short}");
-            BigUint::from_str_radix(&hex_str, 16)
+            let hex_str = core::str::from_utf8(&buf).unwrap();
+            BigUint::from_str_radix(hex_str, 16)
                 .unwrap_or_else(|_| BigUint::zero())
                 .to_string()
         }
         1 => {
-            let shard_create_hex = format!("{:09x}", obj.shard_create_time / 1000);
-            let shard_create_hex = &shard_create_hex[shard_create_hex.len().saturating_sub(9)..];
-            let shard_ix_last = format!("{:x}", obj.shard_ix as u32);
-            let shard_ix_last = &shard_ix_last[shard_ix_last.len() - 1..];
-            let byte1 = obj.byte1.as_deref().unwrap_or("00");
-            let seq_time_hex = format!(
-                "{:09x}",
-                obj.seq_time.unwrap_or(obj.shard_create_time) / 1000
+            // v1 hex layout: "2" + shard_create(9) + shard_ix_last(1) + byte1(2) + seq_time(9)
+            //                + seq_rand(14) + seq_ix(2) + shard_ix(8) + "1" = 47
+            let mut buf = [b'0'; 47];
+            buf[0] = b'2';
+            write_hex_u64(&mut buf[1..10], obj.shard_create_time / 1000, 9);
+            buf[10] = HEX_CHARS[((obj.shard_ix as u32) & 0xF) as usize];
+            write_hex_str(&mut buf[11..13], obj.byte1.as_deref().unwrap_or("00"), 2);
+            write_hex_u64(
+                &mut buf[13..22],
+                obj.seq_time.unwrap_or(obj.shard_create_time) / 1000,
+                9,
             );
-            let seq_time_hex = &seq_time_hex[seq_time_hex.len().saturating_sub(9)..];
-            let seq_rand = obj.seq_rand.as_deref().unwrap_or("00000000000000");
-            let seq_ix = obj.seq_ix.as_ref().and_then(|v| v.to_u64()).unwrap_or(0);
-            let seq_ix_hex = format!("{seq_ix:02x}");
-            let seq_ix_hex = &seq_ix_hex[seq_ix_hex.len().saturating_sub(2)..];
+            write_hex_str(
+                &mut buf[22..36],
+                obj.seq_rand.as_deref().unwrap_or("00000000000000"),
+                14,
+            );
+            write_hex_u64(&mut buf[36..38], obj.seq_ix.unwrap_or(0), 2);
+            write_hex_u32(&mut buf[38..46], obj.shard_ix as u32, 8);
+            buf[46] = b'1';
 
-            let hex_str = format!(
-                "2{shard_create_hex}{shard_ix_last}{byte1}{seq_time_hex}{seq_rand}{seq_ix_hex}{}1",
-                shard_ix_to_hex(obj.shard_ix)
-            );
-            BigUint::from_str_radix(&hex_str, 16)
+            let hex_str = core::str::from_utf8(&buf).unwrap();
+            BigUint::from_str_radix(hex_str, 16)
                 .unwrap_or_else(|_| BigUint::zero())
                 .to_string()
         }
         _ => {
-            // Version 2 (default)
-            let shard_create_hex = format!("{:09x}", obj.shard_create_time / 1000);
-            let shard_create_hex = &shard_create_hex[shard_create_hex.len().saturating_sub(9)..];
-            let shard_ix_last = format!("{:x}", obj.shard_ix as u32);
-            let shard_ix_last = &shard_ix_last[shard_ix_last.len() - 1..];
-
-            let seq_ix = obj
-                .seq_ix
-                .as_ref()
-                .map(|v| format!("{v:x}"))
-                .unwrap_or_else(|| "0".to_string());
-            let seq_ix_padded = format!("{seq_ix:0>16}");
-            let seq_ix_hex = &seq_ix_padded[seq_ix_padded.len().saturating_sub(16)..];
-
-            let byte1 = obj.byte1.as_deref().unwrap_or("00");
-
-            let seq_time_hex = format!(
-                "{:09x}",
-                obj.seq_time.unwrap_or(obj.shard_create_time) / 1000
+            // v2 hex layout (default): "2" + shard_create(9) + shard_ix_last(1) + seq_ix(16)
+            //                          + byte1(2) + seq_time(9) + shard_ix(8) + "2" = 47
+            let mut buf = [b'0'; 47];
+            buf[0] = b'2';
+            write_hex_u64(&mut buf[1..10], obj.shard_create_time / 1000, 9);
+            buf[10] = HEX_CHARS[((obj.shard_ix as u32) & 0xF) as usize];
+            write_hex_u64(&mut buf[11..27], obj.seq_ix.unwrap_or(0), 16);
+            write_hex_str(&mut buf[27..29], obj.byte1.as_deref().unwrap_or("00"), 2);
+            write_hex_u64(
+                &mut buf[29..38],
+                obj.seq_time.unwrap_or(obj.shard_create_time) / 1000,
+                9,
             );
-            let seq_time_hex = &seq_time_hex[seq_time_hex.len().saturating_sub(9)..];
+            write_hex_u32(&mut buf[38..46], obj.shard_ix as u32, 8);
+            buf[46] = b'2';
 
-            let hex_str = format!(
-                "2{shard_create_hex}{shard_ix_last}{seq_ix_hex}{byte1}{seq_time_hex}{}2",
-                shard_ix_to_hex(obj.shard_ix)
-            );
-            BigUint::from_str_radix(&hex_str, 16)
+            let hex_str = core::str::from_utf8(&buf).unwrap();
+            BigUint::from_str_radix(hex_str, 16)
                 .unwrap_or_else(|_| BigUint::zero())
                 .to_string()
         }
@@ -265,7 +291,7 @@ pub fn stringify_sequence(obj: &SeqObj) -> String {
 pub fn increment_sequence(seq_obj: &SeqObj, seq_time: Option<u64>) -> String {
     stringify_sequence(&SeqObj {
         shard_create_time: seq_obj.shard_create_time,
-        seq_ix: seq_obj.seq_ix.clone(),
+        seq_ix: seq_obj.seq_ix,
         byte1: None,
         seq_time: Some(seq_time.unwrap_or_else(|| seq_obj.seq_time.unwrap_or(0) + 1000)),
         seq_rand: None,
@@ -305,15 +331,15 @@ pub fn resolve_shard_id(shard_id: &str) -> Result<(String, i64), SequenceError> 
     Ok((shard_id_name(shard_ix), shard_ix))
 }
 
-/// MD5-hash a partition key and return the result as a 128-bit [`BigUint`].
+/// MD5-hash a partition key and return the result as a 128-bit integer.
 ///
 /// Kinesis uses this hash to determine which shard a record belongs to.
-pub fn partition_key_to_hash_key(partition_key: &str) -> BigUint {
+pub fn partition_key_to_hash_key(partition_key: &str) -> u128 {
     use md5::{Digest, Md5};
     let mut hasher = Md5::new();
     hasher.update(partition_key.as_bytes());
     let result = hasher.finalize();
-    BigUint::from_bytes_be(&result)
+    u128::from_be_bytes(result.into())
 }
 
 #[cfg(test)]
@@ -349,7 +375,7 @@ mod tests {
     fn test_stringify_parse_roundtrip() {
         let obj = SeqObj {
             shard_create_time: 1_600_000_000_000,
-            seq_ix: Some(BigUint::from(42u64)),
+            seq_ix: Some(42),
             byte1: Some("00".to_string()),
             seq_time: Some(1_600_000_001_000),
             seq_rand: None,
@@ -367,6 +393,6 @@ mod tests {
     fn test_partition_key_to_hash_key() {
         // MD5 of "a" is 0cc175b9c0f1b6a831c399e269772661
         let hash = partition_key_to_hash_key("a");
-        assert!(hash > BigUint::zero());
+        assert!(hash > 0);
     }
 }

--- a/crates/ferrokinesis-core/src/types.rs
+++ b/crates/ferrokinesis-core/src/types.rs
@@ -430,8 +430,10 @@ pub struct HashKeyRange {
     pub starting_hash_key: String,
     /// Inclusive upper bound of the hash key range (decimal string).
     pub ending_hash_key: String,
+    #[cfg(feature = "std")]
     #[serde(skip)]
     start_cached: std::sync::OnceLock<u128>,
+    #[cfg(feature = "std")]
     #[serde(skip)]
     end_cached: std::sync::OnceLock<u128>,
 }
@@ -442,23 +444,45 @@ impl HashKeyRange {
         Self {
             starting_hash_key,
             ending_hash_key,
+            #[cfg(feature = "std")]
             start_cached: std::sync::OnceLock::new(),
+            #[cfg(feature = "std")]
             end_cached: std::sync::OnceLock::new(),
         }
     }
 
     /// Returns the starting hash key as a `u128`, parsing and caching on first call.
+    ///
+    /// With the `std` feature the result is cached in a `OnceLock`; without it
+    /// the decimal string is parsed on every call (acceptable for `no_std` builds
+    /// where this crate is used outside of the hot server path).
+    #[cfg(feature = "std")]
     pub fn start_u128(&self) -> u128 {
         *self
             .start_cached
             .get_or_init(|| self.starting_hash_key.parse().unwrap_or(0))
     }
 
+    #[cfg(not(feature = "std"))]
+    pub fn start_u128(&self) -> u128 {
+        self.starting_hash_key.parse().unwrap_or(0)
+    }
+
     /// Returns the ending hash key as a `u128`, parsing and caching on first call.
+    ///
+    /// With the `std` feature the result is cached in a `OnceLock`; without it
+    /// the decimal string is parsed on every call (acceptable for `no_std` builds
+    /// where this crate is used outside of the hot server path).
+    #[cfg(feature = "std")]
     pub fn end_u128(&self) -> u128 {
         *self
             .end_cached
             .get_or_init(|| self.ending_hash_key.parse().unwrap_or(0))
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn end_u128(&self) -> u128 {
+        self.ending_hash_key.parse().unwrap_or(0)
     }
 }
 

--- a/crates/ferrokinesis-core/src/types.rs
+++ b/crates/ferrokinesis-core/src/types.rs
@@ -421,6 +421,8 @@ pub struct Shard {
 /// Inclusive range of MD5 hash keys covered by a shard.
 ///
 /// The full key space (`0` to `2^128 - 1`) is divided among the shards in a stream.
+/// Parsed `u128` values are lazily cached on first access to avoid repeated
+/// string-to-integer conversion on the hot write path.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct HashKeyRange {
@@ -428,6 +430,36 @@ pub struct HashKeyRange {
     pub starting_hash_key: String,
     /// Inclusive upper bound of the hash key range (decimal string).
     pub ending_hash_key: String,
+    #[serde(skip)]
+    start_cached: std::sync::OnceLock<u128>,
+    #[serde(skip)]
+    end_cached: std::sync::OnceLock<u128>,
+}
+
+impl HashKeyRange {
+    /// Creates a new hash key range from decimal string bounds.
+    pub fn new(starting_hash_key: String, ending_hash_key: String) -> Self {
+        Self {
+            starting_hash_key,
+            ending_hash_key,
+            start_cached: std::sync::OnceLock::new(),
+            end_cached: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Returns the starting hash key as a `u128`, parsing and caching on first call.
+    pub fn start_u128(&self) -> u128 {
+        *self
+            .start_cached
+            .get_or_init(|| self.starting_hash_key.parse().unwrap_or(0))
+    }
+
+    /// Returns the ending hash key as a `u128`, parsing and caching on first call.
+    pub fn end_u128(&self) -> u128 {
+        *self
+            .end_cached
+            .get_or_init(|| self.ending_hash_key.parse().unwrap_or(0))
+    }
 }
 
 /// The range of sequence numbers assigned to a shard.

--- a/src/actions/create_stream.rs
+++ b/src/actions/create_stream.rs
@@ -62,10 +62,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
 
         shards.push(Shard {
             shard_id: sequence::shard_id_name(i as i64),
-            hash_key_range: HashKeyRange {
-                starting_hash_key: start.to_string(),
-                ending_hash_key: end.to_string(),
-            },
+            hash_key_range: HashKeyRange::new(start.to_string(), end.to_string()),
             sequence_number_range: SequenceNumberRange {
                 starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
                     shard_create_time: create_time,

--- a/src/actions/get_shard_iterator.rs
+++ b/src/actions/get_shard_iterator.rs
@@ -5,7 +5,6 @@ use crate::shard_iterator;
 use crate::store::Store;
 use crate::types::ShardIteratorType;
 use crate::util::current_time_ms;
-use num_bigint::BigUint;
 use serde_json::{Value, json};
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -145,7 +144,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 let seq_ix = store.current_shard_seq(stream_name, shard_ix).await;
                 iterator_seq = sequence::stringify_sequence(&sequence::SeqObj {
                     shard_create_time: shard_seq_obj.shard_create_time,
-                    seq_ix: Some(BigUint::from(seq_ix)),
+                    seq_ix: Some(seq_ix),
                     seq_time: Some(now),
                     shard_ix: shard_seq_obj.shard_ix,
                     byte1: None,

--- a/src/actions/merge_shards.rs
+++ b/src/actions/merge_shards.rs
@@ -4,8 +4,6 @@ use crate::sequence;
 use crate::store::Store;
 use crate::types::*;
 use crate::util::current_time_ms;
-use num_bigint::BigUint;
-use num_traits::{Num, One, Zero};
 use serde_json::Value;
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -57,21 +55,18 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 }
             }
 
-            let end0: BigUint = stream.shards[shard_ixs[0] as usize]
+            let end0 = stream.shards[shard_ixs[0] as usize]
                 .hash_key_range
-                .ending_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
-            let start1: BigUint = stream.shards[shard_ixs[1] as usize]
+                .end_u128();
+            let start1 = stream.shards[shard_ixs[1] as usize]
                 .hash_key_range
-                .starting_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
+                .start_u128();
 
             // Kinesis requires the two shards to be adjacent — their hash ranges must
-            // be contiguous with no gap. BigUint is necessary here because the MD5 hash
-            // space spans [0, 2^128-1] and the boundary values can equal 2^128-1.
-            if end0 + BigUint::one() != start1 {
+            // be contiguous with no gap. `checked_add` handles the theoretical edge case
+            // where end0 == u128::MAX (impossible in practice since there'd be no room
+            // for another shard, but safe by construction).
+            if end0.checked_add(1) != Some(start1) {
                 return Err(KinesisErrorResponse::client_error(
                     constants::INVALID_ARGUMENT,
                     Some(&format!(
@@ -102,13 +97,6 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 let now = current_time_ms();
                 stream.stream_status = StreamStatus::Active;
 
-                // Use the maximum possible seq_ix (0x7fffffffffffffff) for the closing
-                // sequence number. This ensures no future record written to this shard
-                // could ever produce a sequence number that compares as ≥ the ending
-                // sequence, making the shard-closed invariant unconditionally safe.
-                let max_seq_ix = BigUint::from_str_radix("7fffffffffffffff", 16)
-                    .unwrap_or_else(|_| BigUint::zero());
-
                 for &ix in &shard_ixs_clone {
                     let shard = &mut stream.shards[ix as usize];
                     let create_time = sequence::parse_sequence(
@@ -121,7 +109,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                         Some(sequence::stringify_sequence(&sequence::SeqObj {
                             shard_create_time: create_time,
                             shard_ix: ix,
-                            seq_ix: Some(max_seq_ix.clone()),
+                            seq_ix: Some(sequence::MAX_SEQ_IX),
                             seq_time: Some(now),
                             byte1: None,
                             seq_rand: None,
@@ -142,10 +130,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 stream.shards.push(Shard {
                     parent_shard_id: Some(shard_ids_clone[0].clone()),
                     adjacent_parent_shard_id: Some(shard_ids_clone[1].clone()),
-                    hash_key_range: HashKeyRange {
-                        starting_hash_key: starting_hash,
-                        ending_hash_key: ending_hash,
-                    },
+                    hash_key_range: HashKeyRange::new(starting_hash, ending_hash),
                     sequence_number_range: SequenceNumberRange {
                         starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
                             // Child's create_time is 1 second ahead of the parent's closing

--- a/src/actions/put_record.rs
+++ b/src/actions/put_record.rs
@@ -5,8 +5,6 @@ use crate::sequence;
 use crate::store::Store;
 use crate::types::StoredRecordRef;
 use crate::util::current_time_ms;
-use num_bigint::BigUint;
-use num_traits::{One, Zero};
 use serde_json::{Value, json};
 use std::borrow::Cow;
 
@@ -18,18 +16,15 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     let explicit_hash_key = data[constants::EXPLICIT_HASH_KEY].as_str();
     let seq_for_ordering = data[constants::SEQUENCE_NUMBER_FOR_ORDERING].as_str();
 
-    let hash_key = if let Some(ehk) = explicit_hash_key {
-        let hk: BigUint = ehk.parse().unwrap_or_else(|_| BigUint::zero());
-        let pow_128 = BigUint::one() << 128;
-        if hk >= pow_128 {
-            return Err(KinesisErrorResponse::client_error(
+    let hash_key: u128 = if let Some(ehk) = explicit_hash_key {
+        ehk.parse::<u128>().map_err(|_| {
+            KinesisErrorResponse::client_error(
                 constants::INVALID_ARGUMENT,
                 Some(&format!(
                     "Invalid ExplicitHashKey. ExplicitHashKey must be in the range: [0, 2^128-1]. Specified value was {ehk}"
                 )),
-            ));
-        }
-        hk
+            )
+        })?
     } else {
         sequence::partition_key_to_hash_key(partition_key)
     };

--- a/src/actions/put_records.rs
+++ b/src/actions/put_records.rs
@@ -4,8 +4,6 @@ use crate::error::KinesisErrorResponse;
 use crate::sequence;
 use crate::store::Store;
 use crate::types::StoredRecordRef;
-use num_bigint::BigUint;
-use num_traits::{One, Zero};
 use serde_json::{Value, json};
 use std::borrow::Cow;
 
@@ -74,24 +72,21 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     }
 
     // Pre-compute hash keys (no stream access needed)
-    let pow_128 = BigUint::one() << 128;
-    let mut hash_keys = Vec::with_capacity(records.len());
+    let mut hash_keys: Vec<u128> = Vec::with_capacity(records.len());
 
     for record in records {
         let partition_key = record["PartitionKey"].as_str().unwrap_or("");
         let explicit_hash_key = record["ExplicitHashKey"].as_str();
 
-        let hash_key = if let Some(ehk) = explicit_hash_key {
-            let hk: BigUint = ehk.parse().unwrap_or_else(|_| BigUint::zero());
-            if hk >= pow_128 {
-                return Err(KinesisErrorResponse::client_error(
+        let hash_key: u128 = if let Some(ehk) = explicit_hash_key {
+            ehk.parse::<u128>().map_err(|_| {
+                KinesisErrorResponse::client_error(
                     constants::INVALID_ARGUMENT,
                     Some(&format!(
                         "Invalid ExplicitHashKey. ExplicitHashKey must be in the range: [0, 2^128-1]. Specified value was {ehk}"
                     )),
-                ));
-            }
-            hk
+                )
+            })?
         } else {
             sequence::partition_key_to_hash_key(partition_key)
         };

--- a/src/actions/split_shard.rs
+++ b/src/actions/split_shard.rs
@@ -4,8 +4,6 @@ use crate::sequence;
 use crate::store::Store;
 use crate::types::*;
 use crate::util::current_time_ms;
-use num_bigint::BigUint;
-use num_traits::{Num, One, Zero};
 use serde_json::Value;
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -65,26 +63,16 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 ));
             }
 
-            let hash_key: BigUint = new_starting_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
+            let hash_key: u128 = new_starting_hash_key.parse().unwrap_or(0);
             let shard = &stream.shards[shard_ix as usize];
-            let shard_start: BigUint = shard
-                .hash_key_range
-                .starting_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
-            let shard_end: BigUint = shard
-                .hash_key_range
-                .ending_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
+            let shard_start = shard.hash_key_range.start_u128();
+            let shard_end = shard.hash_key_range.end_u128();
 
             // Strict interior constraint: the split key must be > start+1 AND < end.
             // Equal to start+1 would give the lower child an empty hash range [start, start];
             // equal to end would give the upper child an empty range [end, end]. Either
             // degenerate case would prevent any partition key from routing to that child.
-            if hash_key <= &shard_start + BigUint::one() || hash_key >= shard_end {
+            if hash_key <= shard_start + 1 || hash_key >= shard_end {
                 return Err(KinesisErrorResponse::client_error(
                     constants::INVALID_ARGUMENT,
                     Some(&format!(
@@ -116,12 +104,6 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 let now = current_time_ms();
                 stream.stream_status = StreamStatus::Active;
 
-                // Use the maximum possible seq_ix (0x7fffffffffffffff) for the closing
-                // sequence number so that no future record in this shard could produce a
-                // sequence number that compares as ≥ the ending sequence.
-                let max_seq_ix = BigUint::from_str_radix("7fffffffffffffff", 16)
-                    .unwrap_or_else(|_| BigUint::zero());
-
                 let shard = &mut stream.shards[shard_ix as usize];
                 let create_time =
                     sequence::parse_sequence(&shard.sequence_number_range.starting_sequence_number)
@@ -132,7 +114,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                     Some(sequence::stringify_sequence(&sequence::SeqObj {
                         shard_create_time: create_time,
                         shard_ix,
-                        seq_ix: Some(max_seq_ix),
+                        seq_ix: Some(sequence::MAX_SEQ_IX),
                         seq_time: Some(now),
                         byte1: None,
                         seq_rand: None,
@@ -143,10 +125,10 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 stream.shards.push(Shard {
                     parent_shard_id: Some(shard_id_clone.clone()),
                     adjacent_parent_shard_id: None,
-                    hash_key_range: HashKeyRange {
-                        starting_hash_key: shard_start.to_string(),
-                        ending_hash_key: (&hash_key - BigUint::one()).to_string(),
-                    },
+                    hash_key_range: HashKeyRange::new(
+                        shard_start.to_string(),
+                        (hash_key - 1).to_string(),
+                    ),
                     sequence_number_range: SequenceNumberRange {
                         starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
                             // Child's create_time is 1 second ahead of the parent's closing
@@ -170,10 +152,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 stream.shards.push(Shard {
                     parent_shard_id: Some(shard_id_clone.clone()),
                     adjacent_parent_shard_id: None,
-                    hash_key_range: HashKeyRange {
-                        starting_hash_key: hash_key.to_string(),
-                        ending_hash_key: shard_end.to_string(),
-                    },
+                    hash_key_range: HashKeyRange::new(hash_key.to_string(), shard_end.to_string()),
                     sequence_number_range: SequenceNumberRange {
                         starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
                             shard_create_time: now + 1000,

--- a/src/actions/subscribe_to_shard.rs
+++ b/src/actions/subscribe_to_shard.rs
@@ -7,7 +7,6 @@ use crate::types::{EpochSeconds, ResponseRecord, ShardIteratorType, StreamStatus
 use crate::util::current_time_ms;
 use axum::body::Body;
 use bytes::Bytes;
-use num_bigint::BigUint;
 use serde_json::{Value, json};
 
 /// Maximum subscription duration (5 minutes)
@@ -135,7 +134,7 @@ pub async fn execute_streaming(
             let seq_ix = store.current_shard_seq(&stream_name, shard_ix).await;
             sequence::stringify_sequence(&sequence::SeqObj {
                 shard_create_time: shard_seq_obj.shard_create_time,
-                seq_ix: Some(BigUint::from(seq_ix)),
+                seq_ix: Some(seq_ix),
                 seq_time: Some(now),
                 shard_ix: shard_seq_obj.shard_ix,
                 byte1: None,

--- a/src/actions/update_shard_count.rs
+++ b/src/actions/update_shard_count.rs
@@ -5,7 +5,7 @@ use crate::store::Store;
 use crate::types::*;
 use crate::util::current_time_ms;
 use num_bigint::BigUint;
-use num_traits::{Num, One, Zero};
+use num_traits::One;
 use serde_json::{Value, json};
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -55,12 +55,10 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         let _ = store_clone
             .update_stream(&stream_name_owned, |stream| {
                 let now = current_time_ms();
-                // Use the maximum possible seq_ix (0x7fffffffffffffff) for the closing
-                // sequence number. This ensures no future record written to this shard
-                // could ever produce a sequence number that compares as ≥ the ending
-                // sequence, making the shard-closed invariant unconditionally safe.
-                let max_seq_ix = BigUint::from_str_radix("7fffffffffffffff", 16)
-                    .unwrap_or_else(|_| BigUint::zero());
+                // Use the maximum possible seq_ix for the closing sequence number.
+                // This ensures no future record written to this shard could ever
+                // produce a sequence number that compares as ≥ the ending sequence,
+                // making the shard-closed invariant unconditionally safe.
 
                 // Close all current open shards
                 let open_indices: Vec<usize> = stream
@@ -86,7 +84,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                         Some(sequence::stringify_sequence(&sequence::SeqObj {
                             shard_create_time: create_time,
                             shard_ix: ix as i64,
-                            seq_ix: Some(max_seq_ix.clone()),
+                            seq_ix: Some(sequence::MAX_SEQ_IX),
                             seq_time: Some(now),
                             byte1: None,
                             seq_rand: None,
@@ -113,10 +111,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                         // no parent lineage relationship with the old shards.
                         parent_shard_id: None,
                         adjacent_parent_shard_id: None,
-                        hash_key_range: HashKeyRange {
-                            starting_hash_key: start.to_string(),
-                            ending_hash_key: end.to_string(),
-                        },
+                        hash_key_range: HashKeyRange::new(start.to_string(), end.to_string()),
                         sequence_number_range: SequenceNumberRange {
                             starting_sequence_number: sequence::stringify_sequence(
                                 &sequence::SeqObj {

--- a/src/store.rs
+++ b/src/store.rs
@@ -21,8 +21,6 @@ use crate::sequence;
 use crate::types::{Consumer, StoredRecord, Stream, StreamStatus};
 use crate::util::current_time_ms;
 use dashmap::DashMap;
-use num_bigint::BigUint;
-use num_traits::Zero;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -708,7 +706,7 @@ impl Store {
     pub async fn allocate_sequence(
         &self,
         name: &str,
-        hash_key: &BigUint,
+        hash_key: &u128,
     ) -> Result<SequenceAllocation, KinesisErrorResponse> {
         let entry = self
             .inner
@@ -743,7 +741,7 @@ impl Store {
 
         let seq_num = sequence::stringify_sequence(&sequence::SeqObj {
             shard_create_time,
-            seq_ix: Some(BigUint::from(current_seq_ix)),
+            seq_ix: Some(current_seq_ix),
             byte1: None,
             seq_time: Some(now),
             seq_rand: None,
@@ -767,7 +765,7 @@ impl Store {
     pub async fn allocate_sequences_batch(
         &self,
         name: &str,
-        hash_keys: &[BigUint],
+        hash_keys: &[u128],
     ) -> Result<Vec<SequenceAllocation>, KinesisErrorResponse> {
         let entry = self
             .inner
@@ -800,7 +798,7 @@ impl Store {
 
             let seq_num = sequence::stringify_sequence(&sequence::SeqObj {
                 shard_create_time,
-                seq_ix: Some(BigUint::from(current_seq_ix)),
+                seq_ix: Some(current_seq_ix),
                 byte1: None,
                 seq_time: Some(now),
                 seq_rand: None,
@@ -865,19 +863,11 @@ async fn sync_shard_seq(entry: &StreamEntry, stream: &Stream) {
 }
 
 /// Route a hash key to the appropriate open shard. Returns `(shard_ix, shard_id, create_time_ms)`.
-fn route_hash_to_shard(stream: &Stream, hash_key: &BigUint) -> (i64, String, u64) {
+fn route_hash_to_shard(stream: &Stream, hash_key: &u128) -> (i64, String, u64) {
     for (i, shard) in stream.shards.iter().enumerate() {
         if shard.sequence_number_range.ending_sequence_number.is_none() {
-            let start: BigUint = shard
-                .hash_key_range
-                .starting_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
-            let end: BigUint = shard
-                .hash_key_range
-                .ending_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
+            let start = shard.hash_key_range.start_u128();
+            let end = shard.hash_key_range.end_u128();
             if *hash_key >= start && *hash_key <= end {
                 let create_time =
                     sequence::parse_sequence(&shard.sequence_number_range.starting_sequence_number)

--- a/tests/get_shard_iterator.rs
+++ b/tests/get_shard_iterator.rs
@@ -2,7 +2,6 @@ mod common;
 
 use common::*;
 use ferrokinesis::sequence::{SeqObj, stringify_sequence};
-use num_bigint::BigUint;
 use serde_json::{Value, json};
 
 #[tokio::test]
@@ -336,7 +335,7 @@ async fn get_shard_iterator_at_seq_version_mismatch() {
 
     let fake_seq = stringify_sequence(&SeqObj {
         shard_create_time: 1000,
-        seq_ix: Some(BigUint::from(0u32)),
+        seq_ix: Some(0),
         byte1: None,
         seq_time: Some(1000),
         seq_rand: None,

--- a/tests/prop_hash_space_coverage.rs
+++ b/tests/prop_hash_space_coverage.rs
@@ -75,8 +75,6 @@ fn prop_hash_space_fully_partitioned() {
 /// P2: MD5 hash of any partition key is within [0, 2^128).
 #[test]
 fn prop_md5_hash_in_range() {
-    let pow_128 = BigUint::one() << 128;
-
     let mut runner = TestRunner::new(Config {
         cases: 256,
         ..Config::default()
@@ -85,12 +83,13 @@ fn prop_md5_hash_in_range() {
     runner
         .run(&"[\\PC]{1,256}", |pk| {
             let hash = partition_key_to_hash_key(&pk);
-            prop_assert!(
-                hash < pow_128,
-                "hash {} for partition key {:?} is >= 2^128",
-                hash,
-                pk
-            );
+            // u128 is always in [0, 2^128-1] by definition; verify determinism
+            let hash2 = partition_key_to_hash_key(&pk);
+            prop_assert_eq!(hash, hash2, "MD5 hash not deterministic for {:?}", pk);
+            // Non-empty keys should produce non-zero hashes (extremely unlikely to be 0)
+            if !pk.is_empty() {
+                prop_assert!(hash > 0, "non-empty key {:?} produced zero hash", pk);
+            }
             Ok(())
         })
         .unwrap();

--- a/tests/prop_sequence_roundtrip.rs
+++ b/tests/prop_sequence_roundtrip.rs
@@ -2,7 +2,6 @@
 // is cheap and provides strong coverage of the sequence number encoding space.
 
 use ferrokinesis::sequence::{SeqObj, parse_sequence, stringify_sequence};
-use num_bigint::BigUint;
 use proptest::prelude::*;
 mod common;
 use common::prop_runner;
@@ -34,7 +33,7 @@ fn prop_sequence_roundtrip_identity() {
 
             let obj = SeqObj {
                 shard_create_time,
-                seq_ix: Some(BigUint::from(seq_ix)),
+                seq_ix: Some(seq_ix),
                 byte1: None,
                 seq_time: Some(seq_time),
                 seq_rand: None,

--- a/tests/put_record.rs
+++ b/tests/put_record.rs
@@ -3,7 +3,6 @@ mod common;
 use common::*;
 use ferrokinesis::sequence::{SeqObj, stringify_sequence};
 use ferrokinesis::store::StoreOptions;
-use num_bigint::BigUint;
 use serde_json::{Value, json};
 
 #[tokio::test]
@@ -210,7 +209,7 @@ async fn put_record_seq_for_ordering_future_time() {
 
     let future_seq = stringify_sequence(&SeqObj {
         shard_create_time: 1_000_000_000,
-        seq_ix: Some(BigUint::from(0u32)),
+        seq_ix: Some(0),
         byte1: None,
         seq_time: Some(future_ms),
         seq_rand: None,

--- a/tests/retention_reaper.rs
+++ b/tests/retention_reaper.rs
@@ -6,7 +6,6 @@ use ferrokinesis::sequence;
 use ferrokinesis::store::StoreOptions;
 use ferrokinesis::types::StoredRecord;
 use ferrokinesis::util::current_time_ms;
-use num_bigint::BigUint;
 use serde_json::json;
 
 /// Insert a record with a fabricated sequence number at the given `seq_time`.
@@ -20,7 +19,7 @@ async fn insert_backdated_record(
 ) {
     let seq = sequence::stringify_sequence(&sequence::SeqObj {
         shard_create_time,
-        seq_ix: Some(BigUint::from(seq_ix)),
+        seq_ix: Some(seq_ix),
         seq_time: Some(seq_time),
         shard_ix,
         byte1: None,

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -2,7 +2,6 @@ use ferrokinesis::sequence::{
     SeqObj, increment_sequence, parse_sequence, resolve_shard_id, shard_id_name, shard_ix_to_hex,
     stringify_sequence,
 };
-use num_bigint::BigUint;
 
 // -- Version 0 stringify/parse roundtrip --
 
@@ -49,7 +48,7 @@ fn stringify_v0_non_zero_shard() {
 fn stringify_parse_v1_roundtrip() {
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(7u64)),
+        seq_ix: Some(7),
         byte1: Some("ab".to_string()),
         seq_time: Some(1_600_000_001_000),
         seq_rand: Some("00000000000000".to_string()), // 14 chars
@@ -69,7 +68,7 @@ fn stringify_parse_v1_roundtrip() {
 fn stringify_v1_with_shard_ix_5() {
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(42u64)),
+        seq_ix: Some(42),
         byte1: Some("00".to_string()),
         seq_time: Some(1_600_000_002_000),
         seq_rand: Some("11111111111111".to_string()),
@@ -88,7 +87,7 @@ fn stringify_v1_with_shard_ix_5() {
 fn increment_sequence_with_explicit_time() {
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(0u64)),
+        seq_ix: Some(0),
         byte1: Some("00".to_string()),
         seq_time: Some(1_600_000_001_000),
         seq_rand: None,
@@ -106,7 +105,7 @@ fn increment_sequence_with_explicit_time() {
 fn increment_sequence_without_explicit_time() {
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(0u64)),
+        seq_ix: Some(0),
         byte1: Some("00".to_string()),
         seq_time: Some(1_600_000_001_000),
         seq_rand: None,
@@ -125,7 +124,7 @@ fn increment_sequence_from_parsed() {
     // Get a real sequence from a v2 stringify/parse cycle, then increment it
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(100u64)),
+        seq_ix: Some(100),
         byte1: Some("00".to_string()),
         seq_time: Some(1_600_000_010_000),
         seq_rand: None,
@@ -221,12 +220,9 @@ fn parse_sequence_empty_string() {
 
 #[test]
 fn parse_v2_negative_shard_ix() {
-    use ferrokinesis::sequence::{SeqObj, parse_sequence, stringify_sequence};
-    use num_bigint::BigUint;
-
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(0u32)),
+        seq_ix: Some(0),
         byte1: Some("00".to_string()),
         seq_time: Some(1_600_000_001_000),
         seq_rand: None,


### PR DESCRIPTION
## Summary

Closes #187.

- Replace `BigUint` (heap-allocated) with `u128`/`u64` (stack-allocated) on the PutRecord/PutRecords hot path
- Add lazy `OnceCell<u128>` cache to `HashKeyRange`, eliminating per-record string→BigUint parsing in shard lookup loops
- Replace ~6 `format!()` intermediate `String` allocations in `stringify_sequence()` with direct stack-buffer hex writes
- Add `MAX_SEQ_IX` constant replacing repeated `BigUint::from_str_radix` calls for closing sequence numbers
- BigUint retained only where genuinely needed: sequence number parse/stringify (188-bit numbers) and hash space division in create_stream/update_shard_count (2^128 overflows u128)

16 files changed, 194 insertions(+), 217 deletions(-) — net code reduction while adding the OnceCell cache and stack-buffer helpers.

## Test plan

- [x] All 572+ tests pass (`cargo test`) including property-based roundtrip and ordering tests
- [x] Zero clippy warnings (`cargo clippy --all-targets -- -D warnings`)
- [x] Formatting clean (`cargo fmt --all -- --check`)
- [ ] Benchmark comparison (`cargo bench --bench kinesis_api`) for put_record/put_records/get_records