### PR TITLE
chore: update rand for security audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
   schedule:
     - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2646,9 +2646,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
## Summary
- update `rand` in `Cargo.lock` from 0.9.2 to 0.9.3 to address `RUSTSEC-2026-0097`
- restore a clean `Security Audit` baseline for active feature branches

## Testing
- cargo deny check advisories licenses bans sources
- cargo test --workspace --quiet

Closes #201