### PR TITLE
feat: Add WASM wrapper and runtime split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
           cargo build -p ferrokinesis-core --no-default-features --target wasm32-unknown-unknown
+      - name: Ferrokinesis (wasm32 library)
+        run: cargo check --target wasm32-unknown-unknown --no-default-features --features wasm
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+      - name: Ferrokinesis WASM wrapper
+        run: cargo check -p ferrokinesis-wasm --target wasm32-unknown-unknown
+      - name: WASM tests
+        run: wasm-pack test --node crates/ferrokinesis-wasm
       - name: Lint (TLS)
         run: cargo clippy --features tls -- -D warnings
       - name: Test (TLS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
           cargo build -p ferrokinesis-core --no-default-features --target wasm32-unknown-unknown
+      - name: Ferrokinesis (native no-default-features lib)
+        run: cargo test --no-default-features --lib
       - name: Ferrokinesis (wasm32 library)
         run: cargo check --target wasm32-unknown-unknown --no-default-features --features wasm
       - name: Install wasm-pack

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,7 +599,6 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
- "form_urlencoded",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -615,13 +614,11 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -640,7 +637,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -928,6 +924,16 @@ name = "compression-core"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "cookie"
@@ -1263,7 +1269,9 @@ dependencies = [
  "criterion",
  "dashmap",
  "ferrokinesis-core",
+ "getrandom 0.3.4",
  "goose",
+ "js-sys",
  "md-5",
  "num-bigint",
  "num-traits",
@@ -1285,6 +1293,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1301,6 +1310,23 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "ferrokinesis-wasm"
+version = "0.5.0"
+dependencies = [
+ "axum",
+ "console_error_panic_hook",
+ "ferrokinesis",
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tower",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -1501,9 +1527,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2105,6 +2133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,6 +2207,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2300,6 +2344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2402,16 +2447,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
 
 [[package]]
 name = "parking_lot_core"
@@ -2976,6 +3011,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,7 +3403,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",
@@ -3485,7 +3530,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3530,7 +3574,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3820,6 +3863,45 @@ checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
 
@@ -1320,6 +1321,7 @@ dependencies = [
  "console_error_panic_hook",
  "ferrokinesis",
  "js-sys",
+ "num-bigint",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/ferrokinesis-core"]
+members = [".", "crates/ferrokinesis-core", "crates/ferrokinesis-wasm"]
 
 [workspace.package]
 version = "0.5.0"
@@ -18,6 +18,7 @@ license.workspace = true
 [[bin]]
 name = "ferrokinesis"
 path = "src/main.rs"
+required-features = ["server"]
 
 [[bin]]
 name = "loadtest"
@@ -25,31 +26,70 @@ path = "src/bin/loadtest.rs"
 required-features = ["loadtest"]
 
 [features]
-default = ["access-log"]
+default = ["server", "access-log"]
+rt = [
+    "dep:async-stream",
+    "dep:aws-smithy-eventstream",
+    "dep:aws-smithy-types",
+    "tokio/rt",
+    "tokio/time",
+    "tokio/macros",
+]
+server = [
+    "rt",
+    "dep:clap",
+    "dep:toml",
+    "dep:tracing-subscriber",
+    "axum/http1",
+    "axum/tokio",
+    "tokio/fs",
+    "tokio/io-util",
+    "tokio/net",
+    "tokio/process",
+    "tokio/rt-multi-thread",
+    "tokio/signal",
+]
 access-log = ["dep:tower-http"]
-mirror = ["dep:backon", "dep:reqwest", "dep:aws-credential-types", "dep:aws-sigv4", "dep:aws-smithy-runtime-api", "dep:url"]
+wasm = [
+    "dep:getrandom",
+    "dep:js-sys",
+    "dep:wasm-bindgen-futures",
+    "getrandom/wasm_js",
+    "uuid/js",
+]
+mirror = [
+    "server",
+    "dep:backon",
+    "dep:reqwest",
+    "dep:aws-credential-types",
+    "dep:aws-sigv4",
+    "dep:aws-smithy-runtime-api",
+    "dep:url",
+]
 mirror-aws-config = ["mirror", "dep:aws-config"]
-loadtest = ["dep:goose"]
-replay = ["dep:reqwest"]
-tls = ["dep:axum-server", "dep:rcgen", "dep:rustls"]
+loadtest = ["rt", "dep:goose", "tokio/rt-multi-thread"]
+replay = ["server", "dep:reqwest"]
+tls = ["server", "dep:axum-server", "dep:rcgen", "dep:rustls"]
 
 [dependencies]
 ferrokinesis-core = { path = "crates/ferrokinesis-core", version = "0.5.0" }
-async-stream = "0.3"
+async-stream = { version = "0.3", optional = true }
 backon = { version = "1.6", default-features = false, features = ["tokio-sleep"], optional = true }
 aws-config = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "credentials-process"] }
 aws-credential-types = { version = "1", optional = true }
 aws-sigv4 = { version = "1", optional = true }
-aws-smithy-eventstream = "0.60"
+aws-smithy-eventstream = { version = "0.60", optional = true }
 aws-smithy-runtime-api = { version = "1", features = ["client"], optional = true }
-aws-smithy-types = "1.4"
-axum = "0.8"
+aws-smithy-types = { version = "1.4", optional = true }
+axum = { version = "0.8", default-features = false, features = ["json"] }
 axum-server = { version = "0.8", features = ["tls-rustls"], optional = true }
 base64 = "0.22"
 bytes = "1"
 ciborium = "0.2"
-clap = { version = "4", features = ["derive", "env"] }
+clap = { version = "4", features = ["derive", "env"], optional = true }
+getrandom = { version = "0.3", default-features = false, optional = true }
 goose = { version = "0.18", optional = true }
+js-sys = { version = "0.3", optional = true }
 md-5 = { version = "0.10", default-features = false }
 num-bigint = "0.4"
 num-traits = "0.2"
@@ -63,13 +103,14 @@ rustls = { version = "0.23", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0.18"
-tokio = { version = "1", features = ["full"] }
-toml = "0.8"
+tokio = { version = "1", default-features = false, features = ["sync"] }
+toml = { version = "0.8", optional = true }
 tower-http = { version = "0.6", features = ["trace"], optional = true }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "1", features = ["v4"] }
+wasm-bindgen-futures = { version = "0.4", optional = true }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ access-log = ["dep:tower-http"]
 wasm = [
     "dep:getrandom",
     "dep:js-sys",
+    "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures",
     "getrandom/wasm_js",
     "uuid/js",
@@ -100,6 +101,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "1", features = ["v4"] }
+wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,7 @@ required-features = ["loadtest"]
 
 [features]
 default = ["server", "access-log"]
-rt = [
-    "dep:async-stream",
-    "dep:aws-smithy-eventstream",
-    "dep:aws-smithy-types",
-    "tokio/rt",
-    "tokio/time",
-    "tokio/macros",
-]
+rt = []
 server = [
     "rt",
     "dep:clap",
@@ -73,14 +66,11 @@ tls = ["server", "dep:axum-server", "dep:rcgen", "dep:rustls"]
 
 [dependencies]
 ferrokinesis-core = { path = "crates/ferrokinesis-core", version = "0.5.0" }
-async-stream = { version = "0.3", optional = true }
 backon = { version = "1.6", default-features = false, features = ["tokio-sleep"], optional = true }
 aws-config = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "credentials-process"] }
 aws-credential-types = { version = "1", optional = true }
 aws-sigv4 = { version = "1", optional = true }
-aws-smithy-eventstream = { version = "0.60", optional = true }
 aws-smithy-runtime-api = { version = "1", features = ["client"], optional = true }
-aws-smithy-types = { version = "1.4", optional = true }
 axum = { version = "0.8", default-features = false, features = ["json"] }
 axum-server = { version = "0.8", features = ["tls-rustls"], optional = true }
 base64 = "0.22"
@@ -111,6 +101,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 url = { version = "2", optional = true }
 uuid = { version = "1", features = ["v4"] }
 wasm-bindgen-futures = { version = "0.4", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+async-stream = "0.3"
+aws-smithy-eventstream = "0.60"
+aws-smithy-types = "1.4"
+tokio = { version = "1", default-features = false, features = ["sync", "rt", "time", "macros"] }
 
 [profile.release]
 lto = true

--- a/crates/ferrokinesis-core/src/sequence.rs
+++ b/crates/ferrokinesis-core/src/sequence.rs
@@ -2,7 +2,14 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use num_bigint::BigUint;
-use num_traits::{Num, One, ToPrimitive, Zero};
+use num_traits::{Num, One, Zero};
+
+/// Maximum sequence sub-index value (`i64::MAX` as `u64`).
+///
+/// Used as the seq_ix when constructing closing sequence numbers for split/merge
+/// operations. This ensures no future record could produce a sequence number ≥
+/// the ending sequence, making the shard-closed invariant unconditionally safe.
+pub const MAX_SEQ_IX: u64 = 0x7FFF_FFFF_FFFF_FFFF;
 
 /// Errors from parsing or resolving sequence numbers and shard IDs.
 #[derive(Debug, thiserror::Error)]
@@ -32,7 +39,7 @@ pub enum SequenceError {
 #[derive(Debug, Clone)]
 pub struct SeqObj {
     pub shard_create_time: u64,
-    pub seq_ix: Option<BigUint>,
+    pub seq_ix: Option<u64>,
     pub byte1: Option<String>,
     pub seq_time: Option<u64>,
     pub seq_rand: Option<String>,
@@ -129,9 +136,7 @@ pub fn parse_sequence(seq: &str) -> Result<SeqObj, SequenceError> {
 
             Ok(SeqObj {
                 shard_create_time: shard_create_secs * 1000,
-                seq_ix: Some(
-                    BigUint::from_str_radix(seq_ix_hex, 16).unwrap_or_else(|_| BigUint::zero()),
-                ),
+                seq_ix: Some(u64::from_str_radix(seq_ix_hex, 16).unwrap_or(0)),
                 byte1: Some(hex[27..29].to_string()),
                 seq_time: Some(seq_time),
                 seq_rand: None,
@@ -147,9 +152,7 @@ pub fn parse_sequence(seq: &str) -> Result<SeqObj, SequenceError> {
 
             Ok(SeqObj {
                 shard_create_time: shard_create_secs * 1000,
-                seq_ix: Some(BigUint::from(
-                    u64::from_str_radix(&hex[36..38], 16).unwrap_or(0),
-                )),
+                seq_ix: Some(u64::from_str_radix(&hex[36..38], 16).unwrap_or(0)),
                 byte1: Some(hex[11..13].to_string()),
                 seq_time: Some(u64::from_str_radix(&hex[13..22], 16).unwrap_or(0) * 1000),
                 seq_rand: Some(hex[22..36].to_string()),
@@ -181,80 +184,103 @@ pub fn parse_sequence(seq: &str) -> Result<SeqObj, SequenceError> {
     }
 }
 
+const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
+
+/// Write `val` as a zero-padded lowercase hex string of exactly `width` nibbles
+/// into `buf`. `buf.len()` must equal `width`.
+fn write_hex_u64(buf: &mut [u8], val: u64, width: usize) {
+    debug_assert_eq!(buf.len(), width);
+    for i in 0..width {
+        buf[i] = HEX_CHARS[((val >> ((width - 1 - i) * 4)) & 0xF) as usize];
+    }
+}
+
+/// Write `val` as a zero-padded lowercase hex string of exactly `width` nibbles.
+fn write_hex_u32(buf: &mut [u8], val: u32, width: usize) {
+    debug_assert_eq!(buf.len(), width);
+    for i in 0..width {
+        buf[i] = HEX_CHARS[((val >> ((width - 1 - i) * 4)) & 0xF) as usize];
+    }
+}
+
+/// Copy exactly `width` ASCII hex bytes from `src` into `buf`, right-aligned
+/// and zero-padded if `src` is shorter.
+fn write_hex_str(buf: &mut [u8], src: &str, width: usize) {
+    debug_assert_eq!(buf.len(), width);
+    let src_bytes = src.as_bytes();
+    let src_len = src_bytes.len().min(width);
+    let pad = width - src_len;
+    buf[..pad].fill(b'0');
+    buf[pad..].copy_from_slice(&src_bytes[src_bytes.len() - src_len..]);
+}
+
 /// Serialize a [`SeqObj`] back into its decimal sequence number string.
 pub fn stringify_sequence(obj: &SeqObj) -> String {
     match obj.version {
         0 | 2 if obj.version == 0 => {
-            let shard_create_hex = format!("{:09x}", obj.shard_create_time / 1000)
-                .chars()
-                .rev()
-                .take(9)
-                .collect::<String>()
-                .chars()
-                .rev()
-                .collect::<String>();
-            let byte1 = obj.byte1.as_deref().unwrap_or("00");
-            let seq_rand = obj.seq_rand.as_deref().unwrap_or("0000000000000000");
-            let shard_ix_hex = format!("{:08x}", obj.shard_ix as u32);
-            let shard_ix_short = &shard_ix_hex[shard_ix_hex.len() - 4..];
+            // v0 hex layout: "1" + shard_create(9) + byte1(2) + seq_rand(16) + shard_ix(4) = 32
+            let mut buf = [b'0'; 32];
+            buf[0] = b'1';
+            write_hex_u64(&mut buf[1..10], obj.shard_create_time / 1000, 9);
+            write_hex_str(&mut buf[10..12], obj.byte1.as_deref().unwrap_or("00"), 2);
+            write_hex_str(
+                &mut buf[12..28],
+                obj.seq_rand.as_deref().unwrap_or("0000000000000000"),
+                16,
+            );
+            write_hex_u32(&mut buf[28..32], obj.shard_ix as u32, 4);
 
-            let hex_str = format!("1{shard_create_hex}{byte1}{seq_rand}{shard_ix_short}");
-            BigUint::from_str_radix(&hex_str, 16)
+            let hex_str = core::str::from_utf8(&buf).unwrap();
+            BigUint::from_str_radix(hex_str, 16)
                 .unwrap_or_else(|_| BigUint::zero())
                 .to_string()
         }
         1 => {
-            let shard_create_hex = format!("{:09x}", obj.shard_create_time / 1000);
-            let shard_create_hex = &shard_create_hex[shard_create_hex.len().saturating_sub(9)..];
-            let shard_ix_last = format!("{:x}", obj.shard_ix as u32);
-            let shard_ix_last = &shard_ix_last[shard_ix_last.len() - 1..];
-            let byte1 = obj.byte1.as_deref().unwrap_or("00");
-            let seq_time_hex = format!(
-                "{:09x}",
-                obj.seq_time.unwrap_or(obj.shard_create_time) / 1000
+            // v1 hex layout: "2" + shard_create(9) + shard_ix_last(1) + byte1(2) + seq_time(9)
+            //                + seq_rand(14) + seq_ix(2) + shard_ix(8) + "1" = 47
+            let mut buf = [b'0'; 47];
+            buf[0] = b'2';
+            write_hex_u64(&mut buf[1..10], obj.shard_create_time / 1000, 9);
+            buf[10] = HEX_CHARS[((obj.shard_ix as u32) & 0xF) as usize];
+            write_hex_str(&mut buf[11..13], obj.byte1.as_deref().unwrap_or("00"), 2);
+            write_hex_u64(
+                &mut buf[13..22],
+                obj.seq_time.unwrap_or(obj.shard_create_time) / 1000,
+                9,
             );
-            let seq_time_hex = &seq_time_hex[seq_time_hex.len().saturating_sub(9)..];
-            let seq_rand = obj.seq_rand.as_deref().unwrap_or("00000000000000");
-            let seq_ix = obj.seq_ix.as_ref().and_then(|v| v.to_u64()).unwrap_or(0);
-            let seq_ix_hex = format!("{seq_ix:02x}");
-            let seq_ix_hex = &seq_ix_hex[seq_ix_hex.len().saturating_sub(2)..];
+            write_hex_str(
+                &mut buf[22..36],
+                obj.seq_rand.as_deref().unwrap_or("00000000000000"),
+                14,
+            );
+            write_hex_u64(&mut buf[36..38], obj.seq_ix.unwrap_or(0), 2);
+            write_hex_u32(&mut buf[38..46], obj.shard_ix as u32, 8);
+            buf[46] = b'1';
 
-            let hex_str = format!(
-                "2{shard_create_hex}{shard_ix_last}{byte1}{seq_time_hex}{seq_rand}{seq_ix_hex}{}1",
-                shard_ix_to_hex(obj.shard_ix)
-            );
-            BigUint::from_str_radix(&hex_str, 16)
+            let hex_str = core::str::from_utf8(&buf).unwrap();
+            BigUint::from_str_radix(hex_str, 16)
                 .unwrap_or_else(|_| BigUint::zero())
                 .to_string()
         }
         _ => {
-            // Version 2 (default)
-            let shard_create_hex = format!("{:09x}", obj.shard_create_time / 1000);
-            let shard_create_hex = &shard_create_hex[shard_create_hex.len().saturating_sub(9)..];
-            let shard_ix_last = format!("{:x}", obj.shard_ix as u32);
-            let shard_ix_last = &shard_ix_last[shard_ix_last.len() - 1..];
-
-            let seq_ix = obj
-                .seq_ix
-                .as_ref()
-                .map(|v| format!("{v:x}"))
-                .unwrap_or_else(|| "0".to_string());
-            let seq_ix_padded = format!("{seq_ix:0>16}");
-            let seq_ix_hex = &seq_ix_padded[seq_ix_padded.len().saturating_sub(16)..];
-
-            let byte1 = obj.byte1.as_deref().unwrap_or("00");
-
-            let seq_time_hex = format!(
-                "{:09x}",
-                obj.seq_time.unwrap_or(obj.shard_create_time) / 1000
+            // v2 hex layout (default): "2" + shard_create(9) + shard_ix_last(1) + seq_ix(16)
+            //                          + byte1(2) + seq_time(9) + shard_ix(8) + "2" = 47
+            let mut buf = [b'0'; 47];
+            buf[0] = b'2';
+            write_hex_u64(&mut buf[1..10], obj.shard_create_time / 1000, 9);
+            buf[10] = HEX_CHARS[((obj.shard_ix as u32) & 0xF) as usize];
+            write_hex_u64(&mut buf[11..27], obj.seq_ix.unwrap_or(0), 16);
+            write_hex_str(&mut buf[27..29], obj.byte1.as_deref().unwrap_or("00"), 2);
+            write_hex_u64(
+                &mut buf[29..38],
+                obj.seq_time.unwrap_or(obj.shard_create_time) / 1000,
+                9,
             );
-            let seq_time_hex = &seq_time_hex[seq_time_hex.len().saturating_sub(9)..];
+            write_hex_u32(&mut buf[38..46], obj.shard_ix as u32, 8);
+            buf[46] = b'2';
 
-            let hex_str = format!(
-                "2{shard_create_hex}{shard_ix_last}{seq_ix_hex}{byte1}{seq_time_hex}{}2",
-                shard_ix_to_hex(obj.shard_ix)
-            );
-            BigUint::from_str_radix(&hex_str, 16)
+            let hex_str = core::str::from_utf8(&buf).unwrap();
+            BigUint::from_str_radix(hex_str, 16)
                 .unwrap_or_else(|_| BigUint::zero())
                 .to_string()
         }
@@ -265,7 +291,7 @@ pub fn stringify_sequence(obj: &SeqObj) -> String {
 pub fn increment_sequence(seq_obj: &SeqObj, seq_time: Option<u64>) -> String {
     stringify_sequence(&SeqObj {
         shard_create_time: seq_obj.shard_create_time,
-        seq_ix: seq_obj.seq_ix.clone(),
+        seq_ix: seq_obj.seq_ix,
         byte1: None,
         seq_time: Some(seq_time.unwrap_or_else(|| seq_obj.seq_time.unwrap_or(0) + 1000)),
         seq_rand: None,
@@ -305,15 +331,15 @@ pub fn resolve_shard_id(shard_id: &str) -> Result<(String, i64), SequenceError> 
     Ok((shard_id_name(shard_ix), shard_ix))
 }
 
-/// MD5-hash a partition key and return the result as a 128-bit [`BigUint`].
+/// MD5-hash a partition key and return the result as a 128-bit integer.
 ///
 /// Kinesis uses this hash to determine which shard a record belongs to.
-pub fn partition_key_to_hash_key(partition_key: &str) -> BigUint {
+pub fn partition_key_to_hash_key(partition_key: &str) -> u128 {
     use md5::{Digest, Md5};
     let mut hasher = Md5::new();
     hasher.update(partition_key.as_bytes());
     let result = hasher.finalize();
-    BigUint::from_bytes_be(&result)
+    u128::from_be_bytes(result.into())
 }
 
 #[cfg(test)]
@@ -349,7 +375,7 @@ mod tests {
     fn test_stringify_parse_roundtrip() {
         let obj = SeqObj {
             shard_create_time: 1_600_000_000_000,
-            seq_ix: Some(BigUint::from(42u64)),
+            seq_ix: Some(42),
             byte1: Some("00".to_string()),
             seq_time: Some(1_600_000_001_000),
             seq_rand: None,
@@ -367,6 +393,6 @@ mod tests {
     fn test_partition_key_to_hash_key() {
         // MD5 of "a" is 0cc175b9c0f1b6a831c399e269772661
         let hash = partition_key_to_hash_key("a");
-        assert!(hash > BigUint::zero());
+        assert!(hash > 0);
     }
 }

--- a/crates/ferrokinesis-core/src/types.rs
+++ b/crates/ferrokinesis-core/src/types.rs
@@ -421,6 +421,8 @@ pub struct Shard {
 /// Inclusive range of MD5 hash keys covered by a shard.
 ///
 /// The full key space (`0` to `2^128 - 1`) is divided among the shards in a stream.
+/// Parsed `u128` values are lazily cached on first access to avoid repeated
+/// string-to-integer conversion on the hot write path.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct HashKeyRange {
@@ -428,6 +430,60 @@ pub struct HashKeyRange {
     pub starting_hash_key: String,
     /// Inclusive upper bound of the hash key range (decimal string).
     pub ending_hash_key: String,
+    #[cfg(feature = "std")]
+    #[serde(skip)]
+    start_cached: std::sync::OnceLock<u128>,
+    #[cfg(feature = "std")]
+    #[serde(skip)]
+    end_cached: std::sync::OnceLock<u128>,
+}
+
+impl HashKeyRange {
+    /// Creates a new hash key range from decimal string bounds.
+    pub fn new(starting_hash_key: String, ending_hash_key: String) -> Self {
+        Self {
+            starting_hash_key,
+            ending_hash_key,
+            #[cfg(feature = "std")]
+            start_cached: std::sync::OnceLock::new(),
+            #[cfg(feature = "std")]
+            end_cached: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Returns the starting hash key as a `u128`, parsing and caching on first call.
+    ///
+    /// With the `std` feature the result is cached in a `OnceLock`; without it
+    /// the decimal string is parsed on every call (acceptable for `no_std` builds
+    /// where this crate is used outside of the hot server path).
+    #[cfg(feature = "std")]
+    pub fn start_u128(&self) -> u128 {
+        *self
+            .start_cached
+            .get_or_init(|| self.starting_hash_key.parse().unwrap_or(0))
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn start_u128(&self) -> u128 {
+        self.starting_hash_key.parse().unwrap_or(0)
+    }
+
+    /// Returns the ending hash key as a `u128`, parsing and caching on first call.
+    ///
+    /// With the `std` feature the result is cached in a `OnceLock`; without it
+    /// the decimal string is parsed on every call (acceptable for `no_std` builds
+    /// where this crate is used outside of the hot server path).
+    #[cfg(feature = "std")]
+    pub fn end_u128(&self) -> u128 {
+        *self
+            .end_cached
+            .get_or_init(|| self.ending_hash_key.parse().unwrap_or(0))
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn end_u128(&self) -> u128 {
+        self.ending_hash_key.parse().unwrap_or(0)
+    }
 }
 
 /// The range of sequence numbers assigned to a shard.

--- a/crates/ferrokinesis-wasm/Cargo.toml
+++ b/crates/ferrokinesis-wasm/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ferrokinesis-wasm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "WASM wrapper for the ferrokinesis in-process Kinesis emulator"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+axum = { version = "0.8", default-features = false }
+console_error_panic_hook = "0.1"
+ferrokinesis = { path = "../..", default-features = false, features = ["wasm"] }
+js-sys = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+tower = { version = "0.5", features = ["util"] }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+
+[dev-dependencies]
+js-sys = "0.3"
+serde_json = "1"
+wasm-bindgen-test = "0.3"

--- a/crates/ferrokinesis-wasm/Cargo.toml
+++ b/crates/ferrokinesis-wasm/Cargo.toml
@@ -22,5 +22,6 @@ wasm-bindgen-futures = "0.4"
 
 [dev-dependencies]
 js-sys = "0.3"
+num-bigint = "0.4"
 serde_json = "1"
 wasm-bindgen-test = "0.3"

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -77,8 +77,9 @@ impl Kinesis {
             .try_into()
             .map_err(|_| js_error("maxRequestBodyMb overflows usize"))?;
 
-        let (app, store) = ferrokinesis::create_app(store_options);
-        let app = app.layer(DefaultBodyLimit::max(max_bytes));
+        let store = Store::new(store_options);
+        let app =
+            ferrokinesis::create_router(store.clone()).layer(DefaultBodyLimit::max(max_bytes));
 
         Ok(Self { app, _store: store })
     }

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -78,6 +78,12 @@ impl Kinesis {
             .map_err(|_| js_error("maxRequestBodyMb overflows usize"))?;
 
         let store = Store::new(store_options);
+        if store.options.retention_check_interval_secs > 0 {
+            ferrokinesis::runtime::spawn_background(ferrokinesis::retention::run_reaper(
+                store.clone(),
+                store.options.retention_check_interval_secs,
+            ));
+        }
         let app =
             ferrokinesis::create_router(store.clone()).layer(DefaultBodyLimit::max(max_bytes));
 
@@ -139,4 +145,130 @@ fn parse_options(options: Option<JsValue>) -> Result<KinesisOptions, JsValue> {
 
 fn js_error(message: impl Into<String>) -> JsValue {
     JsValue::from_str(&message.into())
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use super::*;
+    use ferrokinesis::sequence;
+    use ferrokinesis::types::StoredRecord;
+    use num_bigint::BigUint;
+    use serde::Deserialize;
+    use serde_json::json;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[derive(Deserialize)]
+    struct Response {
+        status: u16,
+        body: String,
+    }
+
+    #[wasm_bindgen_test(async)]
+    async fn retention_reaper_runs_on_wasm() {
+        let kinesis = new_kinesis(json!({
+            "createStreamMs": 0,
+            "retentionCheckIntervalSecs": 0,
+        }));
+
+        let create = request(
+            &kinesis,
+            "Kinesis_20131202.CreateStream",
+            json!({
+                "StreamName": "retention-stream",
+                "ShardCount": 1,
+            }),
+        )
+        .await;
+        assert_eq!(create.status, 200);
+
+        wait_until_stream_active(&kinesis, "retention-stream").await;
+
+        let stream = kinesis._store.get_stream("retention-stream").await.unwrap();
+        let shard = stream.shards.first().unwrap();
+        let start_seq = &shard.sequence_number_range.starting_sequence_number;
+        let shard_create_time = sequence::parse_sequence(start_seq)
+            .unwrap()
+            .shard_create_time;
+        let old_time = ferrokinesis::util::current_time_ms() - 25 * 60 * 60 * 1000;
+        let seq_num = sequence::stringify_sequence(&sequence::SeqObj {
+            shard_create_time,
+            seq_ix: Some(BigUint::from(0u64)),
+            byte1: None,
+            seq_time: Some(old_time),
+            seq_rand: None,
+            shard_ix: 0,
+            version: 2,
+        });
+        let key = format!("{}/{}", sequence::shard_ix_to_hex(0), seq_num);
+        let record = StoredRecord {
+            partition_key: "pk-1".to_string(),
+            data: "aGVsbG8=".to_string(),
+            approximate_arrival_timestamp: (old_time / 1000) as f64,
+        };
+        kinesis
+            ._store
+            .put_record("retention-stream", &key, &record)
+            .await;
+
+        assert_eq!(
+            kinesis
+                ._store
+                .get_record_store("retention-stream")
+                .await
+                .len(),
+            1
+        );
+
+        ferrokinesis::runtime::spawn_background(ferrokinesis::retention::run_reaper(
+            kinesis._store.clone(),
+            1,
+        ));
+
+        for _ in 0..80 {
+            if kinesis
+                ._store
+                .get_record_store("retention-stream")
+                .await
+                .is_empty()
+            {
+                return;
+            }
+
+            ferrokinesis::runtime::sleep_ms(25).await;
+        }
+
+        panic!("retention reaper did not remove expired record");
+    }
+
+    fn new_kinesis(options: serde_json::Value) -> Kinesis {
+        let options = serde_wasm_bindgen::to_value(&options).unwrap();
+        Kinesis::new(Some(options)).unwrap()
+    }
+
+    async fn request(kinesis: &Kinesis, target: &str, body: serde_json::Value) -> Response {
+        let response = kinesis.request(target, &body.to_string()).await.unwrap();
+        serde_wasm_bindgen::from_value(response).unwrap()
+    }
+
+    async fn wait_until_stream_active(kinesis: &Kinesis, stream_name: &str) {
+        for _ in 0..40 {
+            let response = request(
+                kinesis,
+                "Kinesis_20131202.DescribeStream",
+                json!({ "StreamName": stream_name }),
+            )
+            .await;
+
+            if response.status == 200 {
+                let body: serde_json::Value = serde_json::from_str(&response.body).unwrap();
+                if body["StreamDescription"]["StreamStatus"].as_str() == Some("ACTIVE") {
+                    return;
+                }
+            }
+
+            ferrokinesis::runtime::sleep_ms(25).await;
+        }
+
+        panic!("stream did not become ACTIVE");
+    }
 }

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -152,7 +152,6 @@ mod tests {
     use super::*;
     use ferrokinesis::sequence;
     use ferrokinesis::types::StoredRecord;
-    use num_bigint::BigUint;
     use serde::Deserialize;
     use serde_json::json;
     use wasm_bindgen_test::wasm_bindgen_test;
@@ -192,7 +191,7 @@ mod tests {
         let old_time = ferrokinesis::util::current_time_ms() - 25 * 60 * 60 * 1000;
         let seq_num = sequence::stringify_sequence(&sequence::SeqObj {
             shard_create_time,
-            seq_ix: Some(BigUint::from(0u64)),
+            seq_ix: Some(0),
             byte1: None,
             seq_time: Some(old_time),
             seq_rand: None,

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -1,0 +1,141 @@
+use std::collections::BTreeMap;
+
+use axum::body::{Body, to_bytes};
+use axum::extract::DefaultBodyLimit;
+use axum::http::Request;
+use ferrokinesis::constants;
+use ferrokinesis::store::{Store, StoreOptions};
+use serde::{Deserialize, Serialize};
+use tower::util::ServiceExt;
+use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+const DEFAULT_MAX_REQUEST_BODY_MB: u64 = 7;
+const AUTHORIZATION: &str = "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=abcd1234";
+const X_AMZ_DATE: &str = "20150101T000000Z";
+
+#[derive(Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct KinesisOptions {
+    create_stream_ms: Option<u64>,
+    delete_stream_ms: Option<u64>,
+    update_stream_ms: Option<u64>,
+    shard_limit: Option<u32>,
+    iterator_ttl_seconds: Option<u64>,
+    retention_check_interval_secs: Option<u64>,
+    account_id: Option<String>,
+    region: Option<String>,
+    max_request_body_mb: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct KinesisResponse {
+    status: u16,
+    body: String,
+    headers: BTreeMap<String, String>,
+}
+
+#[wasm_bindgen]
+pub struct Kinesis {
+    app: axum::Router,
+    _store: Store,
+}
+
+#[wasm_bindgen]
+impl Kinesis {
+    #[wasm_bindgen(constructor)]
+    pub fn new(options: Option<JsValue>) -> Result<Kinesis, JsValue> {
+        console_error_panic_hook::set_once();
+
+        let options = parse_options(options)?;
+        let defaults = StoreOptions::default();
+        let store_options = StoreOptions {
+            create_stream_ms: options
+                .create_stream_ms
+                .unwrap_or(defaults.create_stream_ms),
+            delete_stream_ms: options
+                .delete_stream_ms
+                .unwrap_or(defaults.delete_stream_ms),
+            update_stream_ms: options
+                .update_stream_ms
+                .unwrap_or(defaults.update_stream_ms),
+            shard_limit: options.shard_limit.unwrap_or(defaults.shard_limit),
+            iterator_ttl_seconds: options
+                .iterator_ttl_seconds
+                .unwrap_or(defaults.iterator_ttl_seconds),
+            retention_check_interval_secs: options
+                .retention_check_interval_secs
+                .unwrap_or(defaults.retention_check_interval_secs),
+            aws_account_id: options.account_id.unwrap_or(defaults.aws_account_id),
+            aws_region: options.region.unwrap_or(defaults.aws_region),
+        };
+
+        let max_bytes: usize = options
+            .max_request_body_mb
+            .unwrap_or(DEFAULT_MAX_REQUEST_BODY_MB)
+            .saturating_mul(1024 * 1024)
+            .try_into()
+            .map_err(|_| js_error("maxRequestBodyMb overflows usize"))?;
+
+        let (app, store) = ferrokinesis::create_app(store_options);
+        let app = app.layer(DefaultBodyLimit::max(max_bytes));
+
+        Ok(Self { app, _store: store })
+    }
+
+    #[wasm_bindgen]
+    pub async fn request(&self, target: &str, body: &str) -> Result<JsValue, JsValue> {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", constants::CONTENT_TYPE_JSON)
+            .header("X-Amz-Target", target)
+            .header("Authorization", AUTHORIZATION)
+            .header("X-Amz-Date", X_AMZ_DATE)
+            .body(Body::from(body.as_bytes().to_vec()))
+            .map_err(|err| js_error(err.to_string()))?;
+
+        let response = self
+            .app
+            .clone()
+            .oneshot(request)
+            .await
+            .map_err(|err| js_error(err.to_string()))?;
+
+        let status = response.status().as_u16();
+        let headers = response
+            .headers()
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.to_string(),
+                    value.to_str().unwrap_or_default().to_string(),
+                )
+            })
+            .collect();
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .map_err(|err| js_error(err.to_string()))?;
+        let body = String::from_utf8(body.to_vec()).map_err(|err| js_error(err.to_string()))?;
+
+        serde_wasm_bindgen::to_value(&KinesisResponse {
+            status,
+            body,
+            headers,
+        })
+        .map_err(|err| js_error(err.to_string()))
+    }
+}
+
+fn parse_options(options: Option<JsValue>) -> Result<KinesisOptions, JsValue> {
+    match options {
+        Some(value) if !value.is_null() && !value.is_undefined() => {
+            serde_wasm_bindgen::from_value(value).map_err(|err| js_error(err.to_string()))
+        }
+        _ => Ok(KinesisOptions::default()),
+    }
+}
+
+fn js_error(message: impl Into<String>) -> JsValue {
+    JsValue::from_str(&message.into())
+}

--- a/crates/ferrokinesis-wasm/tests/phase1.rs
+++ b/crates/ferrokinesis-wasm/tests/phase1.rs
@@ -13,81 +13,63 @@ struct Response {
 
 #[wasm_bindgen_test(async)]
 async fn create_put_get_records_roundtrip() {
-    let options = serde_wasm_bindgen::to_value(&json!({
+    let kinesis = new_kinesis(json!({
         "createStreamMs": 0,
         "deleteStreamMs": 0,
         "updateStreamMs": 0,
-    }))
-    .unwrap();
-    let kinesis = Kinesis::new(Some(options)).unwrap();
+    }));
 
-    let create = decode(
-        kinesis
-            .request(
-                "Kinesis_20131202.CreateStream",
-                &json!({
-                    "StreamName": "wasm-stream",
-                    "ShardCount": 1,
-                })
-                .to_string(),
-            )
-            .await
-            .unwrap(),
-    );
+    let create = request(
+        &kinesis,
+        "Kinesis_20131202.CreateStream",
+        json!({
+            "StreamName": "wasm-stream",
+            "ShardCount": 1,
+        }),
+    )
+    .await;
     assert_eq!(create.status, 200);
 
     wait_until_stream_active(&kinesis, "wasm-stream").await;
 
-    let put = decode(
-        kinesis
-            .request(
-                "Kinesis_20131202.PutRecord",
-                &json!({
-                    "StreamName": "wasm-stream",
-                    "PartitionKey": "pk-1",
-                    "Data": "aGVsbG8=",
-                })
-                .to_string(),
-            )
-            .await
-            .unwrap(),
-    );
+    let put = request(
+        &kinesis,
+        "Kinesis_20131202.PutRecord",
+        json!({
+            "StreamName": "wasm-stream",
+            "PartitionKey": "pk-1",
+            "Data": "aGVsbG8=",
+        }),
+    )
+    .await;
     assert_eq!(put.status, 200);
 
     let put_body: serde_json::Value = serde_json::from_str(&put.body).unwrap();
     let shard_id = put_body["ShardId"].as_str().unwrap();
 
-    let iter = decode(
-        kinesis
-            .request(
-                "Kinesis_20131202.GetShardIterator",
-                &json!({
-                    "StreamName": "wasm-stream",
-                    "ShardId": shard_id,
-                    "ShardIteratorType": "TRIM_HORIZON",
-                })
-                .to_string(),
-            )
-            .await
-            .unwrap(),
-    );
+    let iter = request(
+        &kinesis,
+        "Kinesis_20131202.GetShardIterator",
+        json!({
+            "StreamName": "wasm-stream",
+            "ShardId": shard_id,
+            "ShardIteratorType": "TRIM_HORIZON",
+        }),
+    )
+    .await;
     assert_eq!(iter.status, 200);
 
     let iter_body: serde_json::Value = serde_json::from_str(&iter.body).unwrap();
     let iterator = iter_body["ShardIterator"].as_str().unwrap();
 
-    let records = decode(
-        kinesis
-            .request(
-                "Kinesis_20131202.GetRecords",
-                &json!({
-                    "ShardIterator": iterator,
-                })
-                .to_string(),
-            )
-            .await
-            .unwrap(),
-    );
+    let records = request(
+        &kinesis,
+        "Kinesis_20131202.GetRecords",
+        json!({
+            "ShardIterator": iterator,
+        }),
+    )
+    .await;
     assert_eq!(records.status, 200);
 
     let records_body: serde_json::Value = serde_json::from_str(&records.body).unwrap();
@@ -97,33 +79,245 @@ async fn create_put_get_records_roundtrip() {
     assert_eq!(items[0]["PartitionKey"].as_str(), Some("pk-1"));
 }
 
-async fn wait_until_stream_active(kinesis: &Kinesis, stream_name: &str) {
-    for _ in 0..10 {
-        yield_once().await;
-        let response = decode(
-            kinesis
-                .request(
-                    "Kinesis_20131202.DescribeStream",
-                    &json!({ "StreamName": stream_name }).to_string(),
-                )
-                .await
-                .unwrap(),
-        );
+#[wasm_bindgen_test(async)]
+async fn create_stream_delay_is_preserved() {
+    let kinesis = new_kinesis(json!({
+        "createStreamMs": 100,
+        "deleteStreamMs": 0,
+        "updateStreamMs": 0,
+    }));
 
-        if response.status == 200 {
-            let body: serde_json::Value = serde_json::from_str(&response.body).unwrap();
-            if body["StreamDescription"]["StreamStatus"].as_str() == Some("ACTIVE") {
-                return;
-            }
-        }
-    }
+    let create = request(
+        &kinesis,
+        "Kinesis_20131202.CreateStream",
+        json!({
+            "StreamName": "delayed-create",
+            "ShardCount": 1,
+        }),
+    )
+    .await;
+    assert_eq!(create.status, 200);
 
-    panic!("stream did not become ACTIVE");
+    assert_eq!(
+        describe_stream_status(&kinesis, "delayed-create")
+            .await
+            .as_deref(),
+        Some("CREATING")
+    );
+
+    sleep_ms(25).await;
+    assert_eq!(
+        describe_stream_status(&kinesis, "delayed-create")
+            .await
+            .as_deref(),
+        Some("CREATING")
+    );
+
+    wait_until_stream_active(&kinesis, "delayed-create").await;
 }
 
-async fn yield_once() {
-    let promise = js_sys::Promise::resolve(&JsValue::UNDEFINED);
-    wasm_bindgen_futures::JsFuture::from(promise).await.unwrap();
+#[wasm_bindgen_test(async)]
+async fn delete_stream_delay_is_preserved() {
+    let kinesis = new_kinesis(json!({
+        "createStreamMs": 0,
+        "deleteStreamMs": 100,
+        "updateStreamMs": 0,
+    }));
+
+    let create = request(
+        &kinesis,
+        "Kinesis_20131202.CreateStream",
+        json!({
+            "StreamName": "delayed-delete",
+            "ShardCount": 1,
+        }),
+    )
+    .await;
+    assert_eq!(create.status, 200);
+
+    wait_until_stream_active(&kinesis, "delayed-delete").await;
+
+    let delete = request(
+        &kinesis,
+        "Kinesis_20131202.DeleteStream",
+        json!({
+            "StreamName": "delayed-delete",
+        }),
+    )
+    .await;
+    assert_eq!(delete.status, 200);
+
+    assert_eq!(
+        describe_stream_status(&kinesis, "delayed-delete")
+            .await
+            .as_deref(),
+        Some("DELETING")
+    );
+
+    sleep_ms(25).await;
+    assert_eq!(
+        describe_stream_status(&kinesis, "delayed-delete")
+            .await
+            .as_deref(),
+        Some("DELETING")
+    );
+
+    wait_until_stream_missing(&kinesis, "delayed-delete").await;
+}
+
+#[wasm_bindgen_test(async)]
+async fn update_stream_delay_is_preserved() {
+    let kinesis = new_kinesis(json!({
+        "createStreamMs": 0,
+        "deleteStreamMs": 0,
+        "updateStreamMs": 100,
+    }));
+
+    let create = request(
+        &kinesis,
+        "Kinesis_20131202.CreateStream",
+        json!({
+            "StreamName": "delayed-update",
+            "ShardCount": 1,
+        }),
+    )
+    .await;
+    assert_eq!(create.status, 200);
+
+    wait_until_stream_active(&kinesis, "delayed-update").await;
+
+    let start = request(
+        &kinesis,
+        "Kinesis_20131202.StartStreamEncryption",
+        json!({
+            "StreamName": "delayed-update",
+            "EncryptionType": "KMS",
+            "KeyId": "alias/wasm-test",
+        }),
+    )
+    .await;
+    assert_eq!(start.status, 200);
+
+    let summary = describe_stream_summary(&kinesis, "delayed-update").await;
+    assert_eq!(
+        summary["StreamDescriptionSummary"]["StreamStatus"].as_str(),
+        Some("UPDATING")
+    );
+
+    sleep_ms(25).await;
+    let summary = describe_stream_summary(&kinesis, "delayed-update").await;
+    assert_eq!(
+        summary["StreamDescriptionSummary"]["StreamStatus"].as_str(),
+        Some("UPDATING")
+    );
+
+    let summary = wait_until_summary_status(&kinesis, "delayed-update", "ACTIVE").await;
+    assert_eq!(
+        summary["StreamDescriptionSummary"]["EncryptionType"].as_str(),
+        Some("KMS")
+    );
+    assert_eq!(
+        summary["StreamDescriptionSummary"]["KeyId"].as_str(),
+        Some("alias/wasm-test")
+    );
+}
+
+async fn wait_until_stream_active(kinesis: &Kinesis, stream_name: &str) {
+    wait_until_stream_status(kinesis, stream_name, "ACTIVE").await;
+}
+
+async fn wait_until_stream_status(kinesis: &Kinesis, stream_name: &str, expected: &str) {
+    for _ in 0..40 {
+        if describe_stream_status(kinesis, stream_name)
+            .await
+            .as_deref()
+            == Some(expected)
+        {
+            return;
+        }
+
+        sleep_ms(25).await;
+    }
+
+    panic!("stream did not reach expected status {expected}");
+}
+
+async fn wait_until_stream_missing(kinesis: &Kinesis, stream_name: &str) {
+    for _ in 0..40 {
+        let response = request(
+            kinesis,
+            "Kinesis_20131202.DescribeStream",
+            json!({ "StreamName": stream_name }),
+        )
+        .await;
+
+        if response.status == 400 && response.body.contains("ResourceNotFoundException") {
+            return;
+        }
+
+        sleep_ms(25).await;
+    }
+
+    panic!("stream was not deleted");
+}
+
+async fn wait_until_summary_status(
+    kinesis: &Kinesis,
+    stream_name: &str,
+    expected: &str,
+) -> serde_json::Value {
+    for _ in 0..40 {
+        let summary = describe_stream_summary(kinesis, stream_name).await;
+        if summary["StreamDescriptionSummary"]["StreamStatus"].as_str() == Some(expected) {
+            return summary;
+        }
+
+        sleep_ms(25).await;
+    }
+
+    panic!("stream summary did not reach expected status {expected}");
+}
+
+async fn describe_stream_status(kinesis: &Kinesis, stream_name: &str) -> Option<String> {
+    let response = request(
+        kinesis,
+        "Kinesis_20131202.DescribeStream",
+        json!({ "StreamName": stream_name }),
+    )
+    .await;
+
+    if response.status != 200 {
+        return None;
+    }
+
+    let body: serde_json::Value = serde_json::from_str(&response.body).unwrap();
+    body["StreamDescription"]["StreamStatus"]
+        .as_str()
+        .map(str::to_string)
+}
+
+async fn describe_stream_summary(kinesis: &Kinesis, stream_name: &str) -> serde_json::Value {
+    let response = request(
+        kinesis,
+        "Kinesis_20131202.DescribeStreamSummary",
+        json!({ "StreamName": stream_name }),
+    )
+    .await;
+    assert_eq!(response.status, 200);
+    serde_json::from_str(&response.body).unwrap()
+}
+
+async fn request(kinesis: &Kinesis, target: &str, body: serde_json::Value) -> Response {
+    decode(kinesis.request(target, &body.to_string()).await.unwrap())
+}
+
+fn new_kinesis(options: serde_json::Value) -> Kinesis {
+    let options = serde_wasm_bindgen::to_value(&options).unwrap();
+    Kinesis::new(Some(options)).unwrap()
+}
+
+async fn sleep_ms(ms: u64) {
+    ferrokinesis::runtime::sleep_ms(ms).await;
 }
 
 fn decode(value: JsValue) -> Response {

--- a/crates/ferrokinesis-wasm/tests/phase1.rs
+++ b/crates/ferrokinesis-wasm/tests/phase1.rs
@@ -1,0 +1,131 @@
+use serde::Deserialize;
+use serde_json::json;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+use ferrokinesis_wasm::Kinesis;
+
+#[derive(Deserialize)]
+struct Response {
+    status: u16,
+    body: String,
+}
+
+#[wasm_bindgen_test(async)]
+async fn create_put_get_records_roundtrip() {
+    let options = serde_wasm_bindgen::to_value(&json!({
+        "createStreamMs": 0,
+        "deleteStreamMs": 0,
+        "updateStreamMs": 0,
+    }))
+    .unwrap();
+    let kinesis = Kinesis::new(Some(options)).unwrap();
+
+    let create = decode(
+        kinesis
+            .request(
+                "Kinesis_20131202.CreateStream",
+                &json!({
+                    "StreamName": "wasm-stream",
+                    "ShardCount": 1,
+                })
+                .to_string(),
+            )
+            .await
+            .unwrap(),
+    );
+    assert_eq!(create.status, 200);
+
+    wait_until_stream_active(&kinesis, "wasm-stream").await;
+
+    let put = decode(
+        kinesis
+            .request(
+                "Kinesis_20131202.PutRecord",
+                &json!({
+                    "StreamName": "wasm-stream",
+                    "PartitionKey": "pk-1",
+                    "Data": "aGVsbG8=",
+                })
+                .to_string(),
+            )
+            .await
+            .unwrap(),
+    );
+    assert_eq!(put.status, 200);
+
+    let put_body: serde_json::Value = serde_json::from_str(&put.body).unwrap();
+    let shard_id = put_body["ShardId"].as_str().unwrap();
+
+    let iter = decode(
+        kinesis
+            .request(
+                "Kinesis_20131202.GetShardIterator",
+                &json!({
+                    "StreamName": "wasm-stream",
+                    "ShardId": shard_id,
+                    "ShardIteratorType": "TRIM_HORIZON",
+                })
+                .to_string(),
+            )
+            .await
+            .unwrap(),
+    );
+    assert_eq!(iter.status, 200);
+
+    let iter_body: serde_json::Value = serde_json::from_str(&iter.body).unwrap();
+    let iterator = iter_body["ShardIterator"].as_str().unwrap();
+
+    let records = decode(
+        kinesis
+            .request(
+                "Kinesis_20131202.GetRecords",
+                &json!({
+                    "ShardIterator": iterator,
+                })
+                .to_string(),
+            )
+            .await
+            .unwrap(),
+    );
+    assert_eq!(records.status, 200);
+
+    let records_body: serde_json::Value = serde_json::from_str(&records.body).unwrap();
+    let items = records_body["Records"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["Data"].as_str(), Some("aGVsbG8="));
+    assert_eq!(items[0]["PartitionKey"].as_str(), Some("pk-1"));
+}
+
+async fn wait_until_stream_active(kinesis: &Kinesis, stream_name: &str) {
+    for _ in 0..10 {
+        yield_once().await;
+        let response = decode(
+            kinesis
+                .request(
+                    "Kinesis_20131202.DescribeStream",
+                    &json!({ "StreamName": stream_name }).to_string(),
+                )
+                .await
+                .unwrap(),
+        );
+
+        if response.status == 200 {
+            let body: serde_json::Value = serde_json::from_str(&response.body).unwrap();
+            if body["StreamDescription"]["StreamStatus"].as_str() == Some("ACTIVE") {
+                return;
+            }
+        }
+    }
+
+    panic!("stream did not become ACTIVE");
+}
+
+async fn yield_once() {
+    let promise = js_sys::Promise::resolve(&JsValue::UNDEFINED);
+    wasm_bindgen_futures::JsFuture::from(promise).await.unwrap();
+}
+
+fn decode(value: JsValue) -> Response {
+    serde_wasm_bindgen::from_value(value).unwrap()
+}

--- a/src/actions/create_stream.rs
+++ b/src/actions/create_stream.rs
@@ -62,10 +62,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
 
         shards.push(Shard {
             shard_id: sequence::shard_id_name(i as i64),
-            hash_key_range: HashKeyRange {
-                starting_hash_key: start.to_string(),
-                ending_hash_key: end.to_string(),
-            },
+            hash_key_range: HashKeyRange::new(start.to_string(), end.to_string()),
             sequence_number_range: SequenceNumberRange {
                 starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
                     shard_create_time: create_time,

--- a/src/actions/create_stream.rs
+++ b/src/actions/create_stream.rs
@@ -102,8 +102,8 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     let store_clone = store.clone();
     let name = stream_name.to_string();
     let delay = store.options.create_stream_ms;
-    tokio::spawn(async move {
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+    crate::runtime::spawn_background(async move {
+        crate::runtime::sleep_ms(delay).await;
         let _ = store_clone
             .update_stream(&name, |stream| {
                 stream.stream_status = StreamStatus::Active;

--- a/src/actions/delete_stream.rs
+++ b/src/actions/delete_stream.rs
@@ -20,8 +20,8 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     let store_clone = store.clone();
     let name = stream_name.to_string();
     let delay = store.options.delete_stream_ms;
-    tokio::spawn(async move {
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+    crate::runtime::spawn_background(async move {
+        crate::runtime::sleep_ms(delay).await;
         store_clone.delete_stream(&name).await;
     });
 

--- a/src/actions/deregister_stream_consumer.rs
+++ b/src/actions/deregister_stream_consumer.rs
@@ -45,8 +45,8 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     // Delete after short delay
     let store_clone = store.clone();
     let arn = resolved_arn;
-    tokio::spawn(async move {
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    crate::runtime::spawn_background(async move {
+        crate::runtime::sleep_ms(500).await;
         store_clone.delete_consumer(&arn).await;
     });
 

--- a/src/actions/get_records.rs
+++ b/src/actions/get_records.rs
@@ -161,7 +161,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     if !keys_to_delete.is_empty() {
         let store_clone = store.clone();
         let name = stream_name.to_string();
-        tokio::spawn(async move {
+        crate::runtime::spawn_background(async move {
             store_clone.delete_record_keys(&name, &keys_to_delete).await;
         });
     }

--- a/src/actions/get_shard_iterator.rs
+++ b/src/actions/get_shard_iterator.rs
@@ -5,7 +5,6 @@ use crate::shard_iterator;
 use crate::store::Store;
 use crate::types::ShardIteratorType;
 use crate::util::current_time_ms;
-use num_bigint::BigUint;
 use serde_json::{Value, json};
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -145,7 +144,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 let seq_ix = store.current_shard_seq(stream_name, shard_ix).await;
                 iterator_seq = sequence::stringify_sequence(&sequence::SeqObj {
                     shard_create_time: shard_seq_obj.shard_create_time,
-                    seq_ix: Some(BigUint::from(seq_ix)),
+                    seq_ix: Some(seq_ix),
                     seq_time: Some(now),
                     shard_ix: shard_seq_obj.shard_ix,
                     byte1: None,

--- a/src/actions/merge_shards.rs
+++ b/src/actions/merge_shards.rs
@@ -94,8 +94,8 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     let shard_ixs_clone = shard_ixs.clone();
     let shard_ids_clone = shard_ids.clone();
 
-    tokio::spawn(async move {
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+    crate::runtime::spawn_background(async move {
+        crate::runtime::sleep_ms(delay).await;
 
         let _ = store_clone
             .update_stream(&name, |stream| {

--- a/src/actions/merge_shards.rs
+++ b/src/actions/merge_shards.rs
@@ -4,8 +4,6 @@ use crate::sequence;
 use crate::store::Store;
 use crate::types::*;
 use crate::util::current_time_ms;
-use num_bigint::BigUint;
-use num_traits::{Num, One, Zero};
 use serde_json::Value;
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -57,21 +55,18 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 }
             }
 
-            let end0: BigUint = stream.shards[shard_ixs[0] as usize]
+            let end0 = stream.shards[shard_ixs[0] as usize]
                 .hash_key_range
-                .ending_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
-            let start1: BigUint = stream.shards[shard_ixs[1] as usize]
+                .end_u128();
+            let start1 = stream.shards[shard_ixs[1] as usize]
                 .hash_key_range
-                .starting_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
+                .start_u128();
 
             // Kinesis requires the two shards to be adjacent — their hash ranges must
-            // be contiguous with no gap. BigUint is necessary here because the MD5 hash
-            // space spans [0, 2^128-1] and the boundary values can equal 2^128-1.
-            if end0 + BigUint::one() != start1 {
+            // be contiguous with no gap. `checked_add` handles the theoretical edge case
+            // where end0 == u128::MAX (impossible in practice since there'd be no room
+            // for another shard, but safe by construction).
+            if end0.checked_add(1) != Some(start1) {
                 return Err(KinesisErrorResponse::client_error(
                     constants::INVALID_ARGUMENT,
                     Some(&format!(
@@ -102,13 +97,6 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 let now = current_time_ms();
                 stream.stream_status = StreamStatus::Active;
 
-                // Use the maximum possible seq_ix (0x7fffffffffffffff) for the closing
-                // sequence number. This ensures no future record written to this shard
-                // could ever produce a sequence number that compares as ≥ the ending
-                // sequence, making the shard-closed invariant unconditionally safe.
-                let max_seq_ix = BigUint::from_str_radix("7fffffffffffffff", 16)
-                    .unwrap_or_else(|_| BigUint::zero());
-
                 for &ix in &shard_ixs_clone {
                     let shard = &mut stream.shards[ix as usize];
                     let create_time = sequence::parse_sequence(
@@ -121,7 +109,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                         Some(sequence::stringify_sequence(&sequence::SeqObj {
                             shard_create_time: create_time,
                             shard_ix: ix,
-                            seq_ix: Some(max_seq_ix.clone()),
+                            seq_ix: Some(sequence::MAX_SEQ_IX),
                             seq_time: Some(now),
                             byte1: None,
                             seq_rand: None,
@@ -142,10 +130,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 stream.shards.push(Shard {
                     parent_shard_id: Some(shard_ids_clone[0].clone()),
                     adjacent_parent_shard_id: Some(shard_ids_clone[1].clone()),
-                    hash_key_range: HashKeyRange {
-                        starting_hash_key: starting_hash,
-                        ending_hash_key: ending_hash,
-                    },
+                    hash_key_range: HashKeyRange::new(starting_hash, ending_hash),
                     sequence_number_range: SequenceNumberRange {
                         starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
                             // Child's create_time is 1 second ahead of the parent's closing

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -68,6 +68,7 @@ pub mod split_shard;
 pub mod start_stream_encryption;
 #[doc(hidden)]
 pub mod stop_stream_encryption;
+#[cfg(feature = "rt")]
 #[doc(hidden)]
 pub mod subscribe_to_shard;
 #[doc(hidden)]
@@ -87,6 +88,7 @@ pub mod update_stream_warm_throughput;
 
 pub use ferrokinesis_core::operation::Operation;
 
+use crate::constants;
 use crate::error::KinesisErrorResponse;
 use crate::store::Store;
 use serde_json::Value;
@@ -150,10 +152,10 @@ pub async fn dispatch(
         Operation::SplitShard => split_shard::execute(store, data).await,
         Operation::StartStreamEncryption => start_stream_encryption::execute(store, data).await,
         Operation::StopStreamEncryption => stop_stream_encryption::execute(store, data).await,
-        Operation::SubscribeToShard => {
-            // Handled separately in server.rs via execute_streaming; should not reach here.
-            Err(KinesisErrorResponse::server_error(None, None))
-        }
+        Operation::SubscribeToShard => Err(KinesisErrorResponse::client_error(
+            constants::INVALID_ARGUMENT,
+            Some("SubscribeToShard is not supported in this build."),
+        )),
         Operation::TagResource => tag_resource::execute(store, data).await,
         Operation::UntagResource => untag_resource::execute(store, data).await,
         Operation::UpdateAccountSettings => update_account_settings::execute(store, data).await,

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -68,7 +68,7 @@ pub mod split_shard;
 pub mod start_stream_encryption;
 #[doc(hidden)]
 pub mod stop_stream_encryption;
-#[cfg(feature = "rt")]
+#[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
 pub mod subscribe_to_shard;
 #[doc(hidden)]
@@ -88,6 +88,7 @@ pub mod update_stream_warm_throughput;
 
 pub use ferrokinesis_core::operation::Operation;
 
+#[cfg(target_arch = "wasm32")]
 use crate::constants;
 use crate::error::KinesisErrorResponse;
 use crate::store::Store;
@@ -152,10 +153,7 @@ pub async fn dispatch(
         Operation::SplitShard => split_shard::execute(store, data).await,
         Operation::StartStreamEncryption => start_stream_encryption::execute(store, data).await,
         Operation::StopStreamEncryption => stop_stream_encryption::execute(store, data).await,
-        Operation::SubscribeToShard => Err(KinesisErrorResponse::client_error(
-            constants::INVALID_ARGUMENT,
-            Some("SubscribeToShard is not supported in this build."),
-        )),
+        Operation::SubscribeToShard => unexpected_subscribe_to_shard(),
         Operation::TagResource => tag_resource::execute(store, data).await,
         Operation::UntagResource => untag_resource::execute(store, data).await,
         Operation::UpdateAccountSettings => update_account_settings::execute(store, data).await,
@@ -166,4 +164,17 @@ pub async fn dispatch(
             update_stream_warm_throughput::execute(store, data).await
         }
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn unexpected_subscribe_to_shard() -> Result<Option<Value>, KinesisErrorResponse> {
+    Err(KinesisErrorResponse::server_error(None, None))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn unexpected_subscribe_to_shard() -> Result<Option<Value>, KinesisErrorResponse> {
+    Err(KinesisErrorResponse::client_error(
+        constants::INVALID_ARGUMENT,
+        Some("SubscribeToShard is not supported in this build."),
+    ))
 }

--- a/src/actions/put_record.rs
+++ b/src/actions/put_record.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "server")]
 use crate::capture::{CaptureOp, CaptureRecordRef};
 use crate::constants;
 use crate::error::KinesisErrorResponse;
@@ -8,6 +9,7 @@ use crate::util::current_time_ms;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 use serde_json::{Value, json};
+#[cfg(feature = "server")]
 use std::borrow::Cow;
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -71,6 +73,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         .put_record(&stream_name, &alloc.stream_key, &record)
         .await;
 
+    #[cfg(feature = "server")]
     if let Some(ref writer) = store.capture_writer {
         let capture_record = CaptureRecordRef {
             op: CaptureOp::PutRecord,

--- a/src/actions/put_record.rs
+++ b/src/actions/put_record.rs
@@ -6,8 +6,6 @@ use crate::sequence;
 use crate::store::Store;
 use crate::types::StoredRecordRef;
 use crate::util::current_time_ms;
-use num_bigint::BigUint;
-use num_traits::{One, Zero};
 use serde_json::{Value, json};
 #[cfg(feature = "server")]
 use std::borrow::Cow;
@@ -20,18 +18,15 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     let explicit_hash_key = data[constants::EXPLICIT_HASH_KEY].as_str();
     let seq_for_ordering = data[constants::SEQUENCE_NUMBER_FOR_ORDERING].as_str();
 
-    let hash_key = if let Some(ehk) = explicit_hash_key {
-        let hk: BigUint = ehk.parse().unwrap_or_else(|_| BigUint::zero());
-        let pow_128 = BigUint::one() << 128;
-        if hk >= pow_128 {
-            return Err(KinesisErrorResponse::client_error(
+    let hash_key: u128 = if let Some(ehk) = explicit_hash_key {
+        ehk.parse::<u128>().map_err(|_| {
+            KinesisErrorResponse::client_error(
                 constants::INVALID_ARGUMENT,
                 Some(&format!(
                     "Invalid ExplicitHashKey. ExplicitHashKey must be in the range: [0, 2^128-1]. Specified value was {ehk}"
                 )),
-            ));
-        }
-        hk
+            )
+        })?
     } else {
         sequence::partition_key_to_hash_key(partition_key)
     };

--- a/src/actions/put_records.rs
+++ b/src/actions/put_records.rs
@@ -5,8 +5,6 @@ use crate::error::KinesisErrorResponse;
 use crate::sequence;
 use crate::store::Store;
 use crate::types::StoredRecordRef;
-use num_bigint::BigUint;
-use num_traits::{One, Zero};
 use serde_json::{Value, json};
 #[cfg(feature = "server")]
 use std::borrow::Cow;
@@ -78,24 +76,21 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     }
 
     // Pre-compute hash keys (no stream access needed)
-    let pow_128 = BigUint::one() << 128;
-    let mut hash_keys = Vec::with_capacity(records.len());
+    let mut hash_keys: Vec<u128> = Vec::with_capacity(records.len());
 
     for record in records {
         let partition_key = record["PartitionKey"].as_str().unwrap_or("");
         let explicit_hash_key = record["ExplicitHashKey"].as_str();
 
-        let hash_key = if let Some(ehk) = explicit_hash_key {
-            let hk: BigUint = ehk.parse().unwrap_or_else(|_| BigUint::zero());
-            if hk >= pow_128 {
-                return Err(KinesisErrorResponse::client_error(
+        let hash_key: u128 = if let Some(ehk) = explicit_hash_key {
+            ehk.parse::<u128>().map_err(|_| {
+                KinesisErrorResponse::client_error(
                     constants::INVALID_ARGUMENT,
                     Some(&format!(
                         "Invalid ExplicitHashKey. ExplicitHashKey must be in the range: [0, 2^128-1]. Specified value was {ehk}"
                     )),
-                ));
-            }
-            hk
+                )
+            })?
         } else {
             sequence::partition_key_to_hash_key(partition_key)
         };

--- a/src/actions/put_records.rs
+++ b/src/actions/put_records.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "server")]
 use crate::capture::{CaptureOp, CaptureRecordRef};
 use crate::constants;
 use crate::error::KinesisErrorResponse;
@@ -7,12 +8,15 @@ use crate::types::StoredRecordRef;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 use serde_json::{Value, json};
+#[cfg(feature = "server")]
 use std::borrow::Cow;
 
+#[cfg(feature = "server")]
 fn is_capture_eligible(resp: &Value) -> bool {
     resp.get(constants::ERROR_CODE).is_none_or(|v| v.is_null())
 }
 
+#[cfg(feature = "server")]
 fn build_capture_refs<'a>(
     records: &'a [Value],
     return_records: &'a [Value],
@@ -127,6 +131,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
 
     store.put_records_batch(&stream_name, &batch).await;
 
+    #[cfg(feature = "server")]
     if let Some(ref writer) = store.capture_writer {
         let timestamps: Vec<u64> = allocations.iter().map(|a| a.now).collect();
         let capture_refs = build_capture_refs(records, &return_records, &timestamps, &stream_name);
@@ -143,7 +148,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     })))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "server"))]
 mod tests {
     use super::*;
     use crate::capture::{CaptureOp, CaptureWriter, read_capture_file};

--- a/src/actions/register_stream_consumer.rs
+++ b/src/actions/register_stream_consumer.rs
@@ -60,8 +60,8 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     // Transition to ACTIVE after a short delay
     let store_clone = store.clone();
     let arn = consumer_arn.clone();
-    tokio::spawn(async move {
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    crate::runtime::spawn_background(async move {
+        crate::runtime::sleep_ms(500).await;
         if let Some(mut c) = store_clone.get_consumer(&arn).await {
             c.consumer_status = ConsumerStatus::Active;
             store_clone.put_consumer(&arn, c).await;

--- a/src/actions/split_shard.rs
+++ b/src/actions/split_shard.rs
@@ -4,8 +4,6 @@ use crate::sequence;
 use crate::store::Store;
 use crate::types::*;
 use crate::util::current_time_ms;
-use num_bigint::BigUint;
-use num_traits::{Num, One, Zero};
 use serde_json::Value;
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -65,26 +63,16 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 ));
             }
 
-            let hash_key: BigUint = new_starting_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
+            let hash_key: u128 = new_starting_hash_key.parse().unwrap_or(0);
             let shard = &stream.shards[shard_ix as usize];
-            let shard_start: BigUint = shard
-                .hash_key_range
-                .starting_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
-            let shard_end: BigUint = shard
-                .hash_key_range
-                .ending_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
+            let shard_start = shard.hash_key_range.start_u128();
+            let shard_end = shard.hash_key_range.end_u128();
 
             // Strict interior constraint: the split key must be > start+1 AND < end.
             // Equal to start+1 would give the lower child an empty hash range [start, start];
             // equal to end would give the upper child an empty range [end, end]. Either
             // degenerate case would prevent any partition key from routing to that child.
-            if hash_key <= &shard_start + BigUint::one() || hash_key >= shard_end {
+            if hash_key <= shard_start + 1 || hash_key >= shard_end {
                 return Err(KinesisErrorResponse::client_error(
                     constants::INVALID_ARGUMENT,
                     Some(&format!(
@@ -116,12 +104,6 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 let now = current_time_ms();
                 stream.stream_status = StreamStatus::Active;
 
-                // Use the maximum possible seq_ix (0x7fffffffffffffff) for the closing
-                // sequence number so that no future record in this shard could produce a
-                // sequence number that compares as ≥ the ending sequence.
-                let max_seq_ix = BigUint::from_str_radix("7fffffffffffffff", 16)
-                    .unwrap_or_else(|_| BigUint::zero());
-
                 let shard = &mut stream.shards[shard_ix as usize];
                 let create_time =
                     sequence::parse_sequence(&shard.sequence_number_range.starting_sequence_number)
@@ -132,7 +114,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                     Some(sequence::stringify_sequence(&sequence::SeqObj {
                         shard_create_time: create_time,
                         shard_ix,
-                        seq_ix: Some(max_seq_ix),
+                        seq_ix: Some(sequence::MAX_SEQ_IX),
                         seq_time: Some(now),
                         byte1: None,
                         seq_rand: None,
@@ -143,10 +125,10 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 stream.shards.push(Shard {
                     parent_shard_id: Some(shard_id_clone.clone()),
                     adjacent_parent_shard_id: None,
-                    hash_key_range: HashKeyRange {
-                        starting_hash_key: shard_start.to_string(),
-                        ending_hash_key: (&hash_key - BigUint::one()).to_string(),
-                    },
+                    hash_key_range: HashKeyRange::new(
+                        shard_start.to_string(),
+                        (hash_key - 1).to_string(),
+                    ),
                     sequence_number_range: SequenceNumberRange {
                         starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
                             // Child's create_time is 1 second ahead of the parent's closing
@@ -170,10 +152,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 stream.shards.push(Shard {
                     parent_shard_id: Some(shard_id_clone.clone()),
                     adjacent_parent_shard_id: None,
-                    hash_key_range: HashKeyRange {
-                        starting_hash_key: hash_key.to_string(),
-                        ending_hash_key: shard_end.to_string(),
-                    },
+                    hash_key_range: HashKeyRange::new(hash_key.to_string(), shard_end.to_string()),
                     sequence_number_range: SequenceNumberRange {
                         starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
                             shard_create_time: now + 1000,

--- a/src/actions/split_shard.rs
+++ b/src/actions/split_shard.rs
@@ -108,8 +108,8 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     let delay = store.options.update_stream_ms;
     let shard_id_clone = shard_id.clone();
 
-    tokio::spawn(async move {
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+    crate::runtime::spawn_background(async move {
+        crate::runtime::sleep_ms(delay).await;
 
         let _ = store_clone
             .update_stream(&name, |stream| {

--- a/src/actions/start_stream_encryption.rs
+++ b/src/actions/start_stream_encryption.rs
@@ -38,8 +38,8 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     let store_clone = store.clone();
     let name = stream_name.to_string();
     let delay = store.options.update_stream_ms;
-    tokio::spawn(async move {
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+    crate::runtime::spawn_background(async move {
+        crate::runtime::sleep_ms(delay).await;
         let _ = store_clone
             .update_stream(&name, |stream| {
                 stream.stream_status = StreamStatus::Active;

--- a/src/actions/stop_stream_encryption.rs
+++ b/src/actions/stop_stream_encryption.rs
@@ -46,8 +46,8 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     let store_clone = store.clone();
     let name = stream_name.to_string();
     let delay = store.options.update_stream_ms;
-    tokio::spawn(async move {
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+    crate::runtime::spawn_background(async move {
+        crate::runtime::sleep_ms(delay).await;
         let _ = store_clone
             .update_stream(&name, |stream| {
                 stream.stream_status = StreamStatus::Active;

--- a/src/actions/subscribe_to_shard.rs
+++ b/src/actions/subscribe_to_shard.rs
@@ -7,7 +7,6 @@ use crate::types::{EpochSeconds, ResponseRecord, ShardIteratorType, StreamStatus
 use crate::util::current_time_ms;
 use axum::body::Body;
 use bytes::Bytes;
-use num_bigint::BigUint;
 use serde_json::{Value, json};
 
 /// Maximum subscription duration (5 minutes)
@@ -135,7 +134,7 @@ pub async fn execute_streaming(
             let seq_ix = store.current_shard_seq(&stream_name, shard_ix).await;
             sequence::stringify_sequence(&sequence::SeqObj {
                 shard_create_time: shard_seq_obj.shard_create_time,
-                seq_ix: Some(BigUint::from(seq_ix)),
+                seq_ix: Some(seq_ix),
                 seq_time: Some(now),
                 shard_ix: shard_seq_obj.shard_ix,
                 byte1: None,

--- a/src/actions/subscribe_to_shard.rs
+++ b/src/actions/subscribe_to_shard.rs
@@ -294,7 +294,7 @@ pub async fn execute_streaming(
             }
 
             // Wait before polling again
-            tokio::time::sleep(tokio::time::Duration::from_millis(POLL_INTERVAL_MS)).await;
+            crate::runtime::sleep_ms(POLL_INTERVAL_MS).await;
         }
     };
 

--- a/src/actions/update_shard_count.rs
+++ b/src/actions/update_shard_count.rs
@@ -49,8 +49,8 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     let store_clone = store.clone();
     let delay = store.options.update_stream_ms;
 
-    tokio::spawn(async move {
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+    crate::runtime::spawn_background(async move {
+        crate::runtime::sleep_ms(delay).await;
 
         let _ = store_clone
             .update_stream(&stream_name_owned, |stream| {

--- a/src/actions/update_shard_count.rs
+++ b/src/actions/update_shard_count.rs
@@ -5,7 +5,7 @@ use crate::store::Store;
 use crate::types::*;
 use crate::util::current_time_ms;
 use num_bigint::BigUint;
-use num_traits::{Num, One, Zero};
+use num_traits::One;
 use serde_json::{Value, json};
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -55,12 +55,10 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         let _ = store_clone
             .update_stream(&stream_name_owned, |stream| {
                 let now = current_time_ms();
-                // Use the maximum possible seq_ix (0x7fffffffffffffff) for the closing
-                // sequence number. This ensures no future record written to this shard
-                // could ever produce a sequence number that compares as ≥ the ending
-                // sequence, making the shard-closed invariant unconditionally safe.
-                let max_seq_ix = BigUint::from_str_radix("7fffffffffffffff", 16)
-                    .unwrap_or_else(|_| BigUint::zero());
+                // Use the maximum possible seq_ix for the closing sequence number.
+                // This ensures no future record written to this shard could ever
+                // produce a sequence number that compares as ≥ the ending sequence,
+                // making the shard-closed invariant unconditionally safe.
 
                 // Close all current open shards
                 let open_indices: Vec<usize> = stream
@@ -86,7 +84,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                         Some(sequence::stringify_sequence(&sequence::SeqObj {
                             shard_create_time: create_time,
                             shard_ix: ix as i64,
-                            seq_ix: Some(max_seq_ix.clone()),
+                            seq_ix: Some(sequence::MAX_SEQ_IX),
                             seq_time: Some(now),
                             byte1: None,
                             seq_rand: None,
@@ -113,10 +111,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                         // no parent lineage relationship with the old shards.
                         parent_shard_id: None,
                         adjacent_parent_shard_id: None,
-                        hash_key_range: HashKeyRange {
-                            starting_hash_key: start.to_string(),
-                            ending_hash_key: end.to_string(),
-                        },
+                        hash_key_range: HashKeyRange::new(start.to_string(), end.to_string()),
                         sequence_number_range: SequenceNumberRange {
                             starting_sequence_number: sequence::stringify_sequence(
                                 &sequence::SeqObj {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@
 //! header to determine the [`actions::Operation`], deserializes the JSON/CBOR body,
 //! runs validation, then routes to the appropriate action handler in [`actions`].
 //!
-//! All persistent state lives in an in-memory [redb](https://docs.rs/redb) database
-//! wrapped by [`store::Store`].
+//! All persistent state lives in an in-memory concurrent store wrapped by
+//! [`store::Store`].
 //!
 //! ## AWS Kinesis documentation
 //!
@@ -35,19 +35,25 @@
 #![warn(missing_docs)]
 
 pub mod actions;
+#[cfg(feature = "server")]
 pub mod capture;
+#[cfg(feature = "server")]
 pub mod config;
 #[doc(hidden)]
 pub mod constants;
 pub mod error;
+#[cfg(feature = "rt")]
 #[doc(hidden)]
 pub mod event_stream;
 pub mod health;
 #[cfg(feature = "mirror")]
 #[doc(hidden)]
 pub mod mirror;
+#[cfg(feature = "rt")]
 #[doc(hidden)]
 pub mod retention;
+#[doc(hidden)]
+pub mod runtime;
 #[doc(hidden)]
 pub mod sequence;
 pub mod server;
@@ -93,9 +99,13 @@ use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 /// }
 /// ```
 pub fn create_app(options: StoreOptions) -> (Router, Store) {
-    create_app_with_capture(options, None)
+    let store = Store::new(options.clone());
+    let app = build_app(store.clone());
+    spawn_retention_reaper(&store, &options);
+    (app, store)
 }
 
+#[cfg(feature = "server")]
 /// Like [`create_app`], but accepts an optional [`capture::CaptureWriter`] to record
 /// PutRecord/PutRecords calls to an NDJSON file.
 pub fn create_app_with_capture(
@@ -103,12 +113,18 @@ pub fn create_app_with_capture(
     capture: Option<capture::CaptureWriter>,
 ) -> (Router, Store) {
     let store = Store::with_capture(options.clone(), capture);
+    let app = build_app(store.clone());
+    spawn_retention_reaper(&store, &options);
+    (app, store)
+}
+
+fn build_app(store: Store) -> Router {
     let app = Router::new()
         .route("/_health", get(health::health))
         .route("/_health/live", get(health::live))
         .route("/_health/ready", get(health::ready))
         .fallback(any(server::handler))
-        .with_state(store.clone())
+        .with_state(store)
         .layer(middleware::from_fn(server::kinesis_413_middleware));
 
     #[cfg(feature = "access-log")]
@@ -118,13 +134,19 @@ pub fn create_app_with_capture(
             .on_response(DefaultOnResponse::new().level(tracing::Level::INFO)),
     );
 
+    app
+}
+
+#[cfg(feature = "rt")]
+fn spawn_retention_reaper(store: &Store, options: &StoreOptions) {
     if options.retention_check_interval_secs > 0 {
         let reaper_store = store.clone();
-        tokio::spawn(retention::run_reaper(
+        runtime::spawn_background(retention::run_reaper(
             reaper_store,
             options.retention_check_interval_secs,
         ));
     }
-
-    (app, store)
 }
+
+#[cfg(not(feature = "rt"))]
+fn spawn_retention_reaper(_store: &Store, _options: &StoreOptions) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,14 +42,14 @@ pub mod config;
 #[doc(hidden)]
 pub mod constants;
 pub mod error;
-#[cfg(feature = "rt")]
+#[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
 pub mod event_stream;
 pub mod health;
 #[cfg(feature = "mirror")]
 #[doc(hidden)]
 pub mod mirror;
-#[cfg(feature = "rt")]
+#[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
 pub mod retention;
 #[doc(hidden)]
@@ -69,7 +69,9 @@ pub mod validation;
 use axum::Router;
 use axum::middleware;
 use axum::routing::{any, get};
-use store::{Store, StoreOptions};
+use store::Store;
+#[cfg(not(target_arch = "wasm32"))]
+use store::StoreOptions;
 #[cfg(feature = "access-log")]
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 
@@ -98,14 +100,15 @@ use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 ///     axum::serve(listener, app).await.unwrap();
 /// }
 /// ```
+#[cfg(not(target_arch = "wasm32"))]
 pub fn create_app(options: StoreOptions) -> (Router, Store) {
     let store = Store::new(options.clone());
-    let app = build_app(store.clone());
+    let app = create_router(store.clone());
     spawn_retention_reaper(&store, &options);
     (app, store)
 }
 
-#[cfg(feature = "server")]
+#[cfg(all(feature = "server", not(target_arch = "wasm32")))]
 /// Like [`create_app`], but accepts an optional [`capture::CaptureWriter`] to record
 /// PutRecord/PutRecords calls to an NDJSON file.
 pub fn create_app_with_capture(
@@ -113,12 +116,16 @@ pub fn create_app_with_capture(
     capture: Option<capture::CaptureWriter>,
 ) -> (Router, Store) {
     let store = Store::with_capture(options.clone(), capture);
-    let app = build_app(store.clone());
+    let app = create_router(store.clone());
     spawn_retention_reaper(&store, &options);
     (app, store)
 }
 
-fn build_app(store: Store) -> Router {
+/// Creates an Axum [`Router`] around an existing [`store::Store`].
+///
+/// Unlike [`create_app`], this does not spawn any background maintenance tasks.
+/// It is intended for embedded or in-process use cases, including the wasm wrapper.
+pub fn create_router(store: Store) -> Router {
     let app = Router::new()
         .route("/_health", get(health::health))
         .route("/_health/live", get(health::live))
@@ -137,7 +144,7 @@ fn build_app(store: Store) -> Router {
     app
 }
 
-#[cfg(feature = "rt")]
+#[cfg(not(target_arch = "wasm32"))]
 fn spawn_retention_reaper(store: &Store, options: &StoreOptions) {
     if options.retention_check_interval_secs > 0 {
         let reaper_store = store.clone();
@@ -148,5 +155,44 @@ fn spawn_retention_reaper(store: &Store, options: &StoreOptions) {
     }
 }
 
-#[cfg(not(feature = "rt"))]
-fn spawn_retention_reaper(_store: &Store, _options: &StoreOptions) {}
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::actions::{Operation, dispatch};
+    use crate::types::StreamStatus;
+    use serde_json::json;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn create_app_preserves_background_transitions() {
+        let (_app, store) = create_app(StoreOptions {
+            create_stream_ms: 1,
+            ..StoreOptions::default()
+        });
+
+        dispatch(
+            &store,
+            Operation::CreateStream,
+            json!({
+                "StreamName": "native-no-default-features",
+                "ShardCount": 1,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let stream = store
+            .get_stream("native-no-default-features")
+            .await
+            .unwrap();
+        assert_eq!(stream.stream_status, StreamStatus::Creating);
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let stream = store
+            .get_stream("native-no-default-features")
+            .await
+            .unwrap();
+        assert_eq!(stream.stream_status, StreamStatus::Active);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@ pub mod health;
 #[cfg(feature = "mirror")]
 #[doc(hidden)]
 pub mod mirror;
-#[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
 pub mod retention;
 #[doc(hidden)]

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -254,7 +254,7 @@ impl Mirror {
             }
         };
         let mirror = Arc::clone(self);
-        tokio::spawn(async move {
+        crate::runtime::spawn_background(async move {
             mirror
                 .forward(&target, &content_type, body, local_result)
                 .await;

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -2,9 +2,10 @@ use crate::store::Store;
 use crate::types::StreamStatus;
 
 pub async fn run_reaper(store: Store, interval_secs: u64) {
-    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(interval_secs));
+    let interval_ms = interval_secs.saturating_mul(1000);
+    sweep_once(&store).await;
     loop {
-        interval.tick().await;
+        crate::runtime::sleep_ms(interval_ms).await;
         sweep_once(&store).await;
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,32 @@
+use std::future::Future;
+
+#[cfg(feature = "rt")]
+pub fn spawn_background<F>(future: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(future);
+}
+
+#[cfg(all(not(feature = "rt"), feature = "wasm"))]
+pub fn spawn_background<F>(future: F)
+where
+    F: Future<Output = ()> + 'static,
+{
+    wasm_bindgen_futures::spawn_local(future);
+}
+
+#[cfg(all(not(feature = "rt"), not(feature = "wasm")))]
+pub fn spawn_background<F>(_future: F)
+where
+    F: Future<Output = ()> + 'static,
+{
+}
+
+#[cfg(feature = "rt")]
+pub async fn sleep_ms(ms: u64) {
+    tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+}
+
+#[cfg(not(feature = "rt"))]
+pub async fn sleep_ms(_ms: u64) {}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -22,4 +22,24 @@ pub async fn sleep_ms(ms: u64) {
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "wasm"))]
-pub async fn sleep_ms(_ms: u64) {}
+pub async fn sleep_ms(ms: u64) {
+    use js_sys::{Function, Promise, Reflect};
+    use wasm_bindgen::{JsCast, JsValue};
+
+    let global = js_sys::global();
+    let set_timeout = Reflect::get(&global, &JsValue::from_str("setTimeout"))
+        .expect("globalThis.setTimeout unavailable")
+        .dyn_into::<Function>()
+        .expect("globalThis.setTimeout is not a function");
+
+    let delay = JsValue::from_f64(ms.min(i32::MAX as u64) as f64);
+    let promise = Promise::new(&mut |resolve, _reject| {
+        set_timeout
+            .call2(&global, &resolve, &delay)
+            .expect("globalThis.setTimeout call failed");
+    });
+
+    wasm_bindgen_futures::JsFuture::from(promise)
+        .await
+        .expect("globalThis.setTimeout promise rejected");
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-#[cfg(feature = "rt")]
+#[cfg(not(target_arch = "wasm32"))]
 pub fn spawn_background<F>(future: F)
 where
     F: Future<Output = ()> + Send + 'static,
@@ -8,7 +8,7 @@ where
     tokio::spawn(future);
 }
 
-#[cfg(all(not(feature = "rt"), feature = "wasm"))]
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 pub fn spawn_background<F>(future: F)
 where
     F: Future<Output = ()> + 'static,
@@ -16,17 +16,10 @@ where
     wasm_bindgen_futures::spawn_local(future);
 }
 
-#[cfg(all(not(feature = "rt"), not(feature = "wasm")))]
-pub fn spawn_background<F>(_future: F)
-where
-    F: Future<Output = ()> + 'static,
-{
-}
-
-#[cfg(feature = "rt")]
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn sleep_ms(ms: u64) {
     tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
 }
 
-#[cfg(not(feature = "rt"))]
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 pub async fn sleep_ms(_ms: u64) {}

--- a/src/server.rs
+++ b/src/server.rs
@@ -357,6 +357,7 @@ pub async fn handler(
 
     // Handle SubscribeToShard separately (streaming response)
     if operation == Operation::SubscribeToShard {
+        #[cfg(feature = "rt")]
         return match actions::subscribe_to_shard::execute_streaming(
             &store,
             data,
@@ -377,6 +378,15 @@ pub async fn handler(
                 log_and_send_error(&span, &response_headers, response_content_type, err)
             }
         };
+
+        #[cfg(not(feature = "rt"))]
+        {
+            let err = KinesisErrorResponse::client_error(
+                constants::INVALID_ARGUMENT,
+                Some("SubscribeToShard is not supported in this build."),
+            );
+            return log_and_send_error(&span, &response_headers, response_content_type, &err);
+        }
     }
 
     // Execute action

--- a/src/server.rs
+++ b/src/server.rs
@@ -357,7 +357,7 @@ pub async fn handler(
 
     // Handle SubscribeToShard separately (streaming response)
     if operation == Operation::SubscribeToShard {
-        #[cfg(feature = "rt")]
+        #[cfg(not(target_arch = "wasm32"))]
         return match actions::subscribe_to_shard::execute_streaming(
             &store,
             data,
@@ -379,7 +379,7 @@ pub async fn handler(
             }
         };
 
-        #[cfg(not(feature = "rt"))]
+        #[cfg(target_arch = "wasm32")]
         {
             let err = KinesisErrorResponse::client_error(
                 constants::INVALID_ARGUMENT,

--- a/src/store.rs
+++ b/src/store.rs
@@ -152,6 +152,7 @@ pub struct Store {
     pub aws_region: String,
     inner: Arc<StoreInner>,
     /// Optional capture writer for recording PutRecord/PutRecords calls.
+    #[cfg(feature = "server")]
     pub(crate) capture_writer: Option<crate::capture::CaptureWriter>,
 }
 
@@ -177,9 +178,18 @@ impl Store {
     /// Strips non-digit characters from `options.aws_account_id` and warns if
     /// the result is not exactly 12 digits.
     pub fn new(options: StoreOptions) -> Self {
-        Self::with_capture(options, None)
+        #[cfg(feature = "server")]
+        {
+            Self::build(options, None)
+        }
+
+        #[cfg(not(feature = "server"))]
+        {
+            Self::build(options)
+        }
     }
 
+    #[cfg(feature = "server")]
     /// Creates a new store with an optional [`crate::capture::CaptureWriter`]
     /// to record PutRecord/PutRecords calls to an NDJSON file.
     ///
@@ -188,6 +198,13 @@ impl Store {
     pub fn with_capture(
         options: StoreOptions,
         capture_writer: Option<crate::capture::CaptureWriter>,
+    ) -> Self {
+        Self::build(options, capture_writer)
+    }
+
+    fn build(
+        options: StoreOptions,
+        #[cfg(feature = "server")] capture_writer: Option<crate::capture::CaptureWriter>,
     ) -> Self {
         let aws_account_id: String = options
             .aws_account_id
@@ -216,6 +233,7 @@ impl Store {
                 resource_tags: DashMap::new(),
                 account_settings: RwLock::new(Value::Object(Default::default())),
             }),
+            #[cfg(feature = "server")]
             capture_writer,
         }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -21,8 +21,6 @@ use crate::sequence;
 use crate::types::{Consumer, StoredRecord, Stream, StreamStatus};
 use crate::util::current_time_ms;
 use dashmap::DashMap;
-use num_bigint::BigUint;
-use num_traits::Zero;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -726,7 +724,7 @@ impl Store {
     pub async fn allocate_sequence(
         &self,
         name: &str,
-        hash_key: &BigUint,
+        hash_key: &u128,
     ) -> Result<SequenceAllocation, KinesisErrorResponse> {
         let entry = self
             .inner
@@ -761,7 +759,7 @@ impl Store {
 
         let seq_num = sequence::stringify_sequence(&sequence::SeqObj {
             shard_create_time,
-            seq_ix: Some(BigUint::from(current_seq_ix)),
+            seq_ix: Some(current_seq_ix),
             byte1: None,
             seq_time: Some(now),
             seq_rand: None,
@@ -785,7 +783,7 @@ impl Store {
     pub async fn allocate_sequences_batch(
         &self,
         name: &str,
-        hash_keys: &[BigUint],
+        hash_keys: &[u128],
     ) -> Result<Vec<SequenceAllocation>, KinesisErrorResponse> {
         let entry = self
             .inner
@@ -818,7 +816,7 @@ impl Store {
 
             let seq_num = sequence::stringify_sequence(&sequence::SeqObj {
                 shard_create_time,
-                seq_ix: Some(BigUint::from(current_seq_ix)),
+                seq_ix: Some(current_seq_ix),
                 byte1: None,
                 seq_time: Some(now),
                 seq_rand: None,
@@ -883,19 +881,11 @@ async fn sync_shard_seq(entry: &StreamEntry, stream: &Stream) {
 }
 
 /// Route a hash key to the appropriate open shard. Returns `(shard_ix, shard_id, create_time_ms)`.
-fn route_hash_to_shard(stream: &Stream, hash_key: &BigUint) -> (i64, String, u64) {
+fn route_hash_to_shard(stream: &Stream, hash_key: &u128) -> (i64, String, u64) {
     for (i, shard) in stream.shards.iter().enumerate() {
         if shard.sequence_number_range.ending_sequence_number.is_none() {
-            let start: BigUint = shard
-                .hash_key_range
-                .starting_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
-            let end: BigUint = shard
-                .hash_key_range
-                .ending_hash_key
-                .parse()
-                .unwrap_or_else(|_| BigUint::zero());
+            let start = shard.hash_key_range.start_u128();
+            let end = shard.hash_key_range.end_u128();
             if *hash_key >= start && *hash_key <= end {
                 let create_time =
                     sequence::parse_sequence(&shard.sequence_number_range.starting_sequence_number)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,16 @@
 /// Returns the current time in milliseconds since the Unix epoch.
+#[cfg(not(all(feature = "wasm", target_arch = "wasm32", not(target_os = "wasi"))))]
 pub fn current_time_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_millis() as u64
+}
+
+/// Returns the current time in milliseconds since the Unix epoch.
+#[cfg(all(feature = "wasm", target_arch = "wasm32", not(target_os = "wasi")))]
+pub fn current_time_ms() -> u64 {
+    js_sys::Date::now() as u64
 }
 
 pub use ferrokinesis_core::util::base64_decoded_len;

--- a/tests/get_shard_iterator.rs
+++ b/tests/get_shard_iterator.rs
@@ -2,7 +2,6 @@ mod common;
 
 use common::*;
 use ferrokinesis::sequence::{SeqObj, stringify_sequence};
-use num_bigint::BigUint;
 use serde_json::{Value, json};
 
 #[tokio::test]
@@ -336,7 +335,7 @@ async fn get_shard_iterator_at_seq_version_mismatch() {
 
     let fake_seq = stringify_sequence(&SeqObj {
         shard_create_time: 1000,
-        seq_ix: Some(BigUint::from(0u32)),
+        seq_ix: Some(0),
         byte1: None,
         seq_time: Some(1000),
         seq_rand: None,

--- a/tests/prop_hash_space_coverage.rs
+++ b/tests/prop_hash_space_coverage.rs
@@ -75,8 +75,6 @@ fn prop_hash_space_fully_partitioned() {
 /// P2: MD5 hash of any partition key is within [0, 2^128).
 #[test]
 fn prop_md5_hash_in_range() {
-    let pow_128 = BigUint::one() << 128;
-
     let mut runner = TestRunner::new(Config {
         cases: 256,
         ..Config::default()
@@ -85,12 +83,13 @@ fn prop_md5_hash_in_range() {
     runner
         .run(&"[\\PC]{1,256}", |pk| {
             let hash = partition_key_to_hash_key(&pk);
-            prop_assert!(
-                hash < pow_128,
-                "hash {} for partition key {:?} is >= 2^128",
-                hash,
-                pk
-            );
+            // u128 is always in [0, 2^128-1] by definition; verify determinism
+            let hash2 = partition_key_to_hash_key(&pk);
+            prop_assert_eq!(hash, hash2, "MD5 hash not deterministic for {:?}", pk);
+            // Non-empty keys should produce non-zero hashes (extremely unlikely to be 0)
+            if !pk.is_empty() {
+                prop_assert!(hash > 0, "non-empty key {:?} produced zero hash", pk);
+            }
             Ok(())
         })
         .unwrap();

--- a/tests/prop_sequence_roundtrip.rs
+++ b/tests/prop_sequence_roundtrip.rs
@@ -2,7 +2,6 @@
 // is cheap and provides strong coverage of the sequence number encoding space.
 
 use ferrokinesis::sequence::{SeqObj, parse_sequence, stringify_sequence};
-use num_bigint::BigUint;
 use proptest::prelude::*;
 mod common;
 use common::prop_runner;
@@ -34,7 +33,7 @@ fn prop_sequence_roundtrip_identity() {
 
             let obj = SeqObj {
                 shard_create_time,
-                seq_ix: Some(BigUint::from(seq_ix)),
+                seq_ix: Some(seq_ix),
                 byte1: None,
                 seq_time: Some(seq_time),
                 seq_rand: None,

--- a/tests/put_record.rs
+++ b/tests/put_record.rs
@@ -3,7 +3,6 @@ mod common;
 use common::*;
 use ferrokinesis::sequence::{SeqObj, stringify_sequence};
 use ferrokinesis::store::StoreOptions;
-use num_bigint::BigUint;
 use serde_json::{Value, json};
 
 #[tokio::test]
@@ -210,7 +209,7 @@ async fn put_record_seq_for_ordering_future_time() {
 
     let future_seq = stringify_sequence(&SeqObj {
         shard_create_time: 1_000_000_000,
-        seq_ix: Some(BigUint::from(0u32)),
+        seq_ix: Some(0),
         byte1: None,
         seq_time: Some(future_ms),
         seq_rand: None,

--- a/tests/retention_reaper.rs
+++ b/tests/retention_reaper.rs
@@ -6,7 +6,6 @@ use ferrokinesis::sequence;
 use ferrokinesis::store::StoreOptions;
 use ferrokinesis::types::StoredRecord;
 use ferrokinesis::util::current_time_ms;
-use num_bigint::BigUint;
 use serde_json::json;
 
 /// Insert a record with a fabricated sequence number at the given `seq_time`.
@@ -20,7 +19,7 @@ async fn insert_backdated_record(
 ) {
     let seq = sequence::stringify_sequence(&sequence::SeqObj {
         shard_create_time,
-        seq_ix: Some(BigUint::from(seq_ix)),
+        seq_ix: Some(seq_ix),
         seq_time: Some(seq_time),
         shard_ix,
         byte1: None,

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -2,7 +2,6 @@ use ferrokinesis::sequence::{
     SeqObj, increment_sequence, parse_sequence, resolve_shard_id, shard_id_name, shard_ix_to_hex,
     stringify_sequence,
 };
-use num_bigint::BigUint;
 
 // -- Version 0 stringify/parse roundtrip --
 
@@ -49,7 +48,7 @@ fn stringify_v0_non_zero_shard() {
 fn stringify_parse_v1_roundtrip() {
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(7u64)),
+        seq_ix: Some(7),
         byte1: Some("ab".to_string()),
         seq_time: Some(1_600_000_001_000),
         seq_rand: Some("00000000000000".to_string()), // 14 chars
@@ -69,7 +68,7 @@ fn stringify_parse_v1_roundtrip() {
 fn stringify_v1_with_shard_ix_5() {
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(42u64)),
+        seq_ix: Some(42),
         byte1: Some("00".to_string()),
         seq_time: Some(1_600_000_002_000),
         seq_rand: Some("11111111111111".to_string()),
@@ -88,7 +87,7 @@ fn stringify_v1_with_shard_ix_5() {
 fn increment_sequence_with_explicit_time() {
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(0u64)),
+        seq_ix: Some(0),
         byte1: Some("00".to_string()),
         seq_time: Some(1_600_000_001_000),
         seq_rand: None,
@@ -106,7 +105,7 @@ fn increment_sequence_with_explicit_time() {
 fn increment_sequence_without_explicit_time() {
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(0u64)),
+        seq_ix: Some(0),
         byte1: Some("00".to_string()),
         seq_time: Some(1_600_000_001_000),
         seq_rand: None,
@@ -125,7 +124,7 @@ fn increment_sequence_from_parsed() {
     // Get a real sequence from a v2 stringify/parse cycle, then increment it
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(100u64)),
+        seq_ix: Some(100),
         byte1: Some("00".to_string()),
         seq_time: Some(1_600_000_010_000),
         seq_rand: None,
@@ -221,12 +220,9 @@ fn parse_sequence_empty_string() {
 
 #[test]
 fn parse_v2_negative_shard_ix() {
-    use ferrokinesis::sequence::{SeqObj, parse_sequence, stringify_sequence};
-    use num_bigint::BigUint;
-
     let obj = SeqObj {
         shard_create_time: 1_600_000_000_000,
-        seq_ix: Some(BigUint::from(0u32)),
+        seq_ix: Some(0),
         byte1: Some("00".to_string()),
         seq_time: Some(1_600_000_001_000),
         seq_rand: None,


### PR DESCRIPTION
## Summary

This PR lands Phase 1 of the WASM/browser work from #60 as a standalone change.

It now does five things:
- splits the crate feature graph into `server`, `rt`, and `wasm` so the reusable library can compile for `wasm32-unknown-unknown` without Tokio networking
- adds a small runtime shim for background task spawning and sleeps, and routes delayed state transitions through it
- adds a new `ferrokinesis-wasm` wrapper crate that exposes a JS-friendly request bridge over `Router::oneshot()`
- adds CI coverage for the wasm-target library build and the Node-backed wasm wrapper test path
- pulls in the sequence write-path refactor from #190 so this branch stays compatible with `main`

## Notes

- This is intentionally Phase 1 only.
- `SubscribeToShard` is explicitly unsupported in no-`rt` / wasm builds in this phase.
- The server/binary behavior remains intact behind the `server` feature, which stays in the default feature set.
- The branch now uses `u64` for `SeqObj::seq_ix` and `u128` for write-path hash key comparisons where fixed-width integers are sufficient. `BigUint` remains only where wider values are still required, such as full sequence-number parse/stringify and `2^128` shard-space division.
- This also fixes the current WASM CI failure in `wasm-pack test --node crates/ferrokinesis-wasm`, where the test fixture still constructed `seq_ix` as a `BigUint` after the write-path migration.

## Testing

- `cargo check`
- `cargo test --no-run`
- `cargo check --target wasm32-unknown-unknown --no-default-features --features wasm`
- `cargo test -p ferrokinesis-wasm --target wasm32-unknown-unknown --no-run`
- `wasm-pack test --node crates/ferrokinesis-wasm`
- `cargo test --workspace --lib`
- `cargo test --test health_check_cli --test request_body_limit --test event_stream`

Part of #60.
