### PR TITLE
feat(wasm): Add GitHub Pages browser demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,42 @@ jobs:
       - name: Test (TLS)
         run: cargo test --features tls
 
+  browser-demo:
+    name: Browser Demo
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust-toolchain
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: demo/package-lock.json
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --version 0.14.0 --locked
+      - name: Install demo dependencies
+        run: npm ci --prefix demo
+      - name: Install Playwright browser
+        run: |
+          cd demo
+          npx playwright install --with-deps chromium
+      - name: Browser demo smoke test
+        run: npm --prefix demo run test:smoke
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            demo/playwright-report/
+            demo/test-results/
+
   coverage:
     name: Coverage
     if: github.event_name != 'schedule'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Browser Demo
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: browser-demo-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Pages Artifact
+    runs-on: ubuntu-latest
+    env:
+      VITE_BASE_PATH: /${{ github.event.repository.name }}/
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: ./.github/actions/setup-rust-toolchain
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: demo/package-lock.json
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --version 0.14.0 --locked
+      - name: Install demo dependencies
+        run: npm ci --prefix demo
+      - name: Build browser demo
+        run: npm --prefix demo run build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: demo/dist
+
+  deploy:
+    name: Deploy Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ examples/node/node_modules/
 examples/go/quickstart
 examples/go/quickstart_tls
 examples/python/__pycache__/
+demo/node_modules/
+demo/dist/
+demo/playwright-report/
+demo/test-results/
+demo/src/generated/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@
 
 A local AWS Kinesis mock server for testing, written in Rust.
 
