### PR TITLE
ci: add nightly compatibility matrix scaffold

### DIFF
--- a/.github/compatibility-matrix.md
+++ b/.github/compatibility-matrix.md
@@ -1,0 +1,16 @@
+# Compatibility Matrix
+
+This file is the checked-in preface for the nightly compatibility report produced by
+`.github/workflows/compatibility-matrix.yml`.
+
+## Scope
+
+- Build the current ferrokinesis release binary.
+- Run the existing SDK and KCL conformance suites against that binary on a nightly schedule or manual dispatch.
+- Publish a markdown artifact summarizing suite outcomes for the selected ref.
+
+## Limitations
+
+- This is the first implementation slice for issue `#146`, not the final AWS side-by-side wire diff.
+- The current multi-SDK suites still hardcode localhost endpoints or static test credentials, so a real AWS-backed dual-run needs follow-up changes in the per-suite harnesses.
+- Until that lands, treat the generated report as a nightly compatibility canary rather than a definitive AWS parity score.

--- a/.github/scripts/render-compatibility-matrix.py
+++ b/.github/scripts/render-compatibility-matrix.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--template", type=Path, required=True)
+    parser.add_argument("--results-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--ref", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    template = args.template.read_text(encoding="utf-8").rstrip()
+    result_paths = sorted(args.results_dir.glob("*.json"))
+    if not result_paths:
+        raise SystemExit("no compatibility result files found")
+
+    rows = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
+    rows.sort(key=lambda row: row["suite"])
+
+    outcome_counts = Counter(row["outcome"] for row in rows)
+    status_labels = {
+        "success": "PASS",
+        "failure": "FAIL",
+        "cancelled": "CANCELLED",
+        "skipped": "SKIPPED",
+    }
+
+    lines = [template, "", "## Latest Run"]
+    if args.ref:
+        lines.append(f"- Ref: `{args.ref}`")
+    lines.append(f"- Suites: {len(rows)}")
+    lines.append(f"- Passed: {outcome_counts.get('success', 0)}")
+    lines.append(f"- Failed: {outcome_counts.get('failure', 0)}")
+    lines.append(f"- Cancelled: {outcome_counts.get('cancelled', 0)}")
+    lines.append(f"- Skipped: {outcome_counts.get('skipped', 0)}")
+    lines.append("")
+    lines.append("| Suite | Language | Result | DynamoDB Local |")
+    lines.append("| --- | --- | --- | --- |")
+
+    for row in rows:
+        outcome = row["outcome"]
+        label = status_labels.get(outcome, outcome.upper())
+        needs_dynamodb = "yes" if row["needs_dynamodb"] else "no"
+        lines.append(
+            f"| {row['suite']} | `{row['language']}` | {label} | {needs_dynamodb} |"
+        )
+
+    args.output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/render-compatibility-matrix.py
+++ b/.github/scripts/render-compatibility-matrix.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import re
 from collections import Counter
 from pathlib import Path
 
@@ -11,8 +12,50 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--template", type=Path, required=True)
     parser.add_argument("--results-dir", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--workflow", type=Path)
     parser.add_argument("--ref", default="")
     return parser.parse_args()
+
+
+def load_expected_slugs(workflow_path: Path) -> list[str]:
+    workflow = workflow_path.read_text(encoding="utf-8")
+    matches = re.findall(r"^\s+slug:\s*([A-Za-z0-9][A-Za-z0-9._-]*)\s*$", workflow, re.MULTILINE)
+    if not matches:
+        raise SystemExit(f"no compatibility suite slugs found in workflow: {workflow_path}")
+    return matches
+
+
+def load_rows(result_paths: list[Path]) -> list[dict[str, object]]:
+    if not result_paths:
+        raise SystemExit("no compatibility result files found")
+
+    rows = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
+    duplicate_slugs = sorted(
+        slug for slug, count in Counter(str(row["slug"]) for row in rows).items() if count > 1
+    )
+    if duplicate_slugs:
+        raise SystemExit(
+            "duplicate compatibility result slugs: " + ", ".join(duplicate_slugs)
+        )
+    return rows
+
+
+def validate_rows(rows: list[dict[str, object]], expected_slugs: list[str]) -> None:
+    actual_slugs = [str(row["slug"]) for row in rows]
+    missing = sorted(set(expected_slugs) - set(actual_slugs))
+    unexpected = sorted(set(actual_slugs) - set(expected_slugs))
+
+    if missing or unexpected or len(actual_slugs) != len(expected_slugs):
+        details: list[str] = []
+        if missing:
+            details.append("missing: " + ", ".join(missing))
+        if unexpected:
+            details.append("unexpected: " + ", ".join(unexpected))
+        if len(actual_slugs) != len(expected_slugs):
+            details.append(
+                f"expected {len(expected_slugs)} suites but found {len(actual_slugs)} result files"
+            )
+        raise SystemExit("incomplete compatibility result set; " + "; ".join(details))
 
 
 def main() -> int:
@@ -20,11 +63,14 @@ def main() -> int:
 
     template = args.template.read_text(encoding="utf-8").rstrip()
     result_paths = sorted(args.results_dir.glob("*.json"))
-    if not result_paths:
-        raise SystemExit("no compatibility result files found")
-
-    rows = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
-    rows.sort(key=lambda row: row["suite"])
+    rows = load_rows(result_paths)
+    expected_slugs = load_expected_slugs(args.workflow) if args.workflow else []
+    if expected_slugs:
+        validate_rows(rows, expected_slugs)
+        sort_order = {slug: index for index, slug in enumerate(expected_slugs)}
+        rows.sort(key=lambda row: sort_order[str(row["slug"])])
+    else:
+        rows.sort(key=lambda row: str(row["suite"]))
 
     outcome_counts = Counter(row["outcome"] for row in rows)
     status_labels = {

--- a/.github/scripts/render-compatibility-matrix.py
+++ b/.github/scripts/render-compatibility-matrix.py
@@ -6,6 +6,8 @@ import re
 from collections import Counter
 from pathlib import Path
 
+VALID_OUTCOMES = {"success", "failure", "cancelled", "skipped"}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -57,6 +59,14 @@ def validate_rows(rows: list[dict[str, object]], expected_slugs: list[str]) -> N
             )
         raise SystemExit("incomplete compatibility result set; " + "; ".join(details))
 
+    for row in rows:
+        outcome = row.get("outcome")
+        if not isinstance(outcome, str) or outcome not in VALID_OUTCOMES:
+            raise SystemExit(
+                "invalid compatibility outcome for "
+                f"{row['slug']}: {outcome!r}"
+            )
+
 
 def main() -> int:
     args = parse_args()
@@ -72,7 +82,7 @@ def main() -> int:
     else:
         rows.sort(key=lambda row: str(row["suite"]))
 
-    outcome_counts = Counter(row["outcome"] for row in rows)
+    outcome_counts = Counter(str(row["outcome"]) for row in rows)
     status_labels = {
         "success": "PASS",
         "failure": "FAIL",
@@ -93,8 +103,8 @@ def main() -> int:
     lines.append("| --- | --- | --- | --- |")
 
     for row in rows:
-        outcome = row["outcome"]
-        label = status_labels.get(outcome, outcome.upper())
+        outcome = str(row["outcome"])
+        label = status_labels[outcome]
         needs_dynamodb = "yes" if row["needs_dynamodb"] else "no"
         lines.append(
             f"| {row['suite']} | `{row['language']}` | {label} | {needs_dynamodb} |"

--- a/.github/scripts/test_render_compatibility_matrix.py
+++ b/.github/scripts/test_render_compatibility_matrix.py
@@ -1,0 +1,152 @@
+import json
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("render-compatibility-matrix.py")
+
+
+class RenderCompatibilityMatrixTests(unittest.TestCase):
+    def run_script(
+        self,
+        *,
+        workflow_text: str,
+        rows: list[dict[str, object]],
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            template = root / "template.md"
+            workflow = root / "compatibility-matrix.yml"
+            results_dir = root / "results"
+            output = root / "report.md"
+
+            template.write_text("# Compatibility Matrix\n", encoding="utf-8")
+            workflow.write_text(workflow_text, encoding="utf-8")
+            results_dir.mkdir()
+
+            for index, row in enumerate(rows):
+                (results_dir / f"{index}-{row['slug']}.json").write_text(
+                    json.dumps(row), encoding="utf-8"
+                )
+
+            return subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--template",
+                    str(template),
+                    "--results-dir",
+                    str(results_dir),
+                    "--output",
+                    str(output),
+                    "--workflow",
+                    str(workflow),
+                    "--ref",
+                    "abc123",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    def test_renders_when_all_expected_results_are_present(self) -> None:
+        workflow_text = textwrap.dedent(
+            """
+            jobs:
+              compatibility:
+                strategy:
+                  matrix:
+                    include:
+                      - name: Go v2
+                        slug: go-sdk-v2
+                      - name: Python (boto3)
+                        slug: python-boto3
+            """
+        )
+        rows = [
+            {
+                "suite": "Go v2",
+                "slug": "go-sdk-v2",
+                "language": "go",
+                "directory": "tests/conformance/go-sdk-v2",
+                "needs_dynamodb": False,
+                "outcome": "success",
+            },
+            {
+                "suite": "Python (boto3)",
+                "slug": "python-boto3",
+                "language": "python",
+                "directory": "tests/conformance/python-boto3",
+                "needs_dynamodb": False,
+                "outcome": "failure",
+            },
+        ]
+
+        result = self.run_script(workflow_text=workflow_text, rows=rows)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+
+    def test_fails_when_expected_result_is_missing(self) -> None:
+        workflow_text = textwrap.dedent(
+            """
+            jobs:
+              compatibility:
+                strategy:
+                  matrix:
+                    include:
+                      - name: Go v2
+                        slug: go-sdk-v2
+                      - name: Python (boto3)
+                        slug: python-boto3
+            """
+        )
+        rows = [
+            {
+                "suite": "Go v2",
+                "slug": "go-sdk-v2",
+                "language": "go",
+                "directory": "tests/conformance/go-sdk-v2",
+                "needs_dynamodb": False,
+                "outcome": "success",
+            }
+        ]
+
+        result = self.run_script(workflow_text=workflow_text, rows=rows)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("incomplete compatibility result set", result.stderr)
+        self.assertIn("missing: python-boto3", result.stderr)
+
+    def test_fails_when_duplicate_result_slug_is_uploaded(self) -> None:
+        workflow_text = textwrap.dedent(
+            """
+            jobs:
+              compatibility:
+                strategy:
+                  matrix:
+                    include:
+                      - name: Go v2
+                        slug: go-sdk-v2
+            """
+        )
+        row = {
+            "suite": "Go v2",
+            "slug": "go-sdk-v2",
+            "language": "go",
+            "directory": "tests/conformance/go-sdk-v2",
+            "needs_dynamodb": False,
+            "outcome": "success",
+        }
+
+        result = self.run_script(workflow_text=workflow_text, rows=[row, row])
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("duplicate compatibility result slugs", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_render_compatibility_matrix.py
+++ b/.github/scripts/test_render_compatibility_matrix.py
@@ -147,6 +147,123 @@ class RenderCompatibilityMatrixTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("duplicate compatibility result slugs", result.stderr)
 
+    def test_fails_when_row_outcome_is_empty(self) -> None:
+        workflow_text = textwrap.dedent(
+            """
+            jobs:
+              compatibility:
+                strategy:
+                  matrix:
+                    include:
+                      - name: Go v2
+                        slug: go-sdk-v2
+            """
+        )
+        row = {
+            "suite": "Go v2",
+            "slug": "go-sdk-v2",
+            "language": "go",
+            "directory": "tests/conformance/go-sdk-v2",
+            "needs_dynamodb": False,
+            "outcome": "",
+        }
+
+        result = self.run_script(workflow_text=workflow_text, rows=[row])
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid compatibility outcome", result.stderr)
+        self.assertIn("go-sdk-v2", result.stderr)
+
+    def test_fails_when_row_outcome_is_unknown(self) -> None:
+        workflow_text = textwrap.dedent(
+            """
+            jobs:
+              compatibility:
+                strategy:
+                  matrix:
+                    include:
+                      - name: Go v2
+                        slug: go-sdk-v2
+            """
+        )
+        row = {
+            "suite": "Go v2",
+            "slug": "go-sdk-v2",
+            "language": "go",
+            "directory": "tests/conformance/go-sdk-v2",
+            "needs_dynamodb": False,
+            "outcome": "unknown",
+        }
+
+        result = self.run_script(workflow_text=workflow_text, rows=[row])
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid compatibility outcome", result.stderr)
+        self.assertIn("go-sdk-v2", result.stderr)
+
+    def test_fails_when_row_outcome_is_missing(self) -> None:
+        workflow_text = textwrap.dedent(
+            """
+            jobs:
+              compatibility:
+                strategy:
+                  matrix:
+                    include:
+                      - name: Go v2
+                        slug: go-sdk-v2
+            """
+        )
+        row = {
+            "suite": "Go v2",
+            "slug": "go-sdk-v2",
+            "language": "go",
+            "directory": "tests/conformance/go-sdk-v2",
+            "needs_dynamodb": False,
+        }
+
+        result = self.run_script(workflow_text=workflow_text, rows=[row])
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid compatibility outcome", result.stderr)
+        self.assertIn("go-sdk-v2", result.stderr)
+
+    def test_accepts_cancelled_and_skipped_rows(self) -> None:
+        workflow_text = textwrap.dedent(
+            """
+            jobs:
+              compatibility:
+                strategy:
+                  matrix:
+                    include:
+                      - name: Go v2
+                        slug: go-sdk-v2
+                      - name: Python (boto3)
+                        slug: python-boto3
+            """
+        )
+        rows = [
+            {
+                "suite": "Go v2",
+                "slug": "go-sdk-v2",
+                "language": "go",
+                "directory": "tests/conformance/go-sdk-v2",
+                "needs_dynamodb": False,
+                "outcome": "cancelled",
+            },
+            {
+                "suite": "Python (boto3)",
+                "slug": "python-boto3",
+                "language": "python",
+                "directory": "tests/conformance/python-boto3",
+                "needs_dynamodb": False,
+                "outcome": "skipped",
+            },
+        ]
+
+        result = self.run_script(workflow_text=workflow_text, rows=rows)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -1,0 +1,247 @@
+name: Nightly Compatibility Matrix
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to verify
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-compatibility-matrix-${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-server:
+    name: Build Server
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
+      - uses: ./.github/actions/setup-rust-toolchain
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
+      - name: Build release binary
+        run: cargo build --release
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ferrokinesis-linux
+          path: target/release/ferrokinesis
+          retention-days: 1
+
+  compatibility:
+    name: Compatibility (${{ matrix.name }})
+    needs: build-server
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Go v2
+            slug: go-sdk-v2
+            lang: go
+            dir: tests/conformance/go-sdk-v2
+            setup: ""
+            run: go test -v -count=1 -timeout 120s ./...
+          - name: Python (boto3)
+            slug: python-boto3
+            lang: python
+            dir: tests/conformance/python-boto3
+            setup: pip install -r requirements.txt
+            run: pytest -v test_conformance.py
+          - name: Node.js v3
+            slug: node-sdk-v3
+            lang: node
+            dir: tests/conformance/node-sdk-v3
+            setup: npm ci
+            run: npx vitest run --reporter=verbose
+          - name: Java SDK v2
+            slug: java-sdk-v2
+            lang: java-v2
+            dir: tests/conformance/java-sdk-v2
+            setup: ""
+            run: mvn -B test
+          - name: Java SDK v1
+            slug: java-sdk-v1
+            lang: java-v1
+            dir: tests/conformance/java-sdk-v1
+            setup: ""
+            run: mvn -B test
+          - name: Java KCL v1
+            slug: java-kcl-v1
+            lang: java-kcl-v1
+            dir: tests/conformance/java-kcl-v1
+            setup: ""
+            run: mvn -B test
+            needs_dynamodb: true
+          - name: Java KCL v2
+            slug: java-kcl-v2
+            lang: java-kcl-v2
+            dir: tests/conformance/java-kcl-v2
+            setup: ""
+            run: mvn -B test
+            needs_dynamodb: true
+    env:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_DEFAULT_REGION: us-east-1
+      KINESIS_ENDPOINT: http://localhost:4567
+      DYNAMODB_ENDPOINT: http://localhost:8000
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
+
+      - name: Download server binary
+        uses: actions/download-artifact@v4
+        with:
+          name: ferrokinesis-linux
+
+      - name: Start server
+        run: |
+          chmod +x ferrokinesis
+          ./ferrokinesis \
+            --create-stream-ms 0 \
+            --delete-stream-ms 0 \
+            --update-stream-ms 0 &
+
+      - name: Wait for server
+        run: bash tests/conformance/wait-for-server.sh
+
+      - name: Start DynamoDB Local
+        if: matrix.needs_dynamodb
+        run: |
+          docker run -d --name dynamodb-local -p 8000:8000 amazon/dynamodb-local
+          for i in $(seq 1 15); do
+            if curl -sf -X POST http://localhost:8000 \
+              -H 'Content-Type: application/x-amz-json-1.0' \
+              -H 'X-Amz-Target: DynamoDB_20120810.ListTables' \
+              -d '{"Limit": 1}' > /dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Setup Go
+        if: matrix.lang == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+          cache-dependency-path: ${{ matrix.dir }}/go.sum
+
+      - name: Setup Node.js
+        if: matrix.lang == 'node'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ${{ matrix.dir }}/package-lock.json
+
+      - name: Setup Java
+        if: startsWith(matrix.lang, 'java')
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+          cache: maven
+          cache-dependency-path: ${{ matrix.dir }}/pom.xml
+
+      - name: Setup Python
+        if: matrix.lang == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: ${{ matrix.dir }}/requirements.txt
+
+      - name: Install dependencies
+        if: matrix.setup != ''
+        working-directory: ${{ matrix.dir }}
+        run: ${{ matrix.setup }}
+
+      - name: Run compatibility suite
+        id: compatibility
+        working-directory: ${{ matrix.dir }}
+        run: ${{ matrix.run }}
+
+      - name: Capture matrix row
+        if: always()
+        env:
+          NEEDS_DYNAMODB: ${{ matrix.needs_dynamodb || false }}
+        run: |
+          mkdir -p compatibility-results
+          cat > "compatibility-results/${{ matrix.slug }}.json" <<EOF
+          {
+            "suite": "${{ matrix.name }}",
+            "slug": "${{ matrix.slug }}",
+            "language": "${{ matrix.lang }}",
+            "directory": "${{ matrix.dir }}",
+            "needs_dynamodb": ${NEEDS_DYNAMODB},
+            "outcome": "${{ steps.compatibility.outcome }}"
+          }
+          EOF
+
+      - name: Upload matrix row
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compatibility-result-${{ matrix.slug }}
+          path: compatibility-results/${{ matrix.slug }}.json
+          retention-days: 7
+
+      - name: Stop DynamoDB Local
+        if: always() && matrix.needs_dynamodb
+        run: docker rm -f dynamodb-local || true
+
+      - name: Stop server
+        if: always()
+        run: pkill -f ferrokinesis || true
+
+  report:
+    name: Compatibility Report
+    needs: [build-server, compatibility]
+    if: always() && needs.build-server.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
+
+      - name: Download matrix results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: compatibility-result-*
+          path: compatibility-results
+          merge-multiple: true
+
+      - name: Render markdown report
+        run: |
+          python3 .github/scripts/render-compatibility-matrix.py \
+            --template .github/compatibility-matrix.md \
+            --results-dir compatibility-results \
+            --output compatibility-matrix-report.md \
+            --ref "${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}"
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: compatibility-matrix-report
+          path: compatibility-matrix-report.md
+          retention-days: 30
+
+      - name: Append job summary
+        run: cat compatibility-matrix-report.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -1,6 +1,7 @@
 name: Nightly Compatibility Matrix
 
 on:
+  pull_request:
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:
@@ -234,6 +235,7 @@ jobs:
             --template .github/compatibility-matrix.md \
             --results-dir compatibility-results \
             --output compatibility-matrix-report.md \
+            --workflow .github/workflows/compatibility-matrix.yml \
             --ref "${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}"
 
       - name: Upload report artifact

--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -191,7 +191,8 @@ jobs:
             "language": "${{ matrix.lang }}",
             "directory": "${{ matrix.dir }}",
             "needs_dynamodb": ${NEEDS_DYNAMODB},
-            "outcome": "${{ steps.compatibility.outcome }}"
+            "outcome": "${{ job.status }}",
+            "suite_outcome": "${{ steps.compatibility.outcome }}"
           }
           EOF
 

--- a/crates/ferrokinesis-core/src/operation.rs
+++ b/crates/ferrokinesis-core/src/operation.rs
@@ -190,48 +190,91 @@ impl FromStr for Operation {
 }
 
 impl Operation {
+    /// Stable list of every supported Kinesis operation.
+    pub const ALL: [Self; 39] = [
+        Self::AddTagsToStream,
+        Self::CreateStream,
+        Self::DecreaseStreamRetentionPeriod,
+        Self::DeleteResourcePolicy,
+        Self::DeleteStream,
+        Self::DeregisterStreamConsumer,
+        Self::DescribeAccountSettings,
+        Self::DescribeLimits,
+        Self::DescribeStream,
+        Self::DescribeStreamConsumer,
+        Self::DescribeStreamSummary,
+        Self::DisableEnhancedMonitoring,
+        Self::EnableEnhancedMonitoring,
+        Self::GetRecords,
+        Self::GetResourcePolicy,
+        Self::GetShardIterator,
+        Self::IncreaseStreamRetentionPeriod,
+        Self::ListShards,
+        Self::ListStreamConsumers,
+        Self::ListStreams,
+        Self::ListTagsForResource,
+        Self::ListTagsForStream,
+        Self::MergeShards,
+        Self::PutRecord,
+        Self::PutRecords,
+        Self::PutResourcePolicy,
+        Self::RegisterStreamConsumer,
+        Self::RemoveTagsFromStream,
+        Self::SplitShard,
+        Self::StartStreamEncryption,
+        Self::StopStreamEncryption,
+        Self::SubscribeToShard,
+        Self::TagResource,
+        Self::UntagResource,
+        Self::UpdateAccountSettings,
+        Self::UpdateMaxRecordSize,
+        Self::UpdateShardCount,
+        Self::UpdateStreamMode,
+        Self::UpdateStreamWarmThroughput,
+    ];
+
     /// Returns the canonical operation name used in `X-Amz-Target`.
     pub const fn as_str(self) -> &'static str {
         match self {
-            Operation::AddTagsToStream => "AddTagsToStream",
-            Operation::CreateStream => "CreateStream",
-            Operation::DecreaseStreamRetentionPeriod => "DecreaseStreamRetentionPeriod",
-            Operation::DeleteResourcePolicy => "DeleteResourcePolicy",
-            Operation::DeleteStream => "DeleteStream",
-            Operation::DeregisterStreamConsumer => "DeregisterStreamConsumer",
-            Operation::DescribeAccountSettings => "DescribeAccountSettings",
-            Operation::DescribeLimits => "DescribeLimits",
-            Operation::DescribeStream => "DescribeStream",
-            Operation::DescribeStreamConsumer => "DescribeStreamConsumer",
-            Operation::DescribeStreamSummary => "DescribeStreamSummary",
-            Operation::DisableEnhancedMonitoring => "DisableEnhancedMonitoring",
-            Operation::EnableEnhancedMonitoring => "EnableEnhancedMonitoring",
-            Operation::GetRecords => "GetRecords",
-            Operation::GetResourcePolicy => "GetResourcePolicy",
-            Operation::GetShardIterator => "GetShardIterator",
-            Operation::IncreaseStreamRetentionPeriod => "IncreaseStreamRetentionPeriod",
-            Operation::ListShards => "ListShards",
-            Operation::ListStreamConsumers => "ListStreamConsumers",
-            Operation::ListStreams => "ListStreams",
-            Operation::ListTagsForResource => "ListTagsForResource",
-            Operation::ListTagsForStream => "ListTagsForStream",
-            Operation::MergeShards => "MergeShards",
-            Operation::PutRecord => "PutRecord",
-            Operation::PutRecords => "PutRecords",
-            Operation::PutResourcePolicy => "PutResourcePolicy",
-            Operation::RegisterStreamConsumer => "RegisterStreamConsumer",
-            Operation::RemoveTagsFromStream => "RemoveTagsFromStream",
-            Operation::SplitShard => "SplitShard",
-            Operation::StartStreamEncryption => "StartStreamEncryption",
-            Operation::StopStreamEncryption => "StopStreamEncryption",
-            Operation::SubscribeToShard => "SubscribeToShard",
-            Operation::TagResource => "TagResource",
-            Operation::UntagResource => "UntagResource",
-            Operation::UpdateAccountSettings => "UpdateAccountSettings",
-            Operation::UpdateMaxRecordSize => "UpdateMaxRecordSize",
-            Operation::UpdateShardCount => "UpdateShardCount",
-            Operation::UpdateStreamMode => "UpdateStreamMode",
-            Operation::UpdateStreamWarmThroughput => "UpdateStreamWarmThroughput",
+            Self::AddTagsToStream => "AddTagsToStream",
+            Self::CreateStream => "CreateStream",
+            Self::DecreaseStreamRetentionPeriod => "DecreaseStreamRetentionPeriod",
+            Self::DeleteResourcePolicy => "DeleteResourcePolicy",
+            Self::DeleteStream => "DeleteStream",
+            Self::DeregisterStreamConsumer => "DeregisterStreamConsumer",
+            Self::DescribeAccountSettings => "DescribeAccountSettings",
+            Self::DescribeLimits => "DescribeLimits",
+            Self::DescribeStream => "DescribeStream",
+            Self::DescribeStreamConsumer => "DescribeStreamConsumer",
+            Self::DescribeStreamSummary => "DescribeStreamSummary",
+            Self::DisableEnhancedMonitoring => "DisableEnhancedMonitoring",
+            Self::EnableEnhancedMonitoring => "EnableEnhancedMonitoring",
+            Self::GetRecords => "GetRecords",
+            Self::GetResourcePolicy => "GetResourcePolicy",
+            Self::GetShardIterator => "GetShardIterator",
+            Self::IncreaseStreamRetentionPeriod => "IncreaseStreamRetentionPeriod",
+            Self::ListShards => "ListShards",
+            Self::ListStreamConsumers => "ListStreamConsumers",
+            Self::ListStreams => "ListStreams",
+            Self::ListTagsForResource => "ListTagsForResource",
+            Self::ListTagsForStream => "ListTagsForStream",
+            Self::MergeShards => "MergeShards",
+            Self::PutRecord => "PutRecord",
+            Self::PutRecords => "PutRecords",
+            Self::PutResourcePolicy => "PutResourcePolicy",
+            Self::RegisterStreamConsumer => "RegisterStreamConsumer",
+            Self::RemoveTagsFromStream => "RemoveTagsFromStream",
+            Self::SplitShard => "SplitShard",
+            Self::StartStreamEncryption => "StartStreamEncryption",
+            Self::StopStreamEncryption => "StopStreamEncryption",
+            Self::SubscribeToShard => "SubscribeToShard",
+            Self::TagResource => "TagResource",
+            Self::UntagResource => "UntagResource",
+            Self::UpdateAccountSettings => "UpdateAccountSettings",
+            Self::UpdateMaxRecordSize => "UpdateMaxRecordSize",
+            Self::UpdateShardCount => "UpdateShardCount",
+            Self::UpdateStreamMode => "UpdateStreamMode",
+            Self::UpdateStreamWarmThroughput => "UpdateStreamWarmThroughput",
         }
     }
 
@@ -278,6 +321,30 @@ impl Operation {
             Operation::UpdateShardCount => rules::update_shard_count(),
             Operation::UpdateStreamMode => rules::update_stream_mode(),
             Operation::UpdateStreamWarmThroughput => rules::update_stream_warm_throughput(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Operation;
+    use alloc::vec::Vec;
+    use core::str::FromStr;
+
+    #[test]
+    fn all_operations_round_trip_through_canonical_name() {
+        let mut seen = Vec::new();
+
+        for operation in Operation::ALL {
+            let name = operation.as_str();
+
+            assert_eq!(Operation::from_str(name), Ok(operation));
+            assert!(
+                !seen.contains(&name),
+                "duplicate operation name in catalog: {name}"
+            );
+
+            seen.push(name);
         }
     }
 }

--- a/crates/ferrokinesis-core/src/operation.rs
+++ b/crates/ferrokinesis-core/src/operation.rs
@@ -6,132 +6,180 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::str::FromStr;
 
-/// All valid Kinesis API operations.
-///
-/// Adding a variant here causes the compiler to flag any exhaustiveness gaps
-/// in `dispatch` and `validation_rules` — never use wildcard `_` arms.
-///
-/// Each variant corresponds to the operation name from the `X-Amz-Target` header
-/// (e.g. `Kinesis_20131202.PutRecord`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Operation {
+macro_rules! define_operations {
+    (
+        $(
+            $(#[$meta:meta])*
+            $variant:ident => $name:literal,
+        )+
+    ) => {
+        /// All valid Kinesis API operations.
+        ///
+        /// Adding a variant here causes the compiler to flag any exhaustiveness gaps
+        /// in `dispatch` and `validation_rules` — never use wildcard `_` arms.
+        ///
+        /// Each variant corresponds to the operation name from the `X-Amz-Target` header
+        /// (e.g. `Kinesis_20131202.PutRecord`).
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum Operation {
+            $(
+                $(#[$meta])*
+                $variant,
+            )+
+        }
+
+        impl Operation {
+            /// Number of supported Kinesis operations.
+            pub const COUNT: usize = define_operations!(@count $($variant),+);
+
+            /// Stable list of every supported Kinesis operation.
+            pub const ALL: [Self; Self::COUNT] = [
+                $(Self::$variant,)+
+            ];
+
+            /// Returns the canonical operation name used in `X-Amz-Target`.
+            pub const fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $name,)+
+                }
+            }
+        }
+
+        impl FromStr for Operation {
+            type Err = ();
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    $($name => Ok(Self::$variant),)+
+                    _ => Err(()),
+                }
+            }
+        }
+    };
+    (@count $($variant:ident),+) => {
+        <[()]>::len(&[$(define_operations!(@replace $variant)),+])
+    };
+    (@replace $_variant:ident) => { () };
+}
+
+define_operations! {
     /// Adds or updates tags on a stream.
     #[doc(alias = "Kinesis_20131202.AddTagsToStream")]
-    AddTagsToStream,
+    AddTagsToStream => "AddTagsToStream",
     /// Creates a new Kinesis data stream.
     #[doc(alias = "Kinesis_20131202.CreateStream")]
-    CreateStream,
+    CreateStream => "CreateStream",
     /// Decreases the stream's data retention period.
     #[doc(alias = "Kinesis_20131202.DecreaseStreamRetentionPeriod")]
-    DecreaseStreamRetentionPeriod,
+    DecreaseStreamRetentionPeriod => "DecreaseStreamRetentionPeriod",
     /// Deletes a resource-based policy from a stream or consumer.
     #[doc(alias = "Kinesis_20131202.DeleteResourcePolicy")]
-    DeleteResourcePolicy,
+    DeleteResourcePolicy => "DeleteResourcePolicy",
     /// Deletes a Kinesis data stream and all its shards and data.
     #[doc(alias = "Kinesis_20131202.DeleteStream")]
-    DeleteStream,
+    DeleteStream => "DeleteStream",
     /// Deregisters an enhanced fan-out consumer from a stream.
     #[doc(alias = "Kinesis_20131202.DeregisterStreamConsumer")]
-    DeregisterStreamConsumer,
+    DeregisterStreamConsumer => "DeregisterStreamConsumer",
     /// Returns the limits for the current account and region.
     #[doc(alias = "Kinesis_20131202.DescribeAccountSettings")]
-    DescribeAccountSettings,
+    DescribeAccountSettings => "DescribeAccountSettings",
     /// Describes the shard limits and usage for the account.
     #[doc(alias = "Kinesis_20131202.DescribeLimits")]
-    DescribeLimits,
+    DescribeLimits => "DescribeLimits",
     /// Returns detailed information about a stream, including its shards.
     #[doc(alias = "Kinesis_20131202.DescribeStream")]
-    DescribeStream,
+    DescribeStream => "DescribeStream",
     /// Returns detailed information about a registered consumer.
     #[doc(alias = "Kinesis_20131202.DescribeStreamConsumer")]
-    DescribeStreamConsumer,
+    DescribeStreamConsumer => "DescribeStreamConsumer",
     /// Returns a summary of the stream without shard-level detail.
     #[doc(alias = "Kinesis_20131202.DescribeStreamSummary")]
-    DescribeStreamSummary,
+    DescribeStreamSummary => "DescribeStreamSummary",
     /// Disables enhanced shard-level CloudWatch metrics for a stream.
     #[doc(alias = "Kinesis_20131202.DisableEnhancedMonitoring")]
-    DisableEnhancedMonitoring,
+    DisableEnhancedMonitoring => "DisableEnhancedMonitoring",
     /// Enables enhanced shard-level CloudWatch metrics for a stream.
     #[doc(alias = "Kinesis_20131202.EnableEnhancedMonitoring")]
-    EnableEnhancedMonitoring,
+    EnableEnhancedMonitoring => "EnableEnhancedMonitoring",
     /// Gets data records from a shard using a shard iterator.
     #[doc(alias = "Kinesis_20131202.GetRecords")]
-    GetRecords,
+    GetRecords => "GetRecords",
     /// Returns the resource-based policy for a stream or consumer.
     #[doc(alias = "Kinesis_20131202.GetResourcePolicy")]
-    GetResourcePolicy,
+    GetResourcePolicy => "GetResourcePolicy",
     /// Returns a shard iterator for reading records from a shard.
     #[doc(alias = "Kinesis_20131202.GetShardIterator")]
-    GetShardIterator,
+    GetShardIterator => "GetShardIterator",
     /// Increases the stream's data retention period.
     #[doc(alias = "Kinesis_20131202.IncreaseStreamRetentionPeriod")]
-    IncreaseStreamRetentionPeriod,
+    IncreaseStreamRetentionPeriod => "IncreaseStreamRetentionPeriod",
     /// Lists the shards in a stream and provides information about each.
     #[doc(alias = "Kinesis_20131202.ListShards")]
-    ListShards,
+    ListShards => "ListShards",
     /// Lists the consumers registered to a stream.
     #[doc(alias = "Kinesis_20131202.ListStreamConsumers")]
-    ListStreamConsumers,
+    ListStreamConsumers => "ListStreamConsumers",
     /// Lists the Kinesis data streams in the current account and region.
     #[doc(alias = "Kinesis_20131202.ListStreams")]
-    ListStreams,
+    ListStreams => "ListStreams",
     /// Lists the tags for a Kinesis resource (stream or consumer).
     #[doc(alias = "Kinesis_20131202.ListTagsForResource")]
-    ListTagsForResource,
+    ListTagsForResource => "ListTagsForResource",
     /// Lists the tags for a stream (legacy operation; prefer `ListTagsForResource`).
     #[doc(alias = "Kinesis_20131202.ListTagsForStream")]
-    ListTagsForStream,
+    ListTagsForStream => "ListTagsForStream",
     /// Merges two adjacent shards in a stream into a single shard.
     #[doc(alias = "Kinesis_20131202.MergeShards")]
-    MergeShards,
+    MergeShards => "MergeShards",
     /// Writes a single data record into a stream.
     #[doc(alias = "Kinesis_20131202.PutRecord")]
-    PutRecord,
+    PutRecord => "PutRecord",
     /// Writes multiple data records into a stream in a single call.
     #[doc(alias = "Kinesis_20131202.PutRecords")]
-    PutRecords,
+    PutRecords => "PutRecords",
     /// Attaches a resource-based policy to a stream or consumer.
     #[doc(alias = "Kinesis_20131202.PutResourcePolicy")]
-    PutResourcePolicy,
+    PutResourcePolicy => "PutResourcePolicy",
     /// Registers an enhanced fan-out consumer with a stream.
     #[doc(alias = "Kinesis_20131202.RegisterStreamConsumer")]
-    RegisterStreamConsumer,
+    RegisterStreamConsumer => "RegisterStreamConsumer",
     /// Removes tags from a stream.
     #[doc(alias = "Kinesis_20131202.RemoveTagsFromStream")]
-    RemoveTagsFromStream,
+    RemoveTagsFromStream => "RemoveTagsFromStream",
     /// Splits a shard into two new shards.
     #[doc(alias = "Kinesis_20131202.SplitShard")]
-    SplitShard,
+    SplitShard => "SplitShard",
     /// Enables server-side encryption using KMS for a stream.
     #[doc(alias = "Kinesis_20131202.StartStreamEncryption")]
-    StartStreamEncryption,
+    StartStreamEncryption => "StartStreamEncryption",
     /// Disables server-side encryption for a stream.
     #[doc(alias = "Kinesis_20131202.StopStreamEncryption")]
-    StopStreamEncryption,
+    StopStreamEncryption => "StopStreamEncryption",
     /// Subscribes to receive data records from a shard via HTTP/2 event stream.
     #[doc(alias = "Kinesis_20131202.SubscribeToShard")]
-    SubscribeToShard,
+    SubscribeToShard => "SubscribeToShard",
     /// Adds or updates tags on a Kinesis resource.
     #[doc(alias = "Kinesis_20131202.TagResource")]
-    TagResource,
+    TagResource => "TagResource",
     /// Removes tags from a Kinesis resource.
     #[doc(alias = "Kinesis_20131202.UntagResource")]
-    UntagResource,
+    UntagResource => "UntagResource",
     /// Updates account-level settings.
     #[doc(alias = "Kinesis_20131202.UpdateAccountSettings")]
-    UpdateAccountSettings,
+    UpdateAccountSettings => "UpdateAccountSettings",
     /// Updates the maximum record size for a stream.
     #[doc(alias = "Kinesis_20131202.UpdateMaxRecordSize")]
-    UpdateMaxRecordSize,
+    UpdateMaxRecordSize => "UpdateMaxRecordSize",
     /// Updates the shard count of a stream.
     #[doc(alias = "Kinesis_20131202.UpdateShardCount")]
-    UpdateShardCount,
+    UpdateShardCount => "UpdateShardCount",
     /// Switches a stream between `PROVISIONED` and `ON_DEMAND` capacity modes.
     #[doc(alias = "Kinesis_20131202.UpdateStreamMode")]
-    UpdateStreamMode,
+    UpdateStreamMode => "UpdateStreamMode",
     /// Updates the warm throughput configuration of a stream.
     #[doc(alias = "Kinesis_20131202.UpdateStreamWarmThroughput")]
-    UpdateStreamWarmThroughput,
+    UpdateStreamWarmThroughput => "UpdateStreamWarmThroughput",
 }
 
 impl fmt::Display for Operation {
@@ -140,144 +188,7 @@ impl fmt::Display for Operation {
     }
 }
 
-impl FromStr for Operation {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "AddTagsToStream" => Ok(Self::AddTagsToStream),
-            "CreateStream" => Ok(Self::CreateStream),
-            "DecreaseStreamRetentionPeriod" => Ok(Self::DecreaseStreamRetentionPeriod),
-            "DeleteResourcePolicy" => Ok(Self::DeleteResourcePolicy),
-            "DeleteStream" => Ok(Self::DeleteStream),
-            "DeregisterStreamConsumer" => Ok(Self::DeregisterStreamConsumer),
-            "DescribeAccountSettings" => Ok(Self::DescribeAccountSettings),
-            "DescribeLimits" => Ok(Self::DescribeLimits),
-            "DescribeStream" => Ok(Self::DescribeStream),
-            "DescribeStreamConsumer" => Ok(Self::DescribeStreamConsumer),
-            "DescribeStreamSummary" => Ok(Self::DescribeStreamSummary),
-            "DisableEnhancedMonitoring" => Ok(Self::DisableEnhancedMonitoring),
-            "EnableEnhancedMonitoring" => Ok(Self::EnableEnhancedMonitoring),
-            "GetRecords" => Ok(Self::GetRecords),
-            "GetResourcePolicy" => Ok(Self::GetResourcePolicy),
-            "GetShardIterator" => Ok(Self::GetShardIterator),
-            "IncreaseStreamRetentionPeriod" => Ok(Self::IncreaseStreamRetentionPeriod),
-            "ListShards" => Ok(Self::ListShards),
-            "ListStreamConsumers" => Ok(Self::ListStreamConsumers),
-            "ListStreams" => Ok(Self::ListStreams),
-            "ListTagsForResource" => Ok(Self::ListTagsForResource),
-            "ListTagsForStream" => Ok(Self::ListTagsForStream),
-            "MergeShards" => Ok(Self::MergeShards),
-            "PutRecord" => Ok(Self::PutRecord),
-            "PutRecords" => Ok(Self::PutRecords),
-            "PutResourcePolicy" => Ok(Self::PutResourcePolicy),
-            "RegisterStreamConsumer" => Ok(Self::RegisterStreamConsumer),
-            "RemoveTagsFromStream" => Ok(Self::RemoveTagsFromStream),
-            "SplitShard" => Ok(Self::SplitShard),
-            "StartStreamEncryption" => Ok(Self::StartStreamEncryption),
-            "StopStreamEncryption" => Ok(Self::StopStreamEncryption),
-            "SubscribeToShard" => Ok(Self::SubscribeToShard),
-            "TagResource" => Ok(Self::TagResource),
-            "UntagResource" => Ok(Self::UntagResource),
-            "UpdateAccountSettings" => Ok(Self::UpdateAccountSettings),
-            "UpdateMaxRecordSize" => Ok(Self::UpdateMaxRecordSize),
-            "UpdateShardCount" => Ok(Self::UpdateShardCount),
-            "UpdateStreamMode" => Ok(Self::UpdateStreamMode),
-            "UpdateStreamWarmThroughput" => Ok(Self::UpdateStreamWarmThroughput),
-            _ => Err(()),
-        }
-    }
-}
-
 impl Operation {
-    /// Stable list of every supported Kinesis operation.
-    pub const ALL: [Self; 39] = [
-        Self::AddTagsToStream,
-        Self::CreateStream,
-        Self::DecreaseStreamRetentionPeriod,
-        Self::DeleteResourcePolicy,
-        Self::DeleteStream,
-        Self::DeregisterStreamConsumer,
-        Self::DescribeAccountSettings,
-        Self::DescribeLimits,
-        Self::DescribeStream,
-        Self::DescribeStreamConsumer,
-        Self::DescribeStreamSummary,
-        Self::DisableEnhancedMonitoring,
-        Self::EnableEnhancedMonitoring,
-        Self::GetRecords,
-        Self::GetResourcePolicy,
-        Self::GetShardIterator,
-        Self::IncreaseStreamRetentionPeriod,
-        Self::ListShards,
-        Self::ListStreamConsumers,
-        Self::ListStreams,
-        Self::ListTagsForResource,
-        Self::ListTagsForStream,
-        Self::MergeShards,
-        Self::PutRecord,
-        Self::PutRecords,
-        Self::PutResourcePolicy,
-        Self::RegisterStreamConsumer,
-        Self::RemoveTagsFromStream,
-        Self::SplitShard,
-        Self::StartStreamEncryption,
-        Self::StopStreamEncryption,
-        Self::SubscribeToShard,
-        Self::TagResource,
-        Self::UntagResource,
-        Self::UpdateAccountSettings,
-        Self::UpdateMaxRecordSize,
-        Self::UpdateShardCount,
-        Self::UpdateStreamMode,
-        Self::UpdateStreamWarmThroughput,
-    ];
-
-    /// Returns the canonical operation name used in `X-Amz-Target`.
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::AddTagsToStream => "AddTagsToStream",
-            Self::CreateStream => "CreateStream",
-            Self::DecreaseStreamRetentionPeriod => "DecreaseStreamRetentionPeriod",
-            Self::DeleteResourcePolicy => "DeleteResourcePolicy",
-            Self::DeleteStream => "DeleteStream",
-            Self::DeregisterStreamConsumer => "DeregisterStreamConsumer",
-            Self::DescribeAccountSettings => "DescribeAccountSettings",
-            Self::DescribeLimits => "DescribeLimits",
-            Self::DescribeStream => "DescribeStream",
-            Self::DescribeStreamConsumer => "DescribeStreamConsumer",
-            Self::DescribeStreamSummary => "DescribeStreamSummary",
-            Self::DisableEnhancedMonitoring => "DisableEnhancedMonitoring",
-            Self::EnableEnhancedMonitoring => "EnableEnhancedMonitoring",
-            Self::GetRecords => "GetRecords",
-            Self::GetResourcePolicy => "GetResourcePolicy",
-            Self::GetShardIterator => "GetShardIterator",
-            Self::IncreaseStreamRetentionPeriod => "IncreaseStreamRetentionPeriod",
-            Self::ListShards => "ListShards",
-            Self::ListStreamConsumers => "ListStreamConsumers",
-            Self::ListStreams => "ListStreams",
-            Self::ListTagsForResource => "ListTagsForResource",
-            Self::ListTagsForStream => "ListTagsForStream",
-            Self::MergeShards => "MergeShards",
-            Self::PutRecord => "PutRecord",
-            Self::PutRecords => "PutRecords",
-            Self::PutResourcePolicy => "PutResourcePolicy",
-            Self::RegisterStreamConsumer => "RegisterStreamConsumer",
-            Self::RemoveTagsFromStream => "RemoveTagsFromStream",
-            Self::SplitShard => "SplitShard",
-            Self::StartStreamEncryption => "StartStreamEncryption",
-            Self::StopStreamEncryption => "StopStreamEncryption",
-            Self::SubscribeToShard => "SubscribeToShard",
-            Self::TagResource => "TagResource",
-            Self::UntagResource => "UntagResource",
-            Self::UpdateAccountSettings => "UpdateAccountSettings",
-            Self::UpdateMaxRecordSize => "UpdateMaxRecordSize",
-            Self::UpdateShardCount => "UpdateShardCount",
-            Self::UpdateStreamMode => "UpdateStreamMode",
-            Self::UpdateStreamWarmThroughput => "UpdateStreamWarmThroughput",
-        }
-    }
-
     /// Returns the validation rules for this operation.
     pub fn validation_rules(&self) -> Vec<(&'static str, FieldDef)> {
         use validation::rules;
@@ -335,6 +246,8 @@ mod tests {
     fn all_operations_round_trip_through_canonical_name() {
         let mut seen = Vec::new();
 
+        assert_eq!(Operation::ALL.len(), Operation::COUNT);
+
         for operation in Operation::ALL {
             let name = operation.as_str();
 
@@ -346,5 +259,13 @@ mod tests {
 
             seen.push(name);
         }
+    }
+
+    #[test]
+    fn rejects_unknown_operation_names() {
+        assert_eq!(
+            Operation::from_str("DefinitelyNotAKinesisOperation"),
+            Err(())
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a nightly/manual workflow that runs the existing SDK and KCL conformance suites against a built ferrokinesis binary
- render a markdown compatibility report artifact from per-suite JSON results
- add a canonical operation catalog for report tooling

## Notes
- this is the first implementation slice for #146, not the full AWS side-by-side diff yet
- the current suite harnesses still need follow-up work before we can publish a true AWS parity score

## Testing
- cargo test -p ferrokinesis-core all_operations_round_trip_through_canonical_name
- cargo fmt --all --check
- python3 -m py_compile .github/scripts/render-compatibility-matrix.py

Refs #146