### PR TITLE
test: add cross-format CBOR/JSON property tests

### DIFF
--- a/tests/cbor_json_equivalence.rs
+++ b/tests/cbor_json_equivalence.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use base64::Engine;
-use common::{TestServer, assert_values_equivalent, decode_body};
+use common::{TestServer, assert_values_equivalent, decode_body, json_to_cbor_with_bytes_many};
 use ferrokinesis::store::StoreOptions;
 use serde_json::json;
 
@@ -12,6 +12,51 @@ const VOLATILE_KEYS: &[&str] = &[
     "ShardIterator",
     "x-amzn-RequestId",
 ];
+
+fn cbor_field<'a>(value: &'a ciborium::Value, key: &str) -> Option<&'a ciborium::Value> {
+    let ciborium::Value::Map(entries) = value else {
+        return None;
+    };
+
+    entries
+        .iter()
+        .find_map(|(entry_key, entry_value)| match entry_key {
+            ciborium::Value::Text(text) if text == key => Some(entry_value),
+            _ => None,
+        })
+}
+
+#[test]
+fn helper_json_to_cbor_with_bytes_many_replaces_records_data_with_bytes() {
+    let payload = json!({
+        "StreamName": "helper-batch",
+        "Records": [
+            {"Data": base64::engine::general_purpose::STANDARD.encode(b"first"), "PartitionKey": "pk-1"},
+            {"Data": base64::engine::general_purpose::STANDARD.encode(b"second"), "PartitionKey": "pk-2"},
+        ],
+    });
+    let raw_payloads = vec![b"first".to_vec(), b"second".to_vec()];
+
+    let cbor = json_to_cbor_with_bytes_many(&payload, "Records.*.Data", &raw_payloads);
+
+    let records = match cbor_field(&cbor, "Records") {
+        Some(ciborium::Value::Array(records)) => records,
+        other => panic!("expected Records array, got {other:?}"),
+    };
+    assert_eq!(records.len(), raw_payloads.len());
+
+    for (record, expected_bytes) in records.iter().zip(raw_payloads.iter()) {
+        match cbor_field(record, "Data") {
+            Some(ciborium::Value::Bytes(actual_bytes)) => assert_eq!(actual_bytes, expected_bytes),
+            other => panic!("expected Data to be CBOR bytes, got {other:?}"),
+        }
+
+        match cbor_field(record, "PartitionKey") {
+            Some(ciborium::Value::Text(_)) => {}
+            other => panic!("expected PartitionKey to remain CBOR text, got {other:?}"),
+        }
+    }
+}
 
 // ─── Group A: Read-only operation equivalence ────────────────────────────────
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -205,6 +205,34 @@ impl TestServer {
             .unwrap()
     }
 