+## Browser Demo
+
+Try ferrokinesis without installing anything:
+
+[![Open browser demo](https://img.shields.io/badge/Open-browser_demo-102318?style=for-the-badge&logo=googlechrome&logoColor=CDF564)](https://mandrean.github.io/ferrokinesis/)
+
+The GitHub Pages demo runs the in-process WASM wrapper entirely in your browser. It keeps state in memory only, so refresh or `Reset state` starts you from a clean slate.
+
+Run it locally with:
+
+```sh
+npm ci --prefix demo
+npm --prefix demo run dev
+```
+
 ## Features
 
 - Pure Rust implementation
@@ -65,6 +80,14 @@ wasmtime run --wasi tcp-listen=0.0.0.0:4567 target/wasm32-wasip2/debug/ferrokine
 
 The WASI binary is env-configured only. It currently targets the normal JSON/CBOR request path and health endpoints; `SubscribeToShard` remains unsupported there for now.
 
+### Browser Demo
+
+Build the browser demo and its generated WASM package:
+
+```sh
+npm ci --prefix demo
+npm --prefix demo run build
+```
 ### Docker
 
 ```sh

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>ferrokinesis browser demo</title>
+    <meta
+      name="description"
+      content="Try AWS Kinesis API calls in your browser with ferrokinesis."
+    />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="hero">
+        <p class="eyebrow">GitHub Pages browser demo</p>
+        <div class="hero-copy">
+          <div>
+            <h1>Try Kinesis in your browser</h1>
+            <p class="hero-text">
+              A zero-install ferrokinesis demo running entirely in-browser with one
+              in-memory Kinesis instance per page load.
+            </p>
+          </div>
+          <div class="hero-note">
+            <span class="hero-note-label">State model</span>
+            <p>
+              No backend. No persistence. Refresh or <strong>Reset state</strong> for a
+              clean slate.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <main class="workspace">
+        <section class="panel panel-request" aria-labelledby="request-panel-title">
+          <div class="panel-header">
+            <div>
+              <p class="panel-kicker">Request</p>
+              <h2 id="request-panel-title">Preset-driven API calls</h2>
+            </div>
+            <p class="panel-copy">
+              Pick a guided operation, tweak the JSON body, and send it through the
+              in-process WASM wrapper.
+            </p>
+          </div>
+
+          <div class="preset-block">
+            <div class="preset-header">
+              <h3>Guided presets</h3>
+              <p>Terminal look, explicit controls.</p>
+            </div>
+            <div id="preset-list" class="preset-list" aria-label="Operation presets"></div>
+            <p id="preset-summary" class="preset-summary"></p>
+          </div>
+
+          <label class="field" for="target-input">
+            <span>Target</span>
+            <input
+              id="target-input"
+              data-testid="target-input"
+              spellcheck="false"
+              autocomplete="off"
+            />
+          </label>
+
+          <label class="field field-body" for="body-input">
+            <span>JSON body</span>
+            <textarea
+              id="body-input"
+              data-testid="body-input"
+              spellcheck="false"
+              rows="16"
+            ></textarea>
+          </label>
+
+          <div class="actions">
+            <button id="send-request" data-testid="send-request" class="button button-primary">
+              Send request
+            </button>
+            <button id="reset-state" data-testid="reset-state" class="button button-secondary">
+              Reset state
+            </button>
+          </div>
+
+          <p id="banner" data-testid="banner" class="banner" role="status" aria-live="polite">
+            Booting browser demo...
+          </p>
+        </section>
+
+        <section class="panel panel-response" aria-labelledby="response-panel-title">
+          <div class="panel-header">
+            <div>
+              <p class="panel-kicker">Response</p>
+              <h2 id="response-panel-title">Status, headers, JSON output</h2>
+            </div>
+            <p class="panel-copy">
+              Responses are shown exactly as the in-browser emulator returns them.
+            </p>
+          </div>
+
+          <div class="response-meta">
+            <div class="metric">
+              <span class="metric-label">Status</span>
+              <strong id="response-status" data-testid="response-status">Ready</strong>
+            </div>
+            <div class="metric">
+              <span class="metric-label">Duration</span>
+              <strong id="response-duration">--</strong>
+            </div>
+          </div>
+
+          <div class="output-block">
+            <div class="output-header">
+              <h3>Headers</h3>
+            </div>
+            <pre id="headers-output" data-testid="headers-output" class="output">{}</pre>
+          </div>
+
+          <div class="output-block output-block-body">
+            <div class="output-header">
+              <h3>Body</h3>
+            </div>
+            <pre id="response-output" data-testid="response-body" class="output">
+Select a preset and send a request to see the response payload.
+            </pre>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -1,0 +1,1220 @@
+{
+  "name": "ferrokinesis-browser-demo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ferrokinesis-browser-demo",
+      "devDependencies": {
+        "@playwright/test": "^1.54.2",
+        "typescript": "^5.9.3",
+        "vite": "^7.1.12"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.1.tgz",
+      "integrity": "sha512-xB0b51TB7IfDEzAojXahmr+gfA00uYVInJGgNNkeQG6RPnCPGr7udsylFLTubuIUSRE6FkcI1NElyRt83PP5oQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.1.tgz",
+      "integrity": "sha512-XOjPId0qwSDKHaIsdzHJtKCxX0+nH8MhBwvrNsT7tVyKmdTx1jJ4XzN5RZXCdTzMpufLb+B8llTC0D8uCrLhcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.1.tgz",
+      "integrity": "sha512-vQuRd28p0gQpPrS6kppd8IrWmFo42U8Pz1XLRjSZXq5zCqyMDYFABT7/sywL11mO1EL10Qhh7MVPEwkG8GiBeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.1.tgz",
+      "integrity": "sha512-x6VG6U29+Ivlnajrg1IHdzXeAwSoEHBFVO+CtC9Brugx6de712CUJobRUxsIA0KYrQvCmzNrMPFTT1A4CCqNTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.1.tgz",
+      "integrity": "sha512-Sgi0Uo6t1YCHJMNO3Y8+bm+SvOanUGkoZKn/VJPwYUe2kp31X5KnXmzKd/NjW8iA3gFcfNZ64zh14uOGrIllCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.1.tgz",
+      "integrity": "sha512-AM4xnwEZwukdhk7laMWfzWu9JGSVnJd+Fowt6Fd7QW1nrf3h0Hp7Qx5881M4aqrUlKBCybOxz0jofvIIfl7C5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.1.tgz",
+      "integrity": "sha512-KUizqxpwaR2AZdAUsMWfL/C94pUu7TKpoPd88c8yFVixJ+l9hejkrwoK5Zj3wiNh65UeyryKnJyxL1b7yNqFQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.1.tgz",
+      "integrity": "sha512-MZoQ/am77ckJtZGFAtPucgUuJWiop3m2R3lw7tC0QCcbfl4DRhQUBUkHWCkcrT3pqy5Mzv5QQgY6Dmlba6iTWg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.1.tgz",
+      "integrity": "sha512-Sez95TP6xGjkWB1608EfhCX1gdGrO5wzyN99VqzRtC17x/1bhw5VU1V0GfKUwbW/Xr1J8mSasoFoJa6Y7aGGSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.1.tgz",
+      "integrity": "sha512-9Cs2Seq98LWNOJzR89EGTZoiP8EkZ9UbQhBlDgfAkM6asVna1xJ04W2CLYWDN/RpUgOjtQvcv8wQVi1t5oQazA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.1.tgz",
+      "integrity": "sha512-n9yqttftgFy7IrNEnHy1bOp6B4OSe8mJDiPkT7EqlM9FnKOwUMnCK62ixW0Kd9Clw0/wgvh8+SqaDXMFvw3KqQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.1.tgz",
+      "integrity": "sha512-SfpNXDzVTqs/riak4xXcLpq5gIQWsqGWMhN1AGRQKB4qGSs4r0sEs3ervXPcE1O9RsQ5bm8Muz6zmQpQnPss1g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.1.tgz",
+      "integrity": "sha512-LjaChED0wQnjKZU+tsmGbN+9nN1XhaWUkAlSbTdhpEseCS4a15f/Q8xC2BN4GDKRzhhLZpYtJBZr2NZhR0jvNw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.1.tgz",
+      "integrity": "sha512-ojW7iTJSIs4pwB2xV6QXGwNyDctvXOivYllttuPbXguuKDX5vwpqYJsHc6D2LZzjDGHML414Tuj3LvVPe1CT1A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.1.tgz",
+      "integrity": "sha512-FP+Q6WTcxxvsr0wQczhSE+tOZvFPV8A/mUE6mhZYFW9/eea/y/XqAgRoLLMuE9Cz0hfX5bi7p116IWoB+P237A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.1.tgz",
+      "integrity": "sha512-L1uD9b/Ig8Z+rn1KttCJjwhN1FgjRMBKsPaBsDKkfUl7GfFq71pU4vWCnpOsGljycFEbkHWARZLf4lMYg3WOLw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.1.tgz",
+      "integrity": "sha512-EZc9NGTk/oSUzzOD4nYY4gIjteo2M3CiozX6t1IXGCOdgxJTlVu/7EdPeiqeHPSIrxkLhavqpBAUCfvC6vBOug==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.1.tgz",
+      "integrity": "sha512-NQ9KyU1Anuy59L8+HHOKM++CoUxrQWrZWXRik4BJFm+7i5NP6q/SW43xIBr80zzt+PDBJ7LeNmloQGfa0JGk0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.1.tgz",
+      "integrity": "sha512-GZkLk2t6naywsveSFBsEb0PLU+JC9ggVjbndsbG20VPhar6D1gkMfCx4NfP9owpovBXTN+eRdqGSkDGIxPHhmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.1.tgz",
+      "integrity": "sha512-1hjG9Jpl2KDOetr64iQd8AZAEjkDUUK5RbDkYWsViYLC1op1oNzdjMJeFiofcGhqbNTaY2kfgqowE7DILifsrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.1.tgz",
+      "integrity": "sha512-ARoKfflk0SiiYm3r1fmF73K/yB+PThmOwfWCk1sr7x/k9dc3uGLWuEE9if+Pw21el8MSpp3TMnG5vLNsJ/MMGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.1.tgz",
+      "integrity": "sha512-oOST61G6VM45Mz2vdzWMr1s2slI7y9LqxEV5fCoWi2MDONmMvgsJVHSXxce/I2xOSZPTZ47nDPOl1tkwKWSHcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.1.tgz",
+      "integrity": "sha512-x5WgLi5dWpRz7WclKBGEF15LcWTh0ewrHM6Cq4A+WUbkysUMZNeqt05bwPonOQ3ihPS/WMhAZV5zB1DfnI4Sxg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.1.tgz",
+      "integrity": "sha512-wS+zHAJRVP5zOL0e+a3V3E/NTEwM2HEvvNKoDy5Xcfs0o8lljxn+EAFPkUsxihBdmDq1JWzXmmB9cbssCPdxxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.1.tgz",
+      "integrity": "sha512-rhHyrMeLpErT/C7BxcEsU4COHQUzHyrPYW5tOZUeUhziNtRuYxmDWvqQqzpuUt8xpOgmbKa1btGXfnA/ANVO+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.1.tgz",
+      "integrity": "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.1",
+        "@rollup/rollup-android-arm64": "4.59.1",
+        "@rollup/rollup-darwin-arm64": "4.59.1",
+        "@rollup/rollup-darwin-x64": "4.59.1",
+        "@rollup/rollup-freebsd-arm64": "4.59.1",
+        "@rollup/rollup-freebsd-x64": "4.59.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.1",
+        "@rollup/rollup-linux-arm64-musl": "4.59.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.1",
+        "@rollup/rollup-linux-loong64-musl": "4.59.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.1",
+        "@rollup/rollup-linux-x64-gnu": "4.59.1",
+        "@rollup/rollup-linux-x64-musl": "4.59.1",
+        "@rollup/rollup-openbsd-x64": "4.59.1",
+        "@rollup/rollup-openharmony-arm64": "4.59.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.1",
+        "@rollup/rollup-win32-x64-gnu": "4.59.1",
+        "@rollup/rollup-win32-x64-msvc": "4.59.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    }
+  }
+}

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ferrokinesis-browser-demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:wasm": "node ./scripts/build-wasm.mjs",
+    "dev": "npm run build:wasm && vite",
+    "build": "npm run build:wasm && vite build",
+    "preview": "vite preview --host 127.0.0.1 --port 4173",
+    "test:smoke": "npm run build && playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.2",
+    "typescript": "^5.9.3",
+    "vite": "^7.1.12"
+  }
+}

--- a/demo/playwright.config.ts
+++ b/demo/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+
+const cwd = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  timeout: 60_000,
+  reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    headless: true,
+  },
+  webServer: {
+    command: "npm run preview",
+    cwd,
+    url: "http://127.0.0.1:4173",
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/demo/scripts/build-wasm.mjs
+++ b/demo/scripts/build-wasm.mjs
@@ -1,0 +1,55 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..", "..");
+const crateDir = path.join(repoRoot, "crates", "ferrokinesis-wasm");
+const outDir = path.join(repoRoot, "demo", "src", "generated");
+const relativeOutDir = path.relative(crateDir, outDir);
+const useWasmOpt = process.env.FERROKINESIS_WASM_OPT === "1";
+
+rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+const args = [
+  "build",
+  ".",
+  "--target",
+  "web",
+  "--release",
+  "--out-dir",
+  relativeOutDir,
+  "--out-name",
+  "ferrokinesis_wasm",
+];
+
+if (!useWasmOpt) {
+  args.push("--no-opt");
+}
+
+console.log(
+  `Building browser WASM package (${useWasmOpt ? "with wasm-opt" : "without wasm-opt"})...`,
+);
+
+const result = spawnSync("wasm-pack", args, {
+  cwd: crateDir,
+  stdio: "inherit",
+});
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+const wasmPath = path.join(outDir, "ferrokinesis_wasm_bg.wasm");
+const jsPath = path.join(outDir, "ferrokinesis_wasm.js");
+
+console.log(`WASM size: ${formatBytes(statSync(wasmPath).size)}`);
+console.log(`JS glue size: ${formatBytes(statSync(jsPath).size)}`);
+
+function formatBytes(size) {
+  const kib = size / 1024;
+  const mib = kib / 1024;
+  return `${size} bytes (${kib.toFixed(1)} KiB / ${mib.toFixed(2)} MiB)`;
+}

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -228,7 +228,10 @@ async function createKinesis(): Promise<Kinesis> {
 }
 
 async function ensureWasmInitialized(): Promise<void> {
-  wasmInitPromise ??= init();
+  wasmInitPromise ??= init().catch((error) => {
+    wasmInitPromise = null;
+    throw error;
+  });
   await wasmInitPromise;
 }
 

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -1,0 +1,362 @@
+import "./style.css";
+import init, { Kinesis } from "./generated/ferrokinesis_wasm.js";
+
+type JsonBody = Record<string, unknown>;
+
+type BannerKind = "info" | "success" | "error";
+
+interface KinesisResponse {
+  status: number;
+  body: string;
+  headers: Record<string, string>;
+}
+
+interface DerivedState {
+  streamName: string;
+  shardId: string | null;
+  shardIterator: string | null;
+}
+
+interface Preset {
+  id: string;
+  label: string;
+  summary: string;
+  target: string;
+  buildBody: (state: DerivedState) => JsonBody;
+}
+
+const DEMO_STREAM_NAME = "browser-demo-stream";
+const DEFAULT_SHARD_ID = "shardId-000000000000";
+const DATA_PAYLOAD = "aGVsbG8gZnJvbSBmZXJyb2tpbmVzaXM=";
+
+const KINESIS_OPTIONS = {
+  createStreamMs: 0,
+  deleteStreamMs: 0,
+  updateStreamMs: 0,
+};
+
+const PRESETS: Preset[] = [
+  {
+    id: "create-stream",
+    label: "CreateStream",
+    summary: "Create a one-shard stream so the rest of the demo has something to work with.",
+    target: "Kinesis_20131202.CreateStream",
+    buildBody: (state) => ({
+      StreamName: state.streamName,
+      ShardCount: 1,
+    }),
+  },
+  {
+    id: "put-record",
+    label: "PutRecord",
+    summary: "Write one base64 payload into the demo stream with a stable partition key.",
+    target: "Kinesis_20131202.PutRecord",
+    buildBody: (state) => ({
+      StreamName: state.streamName,
+      PartitionKey: "browser-demo-key",
+      Data: DATA_PAYLOAD,
+    }),
+  },
+  {
+    id: "get-shard-iterator",
+    label: "GetShardIterator",
+    summary: "Get a TRIM_HORIZON iterator for the first shard so records can be read back.",
+    target: "Kinesis_20131202.GetShardIterator",
+    buildBody: (state) => ({
+      StreamName: state.streamName,
+      ShardId: state.shardId ?? DEFAULT_SHARD_ID,
+      ShardIteratorType: "TRIM_HORIZON",
+    }),
+  },
+  {
+    id: "get-records",
+    label: "GetRecords",
+    summary: "Read records using the last iterator returned from the previous response.",
+    target: "Kinesis_20131202.GetRecords",
+    buildBody: (state) => ({
+      ShardIterator:
+        state.shardIterator ?? "run GetShardIterator first to populate this field",
+    }),
+  },
+  {
+    id: "list-streams",
+    label: "ListStreams",
+    summary: "List the streams currently alive inside this in-browser emulator instance.",
+    target: "Kinesis_20131202.ListStreams",
+    buildBody: () => ({}),
+  },
+];
+
+const presetList = mustById<HTMLDivElement>("preset-list");
+const presetSummary = mustById<HTMLParagraphElement>("preset-summary");
+const targetInput = mustById<HTMLInputElement>("target-input");
+const bodyInput = mustById<HTMLTextAreaElement>("body-input");
+const sendRequestButton = mustById<HTMLButtonElement>("send-request");
+const resetStateButton = mustById<HTMLButtonElement>("reset-state");
+const banner = mustById<HTMLParagraphElement>("banner");
+const responseStatus = mustById<HTMLElement>("response-status");
+const responseDuration = mustById<HTMLElement>("response-duration");
+const headersOutput = mustById<HTMLElement>("headers-output");
+const responseOutput = mustById<HTMLElement>("response-output");
+
+let wasmInitPromise: Promise<unknown> | null = null;
+let kinesis: Kinesis | null = null;
+let derivedState = initialDerivedState();
+
+void boot();
+
+async function boot(): Promise<void> {
+  renderPresetButtons();
+  clearResponsePanel();
+  setPending(true);
+  setBanner("info", "Starting a fresh in-browser Kinesis instance...");
+
+  try {
+    kinesis = await createKinesis();
+    selectPreset(PRESETS[0].id);
+    setBanner(
+      "success",
+      "Fresh in-memory instance ready. State resets on refresh or when you click Reset state.",
+    );
+  } catch (error) {
+    renderClientError(error);
+    setBanner("error", errorMessage(error));
+  } finally {
+    setPending(false);
+  }
+}
+
+function renderPresetButtons(): void {
+  presetList.replaceChildren(
+    ...PRESETS.map((preset) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "preset-button";
+      button.dataset.presetId = preset.id;
+      button.setAttribute("data-testid", `preset-${preset.id}`);
+      button.textContent = preset.label;
+      button.addEventListener("click", () => selectPreset(preset.id));
+      return button;
+    }),
+  );
+}
+
+function selectPreset(presetId: string): void {
+  const preset = mustPreset(presetId);
+  presetSummary.textContent = preset.summary;
+  targetInput.value = preset.target;
+  bodyInput.value = formatJson(preset.buildBody(derivedState));
+
+  for (const button of presetList.querySelectorAll<HTMLButtonElement>(".preset-button")) {
+    button.dataset.active = String(button.dataset.presetId === presetId);
+  }
+}
+
+sendRequestButton.addEventListener("click", () => {
+  void sendRequest();
+});
+
+resetStateButton.addEventListener("click", () => {
+  void resetState();
+});
+
+async function sendRequest(): Promise<void> {
+  if (!kinesis) {
+    setBanner("error", "The browser demo is still booting. Try again in a moment.");
+    return;
+  }
+
+  const target = targetInput.value.trim();
+  if (!target) {
+    setBanner("error", "Target is required.");
+    return;
+  }
+
+  const bodyText = bodyInput.value.trim();
+  const parsed = parseJson(bodyText);
+  if (!parsed.ok) {
+    setBanner("error", parsed.message);
+    return;
+  }
+
+  setPending(true);
+  setBanner("info", `Sending ${target}...`);
+
+  const startedAt = performance.now();
+
+  try {
+    syncDerivedStateFromRequest(parsed.value);
+    const response = (await kinesis.request(target, bodyText)) as KinesisResponse;
+    syncDerivedStateFromResponse(target, response.body);
+    renderResponse(response, performance.now() - startedAt);
+    setBanner(
+      response.status >= 400 ? "error" : "success",
+      `${target} completed with HTTP ${response.status}.`,
+    );
+  } catch (error) {
+    renderClientError(error);
+    setBanner("error", errorMessage(error));
+  } finally {
+    setPending(false);
+  }
+}
+
+async function resetState(): Promise<void> {
+  setPending(true);
+  setBanner("info", "Resetting browser state...");
+
+  try {
+    derivedState = initialDerivedState();
+    kinesis = await createKinesis();
+    clearResponsePanel();
+    selectPreset(PRESETS[0].id);
+    setBanner(
+      "success",
+      "State reset. You now have a fresh in-browser Kinesis instance with no streams.",
+    );
+  } catch (error) {
+    renderClientError(error);
+    setBanner("error", errorMessage(error));
+  } finally {
+    setPending(false);
+  }
+}
+
+async function createKinesis(): Promise<Kinesis> {
+  await ensureWasmInitialized();
+  return new Kinesis(KINESIS_OPTIONS);
+}
+
+async function ensureWasmInitialized(): Promise<void> {
+  wasmInitPromise ??= init();
+  await wasmInitPromise;
+}
+
+function clearResponsePanel(): void {
+  responseStatus.textContent = "Ready";
+  responseStatus.dataset.statusClass = "pending";
+  responseDuration.textContent = "--";
+  headersOutput.textContent = "{}";
+  responseOutput.textContent =
+    "Select a preset and send a request to see the response payload.";
+}
+
+function renderResponse(response: KinesisResponse, durationMs: number): void {
+  responseStatus.textContent = String(response.status);
+  responseStatus.dataset.statusClass =
+    response.status >= 500 ? "server-error" : response.status >= 400 ? "client-error" : "ok";
+  responseDuration.textContent = `${durationMs.toFixed(1)} ms`;
+  headersOutput.textContent = formatJson(response.headers);
+  responseOutput.textContent = formatMaybeJsonString(response.body);
+}
+
+function renderClientError(error: unknown): void {
+  responseStatus.textContent = "Client error";
+  responseStatus.dataset.statusClass = "client-error";
+  responseDuration.textContent = "--";
+  headersOutput.textContent = "{}";
+  responseOutput.textContent = errorMessage(error);
+}
+
+function setPending(isPending: boolean): void {
+  sendRequestButton.disabled = isPending;
+  resetStateButton.disabled = isPending;
+  targetInput.disabled = isPending;
+  bodyInput.disabled = isPending;
+  sendRequestButton.textContent = isPending ? "Working..." : "Send request";
+}
+
+function setBanner(kind: BannerKind, message: string): void {
+  banner.textContent = message;
+  banner.dataset.kind = kind;
+}
+
+function syncDerivedStateFromRequest(body: JsonBody): void {
+  if (typeof body.StreamName === "string" && body.StreamName.length > 0) {
+    derivedState.streamName = body.StreamName;
+  }
+}
+
+function syncDerivedStateFromResponse(target: string, responseBody: string): void {
+  const decoded = parseJson(responseBody);
+  if (!decoded.ok) {
+    return;
+  }
+
+  if (target.endsWith(".PutRecord") && typeof decoded.value.ShardId === "string") {
+    derivedState.shardId = decoded.value.ShardId;
+  }
+
+  if (
+    target.endsWith(".GetShardIterator") &&
+    typeof decoded.value.ShardIterator === "string"
+  ) {
+    derivedState.shardIterator = decoded.value.ShardIterator;
+  }
+}
+
+function parseJson(input: string): { ok: true; value: JsonBody } | { ok: false; message: string } {
+  try {
+    const value = JSON.parse(input) as unknown;
+    if (!isRecord(value)) {
+      return { ok: false, message: "JSON body must be an object." };
+    }
+    return { ok: true, value };
+  } catch (error) {
+    return {
+      ok: false,
+      message: `Invalid JSON body: ${errorMessage(error)}`,
+    };
+  }
+}
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function formatMaybeJsonString(input: string): string {
+  if (input.length === 0) {
+    return "{}";
+  }
+
+  try {
+    return JSON.stringify(JSON.parse(input), null, 2);
+  } catch {
+    return input;
+  }
+}
+
+function initialDerivedState(): DerivedState {
+  return {
+    streamName: DEMO_STREAM_NAME,
+    shardId: null,
+    shardIterator: null,
+  };
+}
+
+function mustById<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Missing required element: #${id}`);
+  }
+  return element as T;
+}
+
+function mustPreset(id: string): Preset {
+  const preset = PRESETS.find((candidate) => candidate.id === id);
+  if (!preset) {
+    throw new Error(`Unknown preset: ${id}`);
+  }
+  return preset;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function isRecord(value: unknown): value is JsonBody {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -134,7 +134,7 @@ function renderPresetButtons(): void {
       button.className = "preset-button";
       button.dataset.presetId = preset.id;
       button.setAttribute("data-testid", `preset-${preset.id}`);
-      button.textContent = preset.label;
+      appendOperationLabel(button, preset.label);
       button.addEventListener("click", () => selectPreset(preset.id));
       return button;
     }),
@@ -359,4 +359,15 @@ function errorMessage(error: unknown): string {
 
 function isRecord(value: unknown): value is JsonBody {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function appendOperationLabel(button: HTMLButtonElement, label: string): void {
+  const parts = label.split(/(?=[A-Z])/).filter((part) => part.length > 0);
+
+  parts.forEach((part, index) => {
+    button.append(part);
+    if (index < parts.length - 1) {
+      button.append(document.createElement("wbr"));
+    }
+  });
 }

--- a/demo/src/style.css
+++ b/demo/src/style.css
@@ -204,8 +204,12 @@ button {
 }
 
 .preset-button {
+  min-width: 0;
   padding: 14px 12px;
   text-align: left;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.15;
   background: rgba(20, 33, 27, 0.86);
   color: var(--ink);
 }

--- a/demo/src/style.css
+++ b/demo/src/style.css
@@ -1,0 +1,417 @@
+:root {
+  color-scheme: dark;
+  font-family: "IBM Plex Mono", "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  line-height: 1.5;
+  font-weight: 400;
+  background:
+    radial-gradient(circle at top left, rgba(157, 219, 91, 0.22), transparent 34%),
+    radial-gradient(circle at bottom right, rgba(255, 183, 77, 0.18), transparent 30%),
+    linear-gradient(180deg, #08100d 0%, #091815 48%, #050807 100%);
+  color: #f4ffe8;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  --line: rgba(198, 238, 121, 0.18);
+  --panel: rgba(11, 20, 16, 0.82);
+  --panel-strong: rgba(18, 31, 24, 0.92);
+  --ink: #f4ffe8;
+  --muted: #a3b3a8;
+  --accent: #cdf564;
+  --accent-strong: #92d737;
+  --warn: #ffbf69;
+  --danger: #ff8473;
+  --shadow: 0 18px 48px rgba(0, 0, 0, 0.35);
+  --radius: 22px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+  margin: 0;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(205, 245, 100, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(205, 245, 100, 0.05) 1px, transparent 1px);
+  background-size: 100% 44px, 44px 100%;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.5), transparent);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app-shell {
+  width: min(1360px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0 48px;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: calc(var(--radius) + 6px);
+  padding: 28px;
+  background:
+    linear-gradient(135deg, rgba(146, 215, 55, 0.12), transparent 46%),
+    linear-gradient(180deg, rgba(255, 191, 105, 0.1), transparent 72%),
+    rgba(10, 17, 14, 0.86);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.eyebrow,
+.panel-kicker,
+.hero-note-label,
+.metric-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.73rem;
+  color: var(--accent);
+}
+
+.hero-copy {
+  display: grid;
+  grid-template-columns: minmax(0, 1.8fr) minmax(280px, 1fr);
+  gap: 20px;
+  align-items: end;
+}
+
+.hero h1,
+.panel-header h2,
+.output-header h3,
+.preset-header h3 {
+  margin: 0;
+  font-family: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
+  letter-spacing: -0.02em;
+}
+
+.hero h1 {
+  font-size: clamp(2.6rem, 5vw, 4.4rem);
+  line-height: 0.98;
+  margin-top: 6px;
+}
+
+.hero-text,
+.panel-copy,
+.hero-note p,
+.preset-header p,
+.preset-summary {
+  margin: 0;
+  color: var(--muted);
+}
+
+.hero-note {
+  border: 1px solid rgba(255, 191, 105, 0.22);
+  border-radius: 18px;
+  padding: 18px;
+  background: rgba(30, 23, 10, 0.38);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.92fr);
+  gap: 22px;
+  margin-top: 22px;
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 22px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(14px);
+}
+
+.panel-request {
+  background:
+    linear-gradient(180deg, rgba(205, 245, 100, 0.06), transparent 20%),
+    var(--panel);
+}
+
+.panel-response {
+  background:
+    linear-gradient(180deg, rgba(255, 191, 105, 0.08), transparent 20%),
+    var(--panel);
+}
+
+.panel-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.panel-copy {
+  max-width: 28ch;
+}
+
+.preset-block,
+.output-block {
+  border: 1px solid rgba(198, 238, 121, 0.12);
+  border-radius: 18px;
+  padding: 16px;
+  background: rgba(13, 22, 18, 0.84);
+}
+
+.preset-header,
+.output-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.preset-header p {
+  font-size: 0.88rem;
+}
+
+.preset-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.preset-button,
+.button {
+  border-radius: 14px;
+  border: 1px solid transparent;
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease,
+    background-color 140ms ease;
+}
+
+.preset-button {
+  padding: 14px 12px;
+  text-align: left;
+  background: rgba(20, 33, 27, 0.86);
+  color: var(--ink);
+}
+
+.preset-button:hover,
+.preset-button:focus-visible,
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(205, 245, 100, 0.44);
+}
+
+.preset-button[data-active="true"] {
+  background:
+    linear-gradient(135deg, rgba(205, 245, 100, 0.2), rgba(255, 191, 105, 0.16)),
+    rgba(23, 38, 30, 0.96);
+  border-color: rgba(205, 245, 100, 0.52);
+  box-shadow: inset 0 0 0 1px rgba(205, 245, 100, 0.16);
+}
+
+.preset-summary {
+  margin-top: 12px;
+  min-height: 3em;
+}
+
+.field {
+  display: grid;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.field span {
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.76rem;
+}
+
+.field input,
+.field textarea {
+  width: 100%;
+  border: 1px solid rgba(205, 245, 100, 0.16);
+  border-radius: 16px;
+  padding: 14px 16px;
+  background: rgba(6, 11, 10, 0.96);
+  color: var(--ink);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 310px;
+}
+
+.field input:focus-visible,
+.field textarea:focus-visible {
+  outline: 2px solid rgba(205, 245, 100, 0.34);
+  outline-offset: 0;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.button {
+  padding: 12px 18px;
+  min-width: 156px;
+  font-weight: 700;
+}
+
+.button-primary {
+  background: linear-gradient(135deg, #cdf564, #7ecb2f);
+  color: #08100d;
+}
+
+.button-secondary {
+  background: rgba(30, 23, 10, 0.48);
+  color: #ffe8b8;
+  border-color: rgba(255, 191, 105, 0.22);
+}
+
+.button:disabled,
+.preset-button:disabled,
+.field input:disabled,
+.field textarea:disabled {
+  opacity: 0.68;
+  cursor: wait;
+  transform: none;
+}
+
+.banner {
+  margin: 18px 0 0;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(205, 245, 100, 0.14);
+  background: rgba(11, 19, 16, 0.92);
+}
+
+.banner[data-kind="info"] {
+  color: #daf7b8;
+}
+
+.banner[data-kind="success"] {
+  color: #cdf564;
+}
+
+.banner[data-kind="error"] {
+  color: var(--danger);
+  border-color: rgba(255, 132, 115, 0.26);
+}
+
+.response-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.metric {
+  border: 1px solid rgba(205, 245, 100, 0.12);
+  border-radius: 18px;
+  padding: 14px 16px;
+  background: var(--panel-strong);
+}
+
+.metric strong {
+  display: inline-flex;
+  margin-top: 6px;
+  font-size: 1.5rem;
+}
+
+#response-status[data-status-class="ok"] {
+  color: var(--accent);
+}
+
+#response-status[data-status-class="client-error"] {
+  color: var(--warn);
+}
+
+#response-status[data-status-class="server-error"] {
+  color: var(--danger);
+}
+
+#response-status[data-status-class="pending"] {
+  color: var(--muted);
+}
+
+.output-block + .output-block {
+  margin-top: 14px;
+}
+
+.output-block-body {
+  min-height: 420px;
+}
+
+.output {
+  margin: 0;
+  overflow: auto;
+  min-height: 120px;
+  padding: 16px;
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(205, 245, 100, 0.04), transparent 24%),
+    rgba(4, 8, 7, 0.98);
+  color: #e9ffe0;
+  border: 1px solid rgba(205, 245, 100, 0.09);
+}
+
+@media (max-width: 1040px) {
+  .hero-copy,
+  .workspace,
+  .panel-header {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .panel-copy {
+    max-width: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    width: min(100vw - 20px, 100%);
+    padding-top: 20px;
+  }
+
+  .hero,
+  .panel {
+    padding: 18px;
+  }
+
+  .preset-list {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .actions,
+  .response-meta {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .button {
+    width: 100%;
+  }
+}

--- a/demo/tests/demo.spec.ts
+++ b/demo/tests/demo.spec.ts
@@ -26,6 +26,29 @@ test("guided browser flow works end to end", async ({ page }) => {
   await expect(page.getByTestId("response-body")).toContainText("browser-demo-stream");
 });
 
+test("reset recovers after an initial wasm bootstrap failure", async ({ page }) => {
+  let aborted = false;
+  await page.route("**/*.wasm", async (route) => {
+    if (!aborted) {
+      aborted = true;
+      await route.abort();
+      return;
+    }
+
+    await route.continue();
+  });
+
+  await page.goto("/");
+
+  await expect(page.getByTestId("banner")).toContainText("Failed to fetch");
+
+  await page.getByTestId("reset-state").click();
+  await expect(page.getByTestId("banner")).toContainText("State reset");
+
+  await runPreset(page, "preset-create-stream");
+  await expect(page.getByTestId("response-status")).toHaveText("200");
+});
+
 async function runPreset(page: Page, presetTestId: string) {
   await page.getByTestId(presetTestId).click();
   await page.getByTestId("send-request").click();

--- a/demo/tests/demo.spec.ts
+++ b/demo/tests/demo.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test, type Page } from "@playwright/test";
+
+test("guided browser flow works end to end", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: "Try Kinesis in your browser" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("banner")).toContainText("Fresh in-memory instance ready");
+
+  await runPreset(page, "preset-create-stream");
+  await expect(page.getByTestId("response-status")).toHaveText("200");
+
+  await runPreset(page, "preset-put-record");
+  await expect(page.getByTestId("response-body")).toContainText('"SequenceNumber"');
+
+  await runPreset(page, "preset-get-shard-iterator");
+  await expect(page.getByTestId("response-body")).toContainText('"ShardIterator"');
+
+  await runPreset(page, "preset-get-records");
+  await expect(page.getByTestId("response-body")).toContainText(
+    '"Data": "aGVsbG8gZnJvbSBmZXJyb2tpbmVzaXM="',
+  );
+
+  await runPreset(page, "preset-list-streams");
+  await expect(page.getByTestId("response-body")).toContainText("browser-demo-stream");
+});
+
+async function runPreset(page: Page, presetTestId: string) {
+  await page.getByTestId(presetTestId).click();
+  await page.getByTestId("send-request").click();
+}

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "vite.config.ts", "playwright.config.ts", "tests/**/*.ts"]
+}

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+
+const base = process.env.VITE_BASE_PATH ?? "/";
+
+export default defineConfig({
+  base,
+  build: {
+    outDir: "dist",
+    sourcemap: false,
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vite + TypeScript browser demo under `demo/` that drives the existing `ferrokinesis-wasm` Phase 1 wrapper in-process
- add a `wasm-pack --target web` build script, Playwright smoke test, CI job, and GitHub Pages deployment workflow
- document the browser demo in the README and keep state explicitly browser-memory-only with guided presets

## Notes
- this is the browser-only Phase 3 path for #152 and does not depend on the Phase 2 WASI listener
- the demo build currently uses `wasm-pack --no-opt` to avoid flaky `wasm-opt` behavior, and it logs the generated `.wasm` size in the build output
- measured local `.wasm` size: 1993821 bytes (1.90 MiB)

## Testing
- `npm --prefix demo run build`
- `npm --prefix demo run test:smoke`
- `VITE_BASE_PATH=/ferrokinesis/ npm --prefix demo run build`
- `cargo check -p ferrokinesis-wasm --target wasm32-unknown-unknown`
- `wasm-pack test --node crates/ferrokinesis-wasm`

Refs #152