+    /// Make a CBOR request with multiple Data fields encoded as CBOR byte strings.
+    /// `raw_data_many` must match the explicit path traversal order exactly
+    /// (for example, `"Records.*.Data"` consumes one payload per array element).
+    pub async fn cbor_request_raw_data_many(
+        &self,
+        target: &str,
+        fields: &Value,
+        data_field_path: &str,
+        raw_data_many: &[Vec<u8>],
+    ) -> reqwest::Response {
+        let cbor_val = json_to_cbor_with_bytes_many(fields, data_field_path, raw_data_many);
+        let mut buf = Vec::new();
+        ciborium::into_writer(&cbor_val, &mut buf).unwrap();
+        self.client
+            .post(self.url())
+            .header("Content-Type", AMZ_CBOR)
+            .header("X-Amz-Target", format!("{VERSION}.{target}"))
+            .header(
+                "Authorization",
+                "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=abcd1234",
+            )
+            .header("X-Amz-Date", "20150101T000000Z")
+            .body(buf)
+            .send()
+            .await
+            .unwrap()
+    }
+
     /// Make a raw HTTP request with full control over headers/body
     pub async fn raw_request(
         &self,
@@ -457,6 +485,36 @@ pub fn json_to_cbor_with_bytes(
     json_to_cbor_inner(val, data_field_path, raw_data)
 }
 
+/// Convert a serde_json::Value to ciborium::Value, replacing each field matched by
+/// `data_field_path` with the next CBOR Bytes payload from `raw_data_many`.
+/// Path syntax matches [`json_to_cbor_with_bytes`], including wildcard expansion.
+///
+/// Panics if the explicit path matches a different number of fields than the
+/// number of provided payloads.
+pub fn json_to_cbor_with_bytes_many(
+    val: &Value,
+    data_field_path: &str,
+    raw_data_many: &[Vec<u8>],
+) -> ciborium::Value {
+    let mut next_idx = 0;
+    let cbor = json_to_cbor_inner_many(
+        val,
+        data_field_path,
+        data_field_path,
+        raw_data_many,
+        &mut next_idx,
+    );
+    assert_eq!(
+        next_idx,
+        raw_data_many.len(),
+        "path {:?} matched {} field(s), but {} raw payload(s) were provided",
+        data_field_path,
+        next_idx,
+        raw_data_many.len()
+    );
+    cbor
+}
+
 fn json_to_cbor_inner(val: &Value, path: &str, raw_data: &[u8]) -> ciborium::Value {
     match val {
         Value::Null => ciborium::Value::Null,
@@ -500,6 +558,75 @@ fn json_to_cbor_inner(val: &Value, path: &str, raw_data: &[u8]) -> ciborium::Val
                         } else if k == first {
                             // Traverse deeper
                             json_to_cbor_inner(v, rest, raw_data)
+                        } else {
+                            json_to_cbor_inner(v, "", &[])
+                        };
+                        (cbor_key, cbor_val)
+                    })
+                    .collect(),
+            )
+        }
+    }
+}
+
+fn json_to_cbor_inner_many(
+    val: &Value,
+    path: &str,
+    full_path: &str,
+    raw_data_many: &[Vec<u8>],
+    next_idx: &mut usize,
+) -> ciborium::Value {
+    if path.is_empty() {
+        return json_to_cbor_inner(val, "", &[]);
+    }
+
+    match val {
+        Value::Null => ciborium::Value::Null,
+        Value::Bool(b) => ciborium::Value::Bool(*b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                ciborium::Value::Integer(i.into())
+            } else if let Some(f) = n.as_f64() {
+                ciborium::Value::Float(f)
+            } else {
+                ciborium::Value::Null
+            }
+        }
+        Value::String(s) => ciborium::Value::Text(s.clone()),
+        Value::Array(arr) => {
+            let (first, rest) = path.split_once('.').unwrap_or((path, ""));
+            if first == "*" {
+                ciborium::Value::Array(
+                    arr.iter()
+                        .map(|item| {
+                            json_to_cbor_inner_many(item, rest, full_path, raw_data_many, next_idx)
+                        })
+                        .collect(),
+                )
+            } else {
+                json_to_cbor_inner(val, "", &[])
+            }
+        }
+        Value::Object(map) => {
+            let (first, rest) = path.split_once('.').unwrap_or((path, ""));
+            ciborium::Value::Map(
+                map.iter()
+                    .map(|(k, v)| {
+                        let cbor_key = ciborium::Value::Text(k.clone());
+                        let cbor_val = if k == first && rest.is_empty() {
+                            let idx = *next_idx;
+                            let raw = raw_data_many.get(idx).unwrap_or_else(|| {
+                                panic!(
+                                    "path {:?} matched more fields than raw payloads provided: needed payload index {}, provided {}",
+                                    full_path,
+                                    idx,
+                                    raw_data_many.len()
+                                )
+                            });
+                            *next_idx += 1;
+                            ciborium::Value::Bytes(raw.clone())
+                        } else if k == first {
+                            json_to_cbor_inner_many(v, rest, full_path, raw_data_many, next_idx)
                         } else {
                             json_to_cbor_inner(v, "", &[])
                         };

--- a/tests/prop_cbor_json_equivalence.rs
+++ b/tests/prop_cbor_json_equivalence.rs
@@ -1,8 +1,11 @@
-// Case count rationale: 50 cases — each iteration does paired JSON + CBOR requests,
-// doubling the server round-trips compared to single-format tests.
+// Case count rationale: 50 cases — this file exercises multi-request JSON/CBOR
+// equivalence and mixed-format round-trips, so we keep coverage high while
+// bounding total server round-trips.
 mod common;
 use common::*;
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use ferrokinesis::store::StoreOptions;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestRunner};
@@ -11,6 +14,17 @@ use serde_json::json;
 /// Volatile keys that differ between separate JSON and CBOR requests
 /// (because each is a distinct write producing a different sequence number).
 const VOLATILE_KEYS: &[&str] = &["SequenceNumber"];
+
+fn cbor_field<'a>(val: &'a ciborium::Value, key: &str) -> Option<&'a ciborium::Value> {
+    let ciborium::Value::Map(entries) = val else {
+        return None;
+    };
+
+    entries.iter().find_map(|(k, v)| match k {
+        ciborium::Value::Text(text) if text == key => Some(v),
+        _ => None,
+    })
+}
 
 /// P16: PutRecord via JSON and CBOR produce structurally equivalent responses.
 #[test]
@@ -166,6 +180,204 @@ fn prop_put_records_cbor_json_equivalent() {
                     i
                 );
             }
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P31: PutRecord via JSON and GetRecords via CBOR preserve raw Data bytes.
+#[test]
+fn prop_put_record_json_get_records_cbor_roundtrip() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let stream_name = unique_stream_name("prop-cross-jc");
+    rt.block_on(server.create_stream(&stream_name, 1));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    let strategy = proptest::collection::vec(any::<u8>(), 1..=4096);
+
+    runner
+        .run(&strategy, |raw_bytes| {
+            let encoded = STANDARD.encode(&raw_bytes);
+
+            let (seq_num, cbor_body) = rt.block_on(async {
+                let put_res = server
+                    .request(
+                        "PutRecord",
+                        &json!({
+                            "StreamName": stream_name,
+                            "Data": encoded,
+                            "PartitionKey": "cross-format-json",
+                        }),
+                    )
+                    .await;
+                assert_eq!(put_res.status(), 200);
+                let put_body: serde_json::Value = put_res.json().await.unwrap();
+                let seq_num = put_body["SequenceNumber"].as_str().unwrap().to_string();
+                let shard_id = put_body["ShardId"].as_str().unwrap().to_string();
+
+                let iter_res = decode_body(
+                    server
+                        .cbor_request(
+                            "GetShardIterator",
+                            &json!({
+                                "StreamName": stream_name,
+                                "ShardId": shard_id,
+                                "ShardIteratorType": "AT_SEQUENCE_NUMBER",
+                                "StartingSequenceNumber": seq_num,
+                            }),
+                        )
+                        .await,
+                )
+                .await;
+                assert_eq!(iter_res.0, 200);
+                let iterator = iter_res.1["ShardIterator"].as_str().unwrap().to_string();
+
+                let get_res = server
+                    .cbor_request("GetRecords", &json!({"ShardIterator": iterator}))
+                    .await;
+                assert_eq!(get_res.status(), 200);
+                let content_type = get_res
+                    .headers()
+                    .get("content-type")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+                assert!(
+                    content_type.contains("cbor"),
+                    "expected CBOR response, got {content_type}"
+                );
+
+                let body_bytes = get_res.bytes().await.unwrap();
+                let cbor_body: ciborium::Value = ciborium::from_reader(&body_bytes[..]).unwrap();
+                (seq_num, cbor_body)
+            });
+
+            let records = match cbor_field(&cbor_body, "Records") {
+                Some(ciborium::Value::Array(records)) => records,
+                other => panic!("expected Records array in CBOR response, got {other:?}"),
+            };
+            prop_assert!(
+                !records.is_empty(),
+                "no records returned for data of length {}",
+                raw_bytes.len()
+            );
+
+            let data_bytes = match cbor_field(&records[0], "Data") {
+                Some(ciborium::Value::Bytes(data)) => data,
+                other => panic!("expected CBOR byte string for Data, got {other:?}"),
+            };
+            prop_assert_eq!(
+                data_bytes.as_slice(),
+                raw_bytes.as_slice(),
+                "raw CBOR bytes mismatch for input of length {}",
+                raw_bytes.len()
+            );
+
+            let normalized = ferrokinesis::server::cbor_to_json(&cbor_body);
+            let normalized_records = normalized["Records"].as_array().unwrap();
+            prop_assert_eq!(
+                normalized_records[0]["SequenceNumber"].as_str(),
+                Some(seq_num.as_str()),
+                "GetRecords did not return the record written in this case"
+            );
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P32: PutRecord via CBOR and GetRecords via JSON preserve raw Data bytes.
+#[test]
+fn prop_put_record_cbor_get_records_json_roundtrip() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let stream_name = unique_stream_name("prop-cross-cj");
+    rt.block_on(server.create_stream(&stream_name, 1));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    let strategy = proptest::collection::vec(any::<u8>(), 1..=4096);
+
+    runner
+        .run(&strategy, |raw_bytes| {
+            let encoded = STANDARD.encode(&raw_bytes);
+
+            let (seq_num, json_body) = rt.block_on(async {
+                let put_resp = decode_body(
+                    server
+                        .cbor_request_raw_data(
+                            "PutRecord",
+                            &json!({
+                                "StreamName": stream_name,
+                                "Data": encoded,
+                                "PartitionKey": "cross-format-cbor",
+                            }),
+                            "Data",
+                            &raw_bytes,
+                        )
+                        .await,
+                )
+                .await;
+                assert_eq!(put_resp.0, 200);
+                let seq_num = put_resp.1["SequenceNumber"].as_str().unwrap().to_string();
+                let shard_id = put_resp.1["ShardId"].as_str().unwrap().to_string();
+
+                let iter_res = server
+                    .request(
+                        "GetShardIterator",
+                        &json!({
+                            "StreamName": stream_name,
+                            "ShardId": shard_id,
+                            "ShardIteratorType": "AT_SEQUENCE_NUMBER",
+                            "StartingSequenceNumber": seq_num,
+                        }),
+                    )
+                    .await;
+                assert_eq!(iter_res.status(), 200);
+                let iter_body: serde_json::Value = iter_res.json().await.unwrap();
+                let iterator = iter_body["ShardIterator"].as_str().unwrap().to_string();
+
+                let get_res = server
+                    .request("GetRecords", &json!({"ShardIterator": iterator}))
+                    .await;
+                assert_eq!(get_res.status(), 200);
+                let json_body: serde_json::Value = get_res.json().await.unwrap();
+                (seq_num, json_body)
+            });
+
+            let records = json_body["Records"].as_array().unwrap();
+            prop_assert!(
+                !records.is_empty(),
+                "no records returned for data of length {}",
+                raw_bytes.len()
+            );
+
+            let data_b64 = records[0]["Data"]
+                .as_str()
+                .expect("expected JSON Data to be a base64 string");
+            let returned_bytes = STANDARD.decode(data_b64).unwrap();
+            prop_assert_eq!(
+                returned_bytes.as_slice(),
+                raw_bytes.as_slice(),
+                "JSON/base64 round-trip mismatch for input of length {}",
+                raw_bytes.len()
+            );
+            prop_assert_eq!(
+                records[0]["SequenceNumber"].as_str(),
+                Some(seq_num.as_str()),
+                "GetRecords did not return the record written in this case"
+            );
 
             Ok(())
         })

--- a/tests/prop_cbor_json_equivalence.rs
+++ b/tests/prop_cbor_json_equivalence.rs
@@ -26,6 +26,11 @@ fn cbor_field<'a>(val: &'a ciborium::Value, key: &str) -> Option<&'a ciborium::V
     })
 }
 
+fn distinct_batch_payloads() -> impl Strategy<Value = Vec<Vec<u8>>> {
+    proptest::collection::btree_set(proptest::collection::vec(any::<u8>(), 1..=4096), 1..=10)
+        .prop_map(|payloads| payloads.into_iter().collect())
+}
+
 /// P16: PutRecord via JSON and CBOR produce structurally equivalent responses.
 #[test]
 fn prop_put_record_cbor_json_equivalent() {
@@ -378,6 +383,260 @@ fn prop_put_record_cbor_get_records_json_roundtrip() {
                 Some(seq_num.as_str()),
                 "GetRecords did not return the record written in this case"
             );
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P33: PutRecords via JSON and GetRecords via CBOR preserve per-record raw Data bytes.
+#[test]
+fn prop_put_records_json_get_records_cbor_roundtrip() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let stream_name = unique_stream_name("prop-cross-prs-jc");
+    rt.block_on(server.create_stream(&stream_name, 1));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    runner
+        .run(&distinct_batch_payloads(), |raw_payloads| {
+            let (sequence_numbers, cbor_body) = rt.block_on(async {
+                let records: Vec<serde_json::Value> = raw_payloads
+                    .iter()
+                    .enumerate()
+                    .map(|(i, raw_bytes)| {
+                        json!({
+                            "Data": STANDARD.encode(raw_bytes),
+                            "PartitionKey": format!("cross-format-json-{i}"),
+                        })
+                    })
+                    .collect();
+
+                let put_res = server
+                    .request(
+                        "PutRecords",
+                        &json!({
+                            "StreamName": stream_name,
+                            "Records": records,
+                        }),
+                    )
+                    .await;
+                assert_eq!(put_res.status(), 200);
+                let put_body: serde_json::Value = put_res.json().await.unwrap();
+                assert_eq!(put_body["FailedRecordCount"].as_u64(), Some(0));
+
+                let response_records = put_body["Records"].as_array().unwrap();
+                assert_eq!(response_records.len(), raw_payloads.len());
+                let sequence_numbers: Vec<String> = response_records
+                    .iter()
+                    .map(|record| record["SequenceNumber"].as_str().unwrap().to_string())
+                    .collect();
+
+                let iter_res = decode_body(
+                    server
+                        .cbor_request(
+                            "GetShardIterator",
+                            &json!({
+                                "StreamName": stream_name,
+                                "ShardId": "shardId-000000000000",
+                                "ShardIteratorType": "AT_SEQUENCE_NUMBER",
+                                "StartingSequenceNumber": sequence_numbers[0],
+                            }),
+                        )
+                        .await,
+                )
+                .await;
+                assert_eq!(iter_res.0, 200);
+                let iterator = iter_res.1["ShardIterator"].as_str().unwrap().to_string();
+
+                let get_res = server
+                    .cbor_request("GetRecords", &json!({"ShardIterator": iterator}))
+                    .await;
+                assert_eq!(get_res.status(), 200);
+                let content_type = get_res
+                    .headers()
+                    .get("content-type")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+                assert!(
+                    content_type.contains("cbor"),
+                    "expected CBOR response, got {content_type}"
+                );
+
+                let body_bytes = get_res.bytes().await.unwrap();
+                let cbor_body: ciborium::Value = ciborium::from_reader(&body_bytes[..]).unwrap();
+                (sequence_numbers, cbor_body)
+            });
+
+            let records = match cbor_field(&cbor_body, "Records") {
+                Some(ciborium::Value::Array(records)) => records,
+                other => panic!("expected Records array in CBOR response, got {other:?}"),
+            };
+            prop_assert!(
+                records.len() >= raw_payloads.len(),
+                "expected at least {} records, got {}",
+                raw_payloads.len(),
+                records.len()
+            );
+
+            for (i, raw_bytes) in raw_payloads.iter().enumerate() {
+                let data_bytes = match cbor_field(&records[i], "Data") {
+                    Some(ciborium::Value::Bytes(data)) => data,
+                    other => {
+                        panic!("expected CBOR byte string for Data at record {i}, got {other:?}")
+                    }
+                };
+                prop_assert_eq!(
+                    data_bytes.as_slice(),
+                    raw_bytes.as_slice(),
+                    "raw CBOR bytes mismatch at record {}",
+                    i
+                );
+            }
+
+            let normalized = ferrokinesis::server::cbor_to_json(&cbor_body);
+            let normalized_records = normalized["Records"].as_array().unwrap();
+            prop_assert!(
+                normalized_records.len() >= raw_payloads.len(),
+                "expected at least {} normalized records, got {}",
+                raw_payloads.len(),
+                normalized_records.len()
+            );
+            for (i, seq_num) in sequence_numbers.iter().enumerate() {
+                prop_assert_eq!(
+                    normalized_records[i]["SequenceNumber"].as_str(),
+                    Some(seq_num.as_str()),
+                    "GetRecords returned the wrong record order at index {}",
+                    i
+                );
+            }
+
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// P34: PutRecords via CBOR and GetRecords via JSON preserve per-record raw Data bytes.
+#[test]
+fn prop_put_records_cbor_get_records_json_roundtrip() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(TestServer::new());
+
+    let stream_name = unique_stream_name("prop-cross-prs-cj");
+    rt.block_on(server.create_stream(&stream_name, 1));
+
+    let mut runner = TestRunner::new(Config {
+        cases: 50,
+        ..Config::default()
+    });
+
+    runner
+        .run(&distinct_batch_payloads(), |raw_payloads| {
+            let (sequence_numbers, read_records) = rt.block_on(async {
+                let records: Vec<serde_json::Value> = raw_payloads
+                    .iter()
+                    .enumerate()
+                    .map(|(i, raw_bytes)| {
+                        json!({
+                            "Data": STANDARD.encode(raw_bytes),
+                            "PartitionKey": format!("cross-format-cbor-{i}"),
+                        })
+                    })
+                    .collect();
+
+                let put_resp = decode_body(
+                    server
+                        .cbor_request_raw_data_many(
+                            "PutRecords",
+                            &json!({
+                                "StreamName": stream_name,
+                                "Records": records,
+                            }),
+                            "Records.*.Data",
+                            &raw_payloads,
+                        )
+                        .await,
+                )
+                .await;
+                assert_eq!(put_resp.0, 200);
+                assert_eq!(put_resp.1["FailedRecordCount"].as_u64(), Some(0));
+
+                let response_records = put_resp.1["Records"].as_array().unwrap();
+                assert_eq!(response_records.len(), raw_payloads.len());
+                let sequence_numbers: Vec<String> = response_records
+                    .iter()
+                    .map(|record| record["SequenceNumber"].as_str().unwrap().to_string())
+                    .collect();
+
+                let iter_res = server
+                    .request(
+                        "GetShardIterator",
+                        &json!({
+                            "StreamName": stream_name,
+                            "ShardId": "shardId-000000000000",
+                            "ShardIteratorType": "AT_SEQUENCE_NUMBER",
+                            "StartingSequenceNumber": sequence_numbers[0],
+                        }),
+                    )
+                    .await;
+                assert_eq!(iter_res.status(), 200);
+                let iter_body: serde_json::Value = iter_res.json().await.unwrap();
+                let iterator = iter_body["ShardIterator"].as_str().unwrap().to_string();
+
+                let get_res = server
+                    .request("GetRecords", &json!({"ShardIterator": iterator}))
+                    .await;
+                assert_eq!(get_res.status(), 200);
+                let json_body: serde_json::Value = get_res.json().await.unwrap();
+
+                let read_records = json_body["Records"].as_array().unwrap();
+                assert!(
+                    read_records.len() >= raw_payloads.len(),
+                    "expected at least {} records, got {}",
+                    raw_payloads.len(),
+                    read_records.len()
+                );
+
+                for (i, seq_num) in sequence_numbers.iter().enumerate() {
+                    assert_eq!(
+                        read_records[i]["SequenceNumber"].as_str(),
+                        Some(seq_num.as_str()),
+                        "GetRecords returned the wrong record order at index {}",
+                        i
+                    );
+                }
+
+                (
+                    sequence_numbers,
+                    read_records[..raw_payloads.len()].to_vec(),
+                )
+            });
+
+            for (i, (record, raw_bytes)) in read_records.iter().zip(raw_payloads.iter()).enumerate()
+            {
+                let data_b64 = record["Data"]
+                    .as_str()
+                    .expect("expected JSON Data to be a base64 string");
+                let returned_bytes = STANDARD.decode(data_b64).unwrap();
+                prop_assert_eq!(
+                    returned_bytes.as_slice(),
+                    raw_bytes.as_slice(),
+                    "JSON/base64 round-trip mismatch at record {}",
+                    i
+                );
+                prop_assert_eq!(
+                    record["SequenceNumber"].as_str(),
+                    Some(sequence_numbers[i].as_str()),
+                    "GetRecords returned the wrong record at index {}",
+                    i
+                );
+            }
 
             Ok(())
         })


### PR DESCRIPTION
## Summary
- add property coverage for JSON PutRecord -> CBOR GetRecords round-trips
- add property coverage for CBOR PutRecord -> JSON GetRecords round-trips
- pin readback to the exact written record via AT_SEQUENCE_NUMBER and assert wire-format-specific Data handling

## Testing
- cargo test --test prop_cbor_json_equivalence

Closes #183