### PR TITLE
feat: add durable single-node state mode

### DIFF
--- a/crates/ferrokinesis-core/src/types.rs
+++ b/crates/ferrokinesis-core/src/types.rs
@@ -401,7 +401,7 @@ pub struct EnhancedMonitoring {
 }
 
 /// Describes a single shard within a Kinesis data stream.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Shard {
     /// Unique identifier for this shard (e.g. `"shardId-000000000000"`).
@@ -437,6 +437,15 @@ pub struct HashKeyRange {
     #[serde(skip)]
     end_cached: std::sync::OnceLock<u128>,
 }
+
+impl PartialEq for HashKeyRange {
+    fn eq(&self, other: &Self) -> bool {
+        self.starting_hash_key == other.starting_hash_key
+            && self.ending_hash_key == other.ending_hash_key
+    }
+}
+
+impl Eq for HashKeyRange {}
 
 impl HashKeyRange {
     /// Creates a new hash key range from decimal string bounds.
@@ -487,7 +496,7 @@ impl HashKeyRange {
 }
 
 /// The range of sequence numbers assigned to a shard.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct SequenceNumberRange {
     /// The sequence number of the first record written to the shard.

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -24,6 +24,7 @@ struct KinesisOptions {
     iterator_ttl_seconds: Option<u64>,
     retention_check_interval_secs: Option<u64>,
     enforce_limits: Option<bool>,
+    max_retained_bytes: Option<u64>,
     account_id: Option<String>,
     region: Option<String>,
     max_request_body_mb: Option<u64>,
@@ -50,30 +51,7 @@ impl Kinesis {
 
         let options = parse_options(options)?;
         let defaults = StoreOptions::default();
-        let store_options = StoreOptions {
-            create_stream_ms: options
-                .create_stream_ms
-                .unwrap_or(defaults.create_stream_ms),
-            delete_stream_ms: options
-                .delete_stream_ms
-                .unwrap_or(defaults.delete_stream_ms),
-            update_stream_ms: options
-                .update_stream_ms
-                .unwrap_or(defaults.update_stream_ms),
-            shard_limit: options.shard_limit.unwrap_or(defaults.shard_limit),
-            iterator_ttl_seconds: options
-                .iterator_ttl_seconds
-                .unwrap_or(defaults.iterator_ttl_seconds),
-            retention_check_interval_secs: options
-                .retention_check_interval_secs
-                .unwrap_or(defaults.retention_check_interval_secs),
-            enforce_limits: options.enforce_limits.unwrap_or(defaults.enforce_limits),
-            state_dir: defaults.state_dir,
-            snapshot_interval_secs: defaults.snapshot_interval_secs,
-            max_retained_bytes: defaults.max_retained_bytes,
-            aws_account_id: options.account_id.unwrap_or(defaults.aws_account_id),
-            aws_region: options.region.unwrap_or(defaults.aws_region),
-        };
+        let store_options = build_store_options(&options, &defaults);
 
         let max_bytes: usize = options
             .max_request_body_mb
@@ -149,6 +127,7 @@ fn parse_options(options: Option<JsValue>) -> Result<KinesisOptions, JsValue> {
             iterator_ttl_seconds: read_option(&value, "iteratorTtlSeconds")?,
             retention_check_interval_secs: read_option(&value, "retentionCheckIntervalSecs")?,
             enforce_limits: read_option(&value, "enforceLimits")?,
+            max_retained_bytes: read_option(&value, "maxRetainedBytes")?,
             account_id: read_option(&value, "accountId")?,
             region: read_option(&value, "region")?,
             max_request_body_mb: read_option(&value, "maxRequestBodyMb")?,
@@ -170,6 +149,56 @@ fn read_option<T: DeserializeOwned>(value: &JsValue, field: &str) -> Result<Opti
 
 fn js_error(message: impl Into<String>) -> JsValue {
     JsValue::from_str(&message.into())
+}
+
+fn build_store_options(options: &KinesisOptions, defaults: &StoreOptions) -> StoreOptions {
+    StoreOptions {
+        create_stream_ms: options
+            .create_stream_ms
+            .unwrap_or(defaults.create_stream_ms),
+        delete_stream_ms: options
+            .delete_stream_ms
+            .unwrap_or(defaults.delete_stream_ms),
+        update_stream_ms: options
+            .update_stream_ms
+            .unwrap_or(defaults.update_stream_ms),
+        shard_limit: options.shard_limit.unwrap_or(defaults.shard_limit),
+        iterator_ttl_seconds: options
+            .iterator_ttl_seconds
+            .unwrap_or(defaults.iterator_ttl_seconds),
+        retention_check_interval_secs: options
+            .retention_check_interval_secs
+            .unwrap_or(defaults.retention_check_interval_secs),
+        enforce_limits: options.enforce_limits.unwrap_or(defaults.enforce_limits),
+        state_dir: defaults.state_dir.clone(),
+        snapshot_interval_secs: defaults.snapshot_interval_secs,
+        max_retained_bytes: options.max_retained_bytes.or(defaults.max_retained_bytes),
+        aws_account_id: options
+            .account_id
+            .clone()
+            .unwrap_or_else(|| defaults.aws_account_id.clone()),
+        aws_region: options
+            .region
+            .clone()
+            .unwrap_or_else(|| defaults.aws_region.clone()),
+    }
+}
+
+#[cfg(test)]
+mod native_tests {
+    use super::*;
+
+    #[test]
+    fn build_store_options_threads_max_retained_bytes() {
+        let defaults = StoreOptions::default();
+        let options = KinesisOptions {
+            max_retained_bytes: Some(1234),
+            ..KinesisOptions::default()
+        };
+
+        let store_options = build_store_options(&options, &defaults);
+        assert_eq!(store_options.max_retained_bytes, Some(1234));
+    }
 }
 
 #[cfg(all(test, target_arch = "wasm32"))]

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -68,6 +68,9 @@ impl Kinesis {
                 .retention_check_interval_secs
                 .unwrap_or(defaults.retention_check_interval_secs),
             enforce_limits: options.enforce_limits.unwrap_or(defaults.enforce_limits),
+            state_dir: defaults.state_dir,
+            snapshot_interval_secs: defaults.snapshot_interval_secs,
+            max_retained_bytes: defaults.max_retained_bytes,
             aws_account_id: options.account_id.unwrap_or(defaults.aws_account_id),
             aws_region: options.region.unwrap_or(defaults.aws_region),
         };

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -4,7 +4,7 @@ use axum::body::{Body, to_bytes};
 use axum::extract::DefaultBodyLimit;
 use axum::http::Request;
 use ferrokinesis::constants;
-use ferrokinesis::store::{Store, StoreOptions};
+use ferrokinesis::store::{DurableStateOptions, Store, StoreOptions};
 use js_sys::Reflect;
 use serde::{Serialize, de::DeserializeOwned};
 use tower::util::ServiceExt;
@@ -152,6 +152,7 @@ fn js_error(message: impl Into<String>) -> JsValue {
 }
 
 fn build_store_options(options: &KinesisOptions, defaults: &StoreOptions) -> StoreOptions {
+    let max_retained_bytes = options.max_retained_bytes.or(defaults.max_retained_bytes);
     StoreOptions {
         create_stream_ms: options
             .create_stream_ms
@@ -170,9 +171,15 @@ fn build_store_options(options: &KinesisOptions, defaults: &StoreOptions) -> Sto
             .retention_check_interval_secs
             .unwrap_or(defaults.retention_check_interval_secs),
         enforce_limits: options.enforce_limits.unwrap_or(defaults.enforce_limits),
-        state_dir: defaults.state_dir.clone(),
-        snapshot_interval_secs: defaults.snapshot_interval_secs,
-        max_retained_bytes: options.max_retained_bytes.or(defaults.max_retained_bytes),
+        durable: defaults
+            .durable
+            .as_ref()
+            .map(|durable| DurableStateOptions {
+                state_dir: durable.state_dir.clone(),
+                snapshot_interval_secs: durable.snapshot_interval_secs,
+                max_retained_bytes,
+            }),
+        max_retained_bytes,
         aws_account_id: options
             .account_id
             .clone()

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -232,7 +232,8 @@ mod tests {
         kinesis
             ._store
             .put_record("retention-stream", &key, &record)
-            .await;
+            .await
+            .unwrap();
 
         assert_eq!(
             kinesis

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -4,9 +4,7 @@ use axum::body::{Body, to_bytes};
 use axum::extract::DefaultBodyLimit;
 use axum::http::Request;
 use ferrokinesis::constants;
-use ferrokinesis::store::{
-    DurableStateOptions, Store, StoreOptions, validate_durable_settings,
-};
+use ferrokinesis::store::{DurableStateOptions, Store, StoreOptions, validate_durable_settings};
 use js_sys::Reflect;
 use serde::{Serialize, de::DeserializeOwned};
 use tower::util::ServiceExt;

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -4,7 +4,9 @@ use axum::body::{Body, to_bytes};
 use axum::extract::DefaultBodyLimit;
 use axum::http::Request;
 use ferrokinesis::constants;
-use ferrokinesis::store::{DurableStateOptions, Store, StoreOptions};
+use ferrokinesis::store::{
+    DurableStateOptions, Store, StoreOptions, validate_durable_settings,
+};
 use js_sys::Reflect;
 use serde::{Serialize, de::DeserializeOwned};
 use tower::util::ServiceExt;
@@ -51,7 +53,7 @@ impl Kinesis {
 
         let options = parse_options(options)?;
         let defaults = StoreOptions::default();
-        let store_options = build_store_options(&options, &defaults);
+        let store_options = build_store_options(&options, &defaults).map_err(js_error)?;
 
         let max_bytes: usize = options
             .max_request_body_mb
@@ -151,9 +153,19 @@ fn js_error(message: impl Into<String>) -> JsValue {
     JsValue::from_str(&message.into())
 }
 
-fn build_store_options(options: &KinesisOptions, defaults: &StoreOptions) -> StoreOptions {
+fn build_store_options(
+    options: &KinesisOptions,
+    defaults: &StoreOptions,
+) -> Result<StoreOptions, String> {
     let max_retained_bytes = options.max_retained_bytes.or(defaults.max_retained_bytes);
-    StoreOptions {
+    let snapshot_interval_secs = defaults
+        .durable
+        .as_ref()
+        .map(|durable| durable.snapshot_interval_secs);
+    validate_durable_settings(snapshot_interval_secs, max_retained_bytes)
+        .map_err(|err| err.to_string())?;
+
+    Ok(StoreOptions {
         create_stream_ms: options
             .create_stream_ms
             .unwrap_or(defaults.create_stream_ms),
@@ -188,7 +200,7 @@ fn build_store_options(options: &KinesisOptions, defaults: &StoreOptions) -> Sto
             .region
             .clone()
             .unwrap_or_else(|| defaults.aws_region.clone()),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -203,8 +215,20 @@ mod native_tests {
             ..KinesisOptions::default()
         };
 
-        let store_options = build_store_options(&options, &defaults);
+        let store_options = build_store_options(&options, &defaults).unwrap();
         assert_eq!(store_options.max_retained_bytes, Some(1234));
+    }
+
+    #[test]
+    fn build_store_options_rejects_zero_max_retained_bytes() {
+        let defaults = StoreOptions::default();
+        let options = KinesisOptions {
+            max_retained_bytes: Some(0),
+            ..KinesisOptions::default()
+        };
+
+        let err = build_store_options(&options, &defaults).unwrap_err();
+        assert!(err.contains("max_retained_bytes must be greater than 0"));
     }
 }
 

--- a/src/actions/create_stream.rs
+++ b/src/actions/create_stream.rs
@@ -1,7 +1,7 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
 use crate::sequence;
-use crate::store::{PendingTransition, Store, TransitionMutation};
+use crate::store::{PendingTransition, Store};
 use crate::types::*;
 use crate::util::current_time_ms;
 use num_bigint::BigUint;
@@ -17,35 +17,6 @@ const SEQ_ADJUST_MS: u64 = 2000;
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
     let stream_name = data[constants::STREAM_NAME].as_str().unwrap_or("");
     let shard_count = data[constants::SHARD_COUNT].as_i64().unwrap_or(0) as u32;
-
-    // Check if stream already exists
-    if store.contains_stream(stream_name).await {
-        return Err(KinesisErrorResponse::stream_in_use(
-            stream_name,
-            &store.aws_account_id,
-        ));
-    }
-
-    // Check shard limit
-    let shard_sum = store.sum_open_shards().await;
-    if shard_sum + shard_count > store.options.shard_limit {
-        return Err(KinesisErrorResponse::client_error(
-            constants::LIMIT_EXCEEDED,
-            Some(&format!(
-                "This request would exceed the shard limit for the account {} in {}. \
-                 Current shard count for the account: {}. Limit: {}. \
-                 Number of additional shards that would have resulted from this request: {}. \
-                 Refer to the AWS Service Limits page \
-                 (http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) \
-                 for current limits and how to request higher limits.",
-                store.aws_account_id,
-                store.aws_region,
-                shard_sum,
-                store.options.shard_limit,
-                shard_count
-            )),
-        ));
-    }
 
     let pow_128 = BigUint::one() << 128;
     let shard_hash = &pow_128 / BigUint::from(shard_count);
@@ -100,11 +71,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     .build();
 
     store
-        .put_stream_with_transition(
-            stream_name,
-            stream,
-            TransitionMutation::Upsert(transition.clone()),
-        )
+        .create_stream_with_reservation(stream_name, shard_count, stream, transition.clone())
         .await?;
     tracing::info!(stream = stream_name, shards = shard_count, "stream created");
     store.schedule_transition(transition);

--- a/src/actions/create_stream.rs
+++ b/src/actions/create_stream.rs
@@ -105,7 +105,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
             stream,
             TransitionMutation::Upsert(transition.clone()),
         )
-        .await;
+        .await?;
     tracing::info!(stream = stream_name, shards = shard_count, "stream created");
     store.schedule_transition(transition);
 

--- a/src/actions/create_stream.rs
+++ b/src/actions/create_stream.rs
@@ -1,7 +1,7 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
 use crate::sequence;
-use crate::store::Store;
+use crate::store::{PendingTransition, Store, TransitionMutation};
 use crate::types::*;
 use crate::util::current_time_ms;
 use num_bigint::BigUint;
@@ -80,6 +80,13 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         });
     }
 
+    let delay = store.options.create_stream_ms;
+    let transition = PendingTransition::CreateStream {
+        stream_name: stream_name.to_string(),
+        ready_at_ms: current_time_ms().saturating_add(delay),
+        shards: shards.clone(),
+    };
+
     let stream = StreamBuilder::new(
         stream_name.to_string(),
         format!(
@@ -92,23 +99,15 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     )
     .build();
 
-    store.put_stream(stream_name, stream).await;
+    store
+        .put_stream_with_transition(
+            stream_name,
+            stream,
+            TransitionMutation::Upsert(transition.clone()),
+        )
+        .await;
     tracing::info!(stream = stream_name, shards = shard_count, "stream created");
-
-    // Transition to ACTIVE after delay
-    let store_clone = store.clone();
-    let name = stream_name.to_string();
-    let delay = store.options.create_stream_ms;
-    crate::runtime::spawn_background(async move {
-        crate::runtime::sleep_ms(delay).await;
-        let _ = store_clone
-            .update_stream(&name, |stream| {
-                stream.stream_status = StreamStatus::Active;
-                stream.shards = shards;
-                Ok(())
-            })
-            .await;
-    });
+    store.schedule_transition(transition);
 
     Ok(None) // Empty 200 response
 }

--- a/src/actions/delete_resource_policy.rs
+++ b/src/actions/delete_resource_policy.rs
@@ -13,7 +13,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         ));
     }
 
-    store.delete_policy(resource_arn).await;
+    store.delete_policy(resource_arn).await?;
     tracing::trace!(resource_arn, "resource policy deleted");
     Ok(None)
 }

--- a/src/actions/delete_stream.rs
+++ b/src/actions/delete_stream.rs
@@ -1,29 +1,32 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
-use crate::store::Store;
+use crate::store::{PendingTransition, Store, TransitionMutation};
 use crate::types::StreamStatus;
+use crate::util::current_time_ms;
 use serde_json::Value;
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
     let stream_name = data[constants::STREAM_NAME].as_str().unwrap_or("");
 
     // Verify stream exists and set to DELETING
+    let delay = store.options.delete_stream_ms;
+    let transition = PendingTransition::DeleteStream {
+        stream_name: stream_name.to_string(),
+        ready_at_ms: current_time_ms().saturating_add(delay),
+    };
+
     store
-        .update_stream(stream_name, |stream| {
-            stream.stream_status = StreamStatus::Deleting;
-            Ok(())
-        })
+        .update_stream_with_transition(
+            stream_name,
+            TransitionMutation::Upsert(transition.clone()),
+            |stream| {
+                stream.stream_status = StreamStatus::Deleting;
+                Ok(())
+            },
+        )
         .await?;
     tracing::info!(stream = stream_name, "stream deletion initiated");
-
-    // Delete after delay
-    let store_clone = store.clone();
-    let name = stream_name.to_string();
-    let delay = store.options.delete_stream_ms;
-    crate::runtime::spawn_background(async move {
-        crate::runtime::sleep_ms(delay).await;
-        store_clone.delete_stream(&name).await;
-    });
+    store.schedule_transition(transition);
 
     Ok(None)
 }

--- a/src/actions/deregister_stream_consumer.rs
+++ b/src/actions/deregister_stream_consumer.rs
@@ -50,7 +50,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
             updated,
             TransitionMutation::Upsert(transition.clone()),
         )
-        .await;
+        .await?;
     tracing::info!(consumer_arn = %resolved_arn, "consumer deregistered");
     store.schedule_transition(transition);
 

--- a/src/actions/deregister_stream_consumer.rs
+++ b/src/actions/deregister_stream_consumer.rs
@@ -1,7 +1,8 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
-use crate::store::Store;
+use crate::store::{PendingTransition, Store, TransitionMutation};
 use crate::types::ConsumerStatus;
+use crate::util::current_time_ms;
 use serde_json::Value;
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -39,16 +40,19 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     // Set to DELETING
     let mut updated = consumer;
     updated.consumer_status = ConsumerStatus::Deleting;
-    store.put_consumer(&resolved_arn, updated).await;
+    let transition = PendingTransition::DeregisterConsumer {
+        consumer_arn: resolved_arn.clone(),
+        ready_at_ms: current_time_ms().saturating_add(500),
+    };
+    store
+        .put_consumer_with_transition(
+            &resolved_arn,
+            updated,
+            TransitionMutation::Upsert(transition.clone()),
+        )
+        .await;
     tracing::info!(consumer_arn = %resolved_arn, "consumer deregistered");
-
-    // Delete after short delay
-    let store_clone = store.clone();
-    let arn = resolved_arn;
-    crate::runtime::spawn_background(async move {
-        crate::runtime::sleep_ms(500).await;
-        store_clone.delete_consumer(&arn).await;
-    });
+    store.schedule_transition(transition);
 
     Ok(None)
 }

--- a/src/actions/get_shard_iterator.rs
+++ b/src/actions/get_shard_iterator.rs
@@ -187,6 +187,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 let result =
                     shard_iterator::create_shard_iterator(stream_name, &shard_id, &seq, now);
                 tracing::trace!(stream = %stream_name, shard = %shard_id, iterator_type = %iterator_type_raw, "shard iterator created");
+                store.record_iterator_created(now).await;
                 return Ok(Some(json!({ "ShardIterator": result })));
             }
             ShardIteratorType::AtSequenceNumber | ShardIteratorType::AfterSequenceNumber => {
@@ -205,5 +206,6 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
 
     let result = shard_iterator::create_shard_iterator(stream_name, &shard_id, &iterator_seq, now);
     tracing::trace!(stream = %stream_name, shard = %shard_id, iterator_type = %iterator_type_raw, "shard iterator created");
+    store.record_iterator_created(now).await;
     Ok(Some(json!({ "ShardIterator": result })))
 }

--- a/src/actions/merge_shards.rs
+++ b/src/actions/merge_shards.rs
@@ -1,7 +1,7 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
 use crate::sequence;
-use crate::store::Store;
+use crate::store::{PendingTransition, Store, TransitionMutation};
 use crate::types::*;
 use crate::util::current_time_ms;
 use serde_json::Value;
@@ -31,8 +31,16 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         shard_ixs.push(ix);
     }
 
+    let delay = store.options.update_stream_ms;
+    let transition = PendingTransition::MergeShards {
+        stream_name: stream_name.to_string(),
+        ready_at_ms: current_time_ms().saturating_add(delay),
+        shard_to_merge: shard_ids[0].clone(),
+        adjacent_shard_to_merge: shard_ids[1].clone(),
+    };
+
     store
-        .update_stream(stream_name, |stream| {
+        .update_stream_with_transition(stream_name, TransitionMutation::Upsert(transition.clone()), |stream| {
             if stream.stream_status != StreamStatus::Active {
                 return Err(KinesisErrorResponse::client_error(
                     constants::RESOURCE_IN_USE,
@@ -81,83 +89,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         })
         .await?;
     tracing::info!(stream = stream_name, "shards merged");
-
-    // Schedule transition
-    let store_clone = store.clone();
-    let name = stream_name.to_string();
-    let delay = store.options.update_stream_ms;
-    let shard_ixs_clone = shard_ixs.clone();
-    let shard_ids_clone = shard_ids.clone();
-
-    crate::runtime::spawn_background(async move {
-        crate::runtime::sleep_ms(delay).await;
-
-        if store_clone
-            .update_stream(&name, |stream| {
-                let now = current_time_ms();
-                stream.stream_status = StreamStatus::Active;
-
-                for &ix in &shard_ixs_clone {
-                    let shard = &mut stream.shards[ix as usize];
-                    let create_time = sequence::parse_sequence(
-                        &shard.sequence_number_range.starting_sequence_number,
-                    )
-                    .map(|s| s.shard_create_time)
-                    .unwrap_or(0);
-
-                    shard.sequence_number_range.ending_sequence_number =
-                        Some(sequence::stringify_sequence(&sequence::SeqObj {
-                            shard_create_time: create_time,
-                            shard_ix: ix,
-                            seq_ix: Some(sequence::MAX_SEQ_IX),
-                            seq_time: Some(now),
-                            byte1: None,
-                            seq_rand: None,
-                            version: 2,
-                        }));
-                }
-
-                let new_ix = stream.shards.len() as i64;
-                let starting_hash = stream.shards[shard_ixs_clone[0] as usize]
-                    .hash_key_range
-                    .starting_hash_key
-                    .clone();
-                let ending_hash = stream.shards[shard_ixs_clone[1] as usize]
-                    .hash_key_range
-                    .ending_hash_key
-                    .clone();
-
-                stream.shards.push(Shard {
-                    parent_shard_id: Some(shard_ids_clone[0].clone()),
-                    adjacent_parent_shard_id: Some(shard_ids_clone[1].clone()),
-                    hash_key_range: HashKeyRange::new(starting_hash, ending_hash),
-                    sequence_number_range: SequenceNumberRange {
-                        starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
-                            // Child's create_time is 1 second ahead of the parent's closing
-                            // timestamp so child sequence numbers always sort lexically after
-                            // the parent's last sequence (the token format encodes create_time
-                            // in hex[1..10], so a higher create_time produces a larger number).
-                            shard_create_time: now + 1000,
-                            shard_ix: new_ix,
-                            seq_ix: None,
-                            seq_time: None,
-                            byte1: None,
-                            seq_rand: None,
-                            version: 2,
-                        }),
-                        ending_sequence_number: None,
-                    },
-                    shard_id: sequence::shard_id_name(new_ix),
-                });
-
-                Ok(())
-            })
-            .await
-            .is_ok()
-        {
-            store_clone.clear_throughput_windows_for_shards(&name, shard_ids_clone.iter());
-        }
-    });
+    store.schedule_transition(transition);
 
     Ok(None)
 }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -111,6 +111,7 @@ pub async fn dispatch(
     operation: Operation,
     data: Value,
 ) -> Result<Option<Value>, KinesisErrorResponse> {
+    store.check_available()?;
     match operation {
         Operation::AddTagsToStream => add_tags_to_stream::execute(store, data).await,
         Operation::CreateStream => create_stream::execute(store, data).await,

--- a/src/actions/put_record.rs
+++ b/src/actions/put_record.rs
@@ -75,13 +75,17 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         }
     } as u64;
 
-    store
+    let reservation = store
         .try_reserve_shard_throughput(&stream_name, &alloc.shard_id, decoded_len, alloc.now)
         .await?;
 
-    store
+    if let Err(err) = store
         .put_record(&stream_name, &alloc.stream_key, &record)
-        .await?;
+        .await
+    {
+        store.refund_shard_throughput(reservation).await;
+        return Err(err);
+    }
 
     #[cfg(feature = "server")]
     if let Some(ref writer) = store.capture_writer {

--- a/src/actions/put_record.rs
+++ b/src/actions/put_record.rs
@@ -13,6 +13,7 @@ use std::borrow::Cow;
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
     let stream_name = store.resolve_stream_name(&data)?;
+    store.check_writable()?;
 
     let partition_key = data[constants::PARTITION_KEY].as_str().unwrap_or("");
     let record_data = data[constants::DATA].as_str().unwrap_or("");

--- a/src/actions/put_records.rs
+++ b/src/actions/put_records.rs
@@ -106,6 +106,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
 
     let mut return_records: Vec<Value> = Vec::with_capacity(records.len());
     let mut batch: Vec<(String, StoredRecordRef<'_>)> = Vec::with_capacity(records.len());
+    let mut reservations = Vec::with_capacity(records.len());
     let mut failed_record_count = 0u64;
 
     for (i, record) in records.iter().enumerate() {
@@ -121,17 +122,20 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
             }
         } as u64;
 
-        if let Err(err) = store
+        let reservation = match store
             .try_reserve_shard_throughput(&stream_name, &alloc.shard_id, decoded_len, alloc.now)
             .await
         {
-            failed_record_count += 1;
-            return_records.push(json!({
-                constants::ERROR_CODE: err.body.error_type,
-                "ErrorMessage": err.body.message.unwrap_or_else(|| "Rate exceeded for shard".to_string()),
-            }));
-            continue;
-        }
+            Ok(reservation) => reservation,
+            Err(err) => {
+                failed_record_count += 1;
+                return_records.push(json!({
+                    constants::ERROR_CODE: err.body.error_type,
+                    "ErrorMessage": err.body.message.unwrap_or_else(|| "Rate exceeded for shard".to_string()),
+                }));
+                continue;
+            }
+        };
 
         batch.push((
             alloc.stream_key.clone(),
@@ -141,6 +145,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 approximate_arrival_timestamp: (alloc.now / 1000) as f64,
             },
         ));
+        reservations.push(reservation);
 
         return_records.push(json!({
             "ShardId": alloc.shard_id,
@@ -148,8 +153,13 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         }));
     }
 
-    if !batch.is_empty() {
-        store.put_records_batch(&stream_name, &batch).await?;
+    if !batch.is_empty()
+        && let Err(err) = store.put_records_batch(&stream_name, &batch).await
+    {
+        for reservation in reservations {
+            store.refund_shard_throughput(reservation).await;
+        }
+        return Err(err);
     }
 
     #[cfg(feature = "server")]

--- a/src/actions/put_records.rs
+++ b/src/actions/put_records.rs
@@ -42,6 +42,7 @@ fn build_capture_refs<'a>(
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
     let stream_name = store.resolve_stream_name(&data)?;
+    store.check_writable()?;
 
     let records = data[constants::RECORDS].as_array().ok_or_else(|| {
         KinesisErrorResponse::client_error(constants::SERIALIZATION_EXCEPTION, None)

--- a/src/actions/put_resource_policy.rs
+++ b/src/actions/put_resource_policy.rs
@@ -22,7 +22,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         ));
     }
 
-    store.put_policy(resource_arn, policy).await;
+    store.put_policy(resource_arn, policy).await?;
     tracing::trace!(resource_arn, "resource policy put");
     Ok(None)
 }

--- a/src/actions/register_stream_consumer.rs
+++ b/src/actions/register_stream_consumer.rs
@@ -61,7 +61,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
             consumer.clone(),
             TransitionMutation::Upsert(transition.clone()),
         )
-        .await;
+        .await?;
     tracing::info!(
         stream = stream_arn,
         consumer = consumer_name,

--- a/src/actions/register_stream_consumer.rs
+++ b/src/actions/register_stream_consumer.rs
@@ -1,6 +1,6 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
-use crate::store::Store;
+use crate::store::{PendingTransition, Store, TransitionMutation};
 use crate::types::{Consumer, ConsumerStatus, EpochSeconds};
 use crate::util::current_time_ms;
 use serde_json::{Value, json};
@@ -50,23 +50,24 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         consumer_creation_timestamp: creation_ts,
     };
 
-    store.put_consumer(&consumer_arn, consumer.clone()).await;
+    let transition = PendingTransition::RegisterConsumer {
+        consumer_arn: consumer_arn.clone(),
+        ready_at_ms: now.saturating_add(500),
+    };
+
+    store
+        .put_consumer_with_transition(
+            &consumer_arn,
+            consumer.clone(),
+            TransitionMutation::Upsert(transition.clone()),
+        )
+        .await;
     tracing::info!(
         stream = stream_arn,
         consumer = consumer_name,
         "consumer registered"
     );
-
-    // Transition to ACTIVE after a short delay
-    let store_clone = store.clone();
-    let arn = consumer_arn.clone();
-    crate::runtime::spawn_background(async move {
-        crate::runtime::sleep_ms(500).await;
-        if let Some(mut c) = store_clone.get_consumer(&arn).await {
-            c.consumer_status = ConsumerStatus::Active;
-            store_clone.put_consumer(&arn, c).await;
-        }
-    });
+    store.schedule_transition(transition);
 
     Ok(Some(json!({
         "Consumer": consumer,

--- a/src/actions/split_shard.rs
+++ b/src/actions/split_shard.rs
@@ -1,7 +1,7 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
 use crate::sequence;
-use crate::store::Store;
+use crate::store::{PendingTransition, Store, TransitionMutation};
 use crate::types::*;
 use crate::util::current_time_ms;
 use serde_json::Value;
@@ -26,8 +26,16 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     // Get shard sum across all streams (separate read transaction)
     let shard_sum = store.sum_open_shards().await;
 
-    let (shard_start, shard_end, hash_key) = store
-        .update_stream(stream_name, |stream| {
+    let delay = store.options.update_stream_ms;
+    let transition = PendingTransition::SplitShard {
+        stream_name: stream_name.to_string(),
+        ready_at_ms: current_time_ms().saturating_add(delay),
+        shard_to_split: shard_id.clone(),
+        new_starting_hash_key: new_starting_hash_key.to_string(),
+    };
+
+    store
+        .update_stream_with_transition(stream_name, TransitionMutation::Upsert(transition.clone()), |stream| {
             if stream.stream_status != StreamStatus::Active {
                 return Err(KinesisErrorResponse::client_error(
                     constants::RESOURCE_IN_USE,
@@ -85,97 +93,11 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
             }
 
             stream.stream_status = StreamStatus::Updating;
-
-            Ok((shard_start, shard_end, hash_key))
+            Ok(())
         })
         .await?;
     tracing::info!(stream = stream_name, "shard split");
-
-    let store_clone = store.clone();
-    let name = stream_name.to_string();
-    let delay = store.options.update_stream_ms;
-    let shard_id_clone = shard_id.clone();
-
-    crate::runtime::spawn_background(async move {
-        crate::runtime::sleep_ms(delay).await;
-
-        if store_clone
-            .update_stream(&name, |stream| {
-                let now = current_time_ms();
-                stream.stream_status = StreamStatus::Active;
-
-                let shard = &mut stream.shards[shard_ix as usize];
-                let create_time =
-                    sequence::parse_sequence(&shard.sequence_number_range.starting_sequence_number)
-                        .map(|s| s.shard_create_time)
-                        .unwrap_or(0);
-
-                shard.sequence_number_range.ending_sequence_number =
-                    Some(sequence::stringify_sequence(&sequence::SeqObj {
-                        shard_create_time: create_time,
-                        shard_ix,
-                        seq_ix: Some(sequence::MAX_SEQ_IX),
-                        seq_time: Some(now),
-                        byte1: None,
-                        seq_rand: None,
-                        version: 2,
-                    }));
-
-                let new_ix1 = stream.shards.len() as i64;
-                stream.shards.push(Shard {
-                    parent_shard_id: Some(shard_id_clone.clone()),
-                    adjacent_parent_shard_id: None,
-                    hash_key_range: HashKeyRange::new(
-                        shard_start.to_string(),
-                        (hash_key - 1).to_string(),
-                    ),
-                    sequence_number_range: SequenceNumberRange {
-                        starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
-                            // Child's create_time is 1 second ahead of the parent's closing
-                            // timestamp so child sequence numbers always sort lexically after
-                            // the parent's last sequence (the token format encodes create_time
-                            // in hex[1..10], so a higher create_time produces a larger number).
-                            shard_create_time: now + 1000,
-                            shard_ix: new_ix1,
-                            seq_ix: None,
-                            seq_time: None,
-                            byte1: None,
-                            seq_rand: None,
-                            version: 2,
-                        }),
-                        ending_sequence_number: None,
-                    },
-                    shard_id: sequence::shard_id_name(new_ix1),
-                });
-
-                let new_ix2 = stream.shards.len() as i64;
-                stream.shards.push(Shard {
-                    parent_shard_id: Some(shard_id_clone.clone()),
-                    adjacent_parent_shard_id: None,
-                    hash_key_range: HashKeyRange::new(hash_key.to_string(), shard_end.to_string()),
-                    sequence_number_range: SequenceNumberRange {
-                        starting_sequence_number: sequence::stringify_sequence(&sequence::SeqObj {
-                            shard_create_time: now + 1000,
-                            shard_ix: new_ix2,
-                            seq_ix: None,
-                            seq_time: None,
-                            byte1: None,
-                            seq_rand: None,
-                            version: 2,
-                        }),
-                        ending_sequence_number: None,
-                    },
-                    shard_id: sequence::shard_id_name(new_ix2),
-                });
-
-                Ok(())
-            })
-            .await
-            .is_ok()
-        {
-            store_clone.clear_throughput_windows_for_shards(&name, [shard_id_clone.as_str()]);
-        }
-    });
+    store.schedule_transition(transition);
 
     Ok(None)
 }

--- a/src/actions/split_shard.rs
+++ b/src/actions/split_shard.rs
@@ -1,8 +1,7 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
 use crate::sequence;
-use crate::store::{PendingTransition, Store, TransitionMutation};
-use crate::types::*;
+use crate::store::{PendingTransition, Store};
 use crate::util::current_time_ms;
 use serde_json::Value;
 
@@ -23,9 +22,6 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         )
     })?;
 
-    // Get shard sum across all streams (separate read transaction)
-    let shard_sum = store.sum_open_shards().await;
-
     let delay = store.options.update_stream_ms;
     let transition = PendingTransition::SplitShard {
         stream_name: stream_name.to_string(),
@@ -35,66 +31,13 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     };
 
     store
-        .update_stream_with_transition(stream_name, TransitionMutation::Upsert(transition.clone()), |stream| {
-            if stream.stream_status != StreamStatus::Active {
-                return Err(KinesisErrorResponse::client_error(
-                    constants::RESOURCE_IN_USE,
-                    Some(&format!(
-                        "Stream {} under account {} not ACTIVE, instead in state {}",
-                        stream_name, store.aws_account_id, stream.stream_status
-                    )),
-                ));
-            }
-
-            if shard_ix >= stream.shards.len() as i64 {
-                return Err(KinesisErrorResponse::client_error(
-                    constants::RESOURCE_NOT_FOUND,
-                    Some(&format!(
-                        "Could not find shard {} in stream {} under account {}.",
-                        shard_id, stream_name, store.aws_account_id
-                    )),
-                ));
-            }
-
-            if shard_sum + 1 > store.options.shard_limit {
-                return Err(KinesisErrorResponse::client_error(
-                    constants::LIMIT_EXCEEDED,
-                    Some(&format!(
-                        "This request would exceed the shard limit for the account {} in {}. \
-                         Current shard count for the account: {}. Limit: {}. \
-                         Number of additional shards that would have resulted from this request: 1. \
-                         Refer to the AWS Service Limits page \
-                         (http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) \
-                         for current limits and how to request higher limits.",
-                        store.aws_account_id, store.aws_region, shard_sum, store.options.shard_limit
-                    )),
-                ));
-            }
-
-            let hash_key: u128 = new_starting_hash_key.parse().unwrap_or(0);
-            let shard = &stream.shards[shard_ix as usize];
-            let shard_start = shard.hash_key_range.start_u128();
-            let shard_end = shard.hash_key_range.end_u128();
-
-            // Strict interior constraint: the split key must be > start+1 AND < end.
-            // Equal to start+1 would give the lower child an empty hash range [start, start];
-            // equal to end would give the upper child an empty range [end, end]. Either
-            // degenerate case would prevent any partition key from routing to that child.
-            if hash_key <= shard_start + 1 || hash_key >= shard_end {
-                return Err(KinesisErrorResponse::client_error(
-                    constants::INVALID_ARGUMENT,
-                    Some(&format!(
-                        "NewStartingHashKey {} used in SplitShard() on shard {} in stream {} under account {} \
-                         is not both greater than one plus the shard's StartingHashKey {} and less than the shard's EndingHashKey {}.",
-                        new_starting_hash_key, shard_id, stream_name, store.aws_account_id,
-                        shard.hash_key_range.starting_hash_key, shard.hash_key_range.ending_hash_key
-                    )),
-                ));
-            }
-
-            stream.stream_status = StreamStatus::Updating;
-            Ok(())
-        })
+        .split_shard_with_reservation(
+            stream_name,
+            &shard_id,
+            shard_ix,
+            new_starting_hash_key,
+            transition.clone(),
+        )
         .await?;
     tracing::info!(stream = stream_name, "shard split");
     store.schedule_transition(transition);

--- a/src/actions/start_stream_encryption.rs
+++ b/src/actions/start_stream_encryption.rs
@@ -1,7 +1,8 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
-use crate::store::Store;
-use crate::types::{EncryptionType, StreamStatus};
+use crate::store::{PendingTransition, Store, TransitionMutation};
+use crate::types::StreamStatus;
+use crate::util::current_time_ms;
 use serde_json::Value;
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -16,38 +17,35 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         ));
     }
 
-    store
-        .update_stream(stream_name, |stream| {
-            if stream.stream_status != StreamStatus::Active {
-                return Err(KinesisErrorResponse::client_error(
-                    constants::RESOURCE_IN_USE,
-                    Some(&format!(
-                        "Stream {} under account {} not ACTIVE, instead in state {}",
-                        stream_name, store.aws_account_id, stream.stream_status
-                    )),
-                ));
-            }
+    let delay = store.options.update_stream_ms;
+    let transition = PendingTransition::StartStreamEncryption {
+        stream_name: stream_name.to_string(),
+        ready_at_ms: current_time_ms().saturating_add(delay),
+    };
 
-            stream.stream_status = StreamStatus::Updating;
-            stream.key_id = Some(key_id.to_string());
-            Ok(())
-        })
+    store
+        .update_stream_with_transition(
+            stream_name,
+            TransitionMutation::Upsert(transition.clone()),
+            |stream| {
+                if stream.stream_status != StreamStatus::Active {
+                    return Err(KinesisErrorResponse::client_error(
+                        constants::RESOURCE_IN_USE,
+                        Some(&format!(
+                            "Stream {} under account {} not ACTIVE, instead in state {}",
+                            stream_name, store.aws_account_id, stream.stream_status
+                        )),
+                    ));
+                }
+
+                stream.stream_status = StreamStatus::Updating;
+                stream.key_id = Some(key_id.to_string());
+                Ok(())
+            },
+        )
         .await?;
     tracing::info!(stream = stream_name, "encryption started");
-
-    let store_clone = store.clone();
-    let name = stream_name.to_string();
-    let delay = store.options.update_stream_ms;
-    crate::runtime::spawn_background(async move {
-        crate::runtime::sleep_ms(delay).await;
-        let _ = store_clone
-            .update_stream(&name, |stream| {
-                stream.stream_status = StreamStatus::Active;
-                stream.encryption_type = EncryptionType::Kms;
-                Ok(())
-            })
-            .await;
-    });
+    store.schedule_transition(transition);
 
     Ok(None)
 }

--- a/src/actions/stop_stream_encryption.rs
+++ b/src/actions/stop_stream_encryption.rs
@@ -1,7 +1,8 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
-use crate::store::Store;
+use crate::store::{PendingTransition, Store, TransitionMutation};
 use crate::types::{EncryptionType, StreamStatus};
+use crate::util::current_time_ms;
 use serde_json::Value;
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
@@ -15,48 +16,44 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         ));
     }
 
+    let delay = store.options.update_stream_ms;
+    let transition = PendingTransition::StopStreamEncryption {
+        stream_name: stream_name.to_string(),
+        ready_at_ms: current_time_ms().saturating_add(delay),
+    };
+
     store
-        .update_stream(stream_name, |stream| {
-            if stream.stream_status != StreamStatus::Active {
-                return Err(KinesisErrorResponse::client_error(
-                    constants::RESOURCE_IN_USE,
-                    Some(&format!(
-                        "Stream {} under account {} not ACTIVE, instead in state {}",
-                        stream_name, store.aws_account_id, stream.stream_status
-                    )),
-                ));
-            }
+        .update_stream_with_transition(
+            stream_name,
+            TransitionMutation::Upsert(transition.clone()),
+            |stream| {
+                if stream.stream_status != StreamStatus::Active {
+                    return Err(KinesisErrorResponse::client_error(
+                        constants::RESOURCE_IN_USE,
+                        Some(&format!(
+                            "Stream {} under account {} not ACTIVE, instead in state {}",
+                            stream_name, store.aws_account_id, stream.stream_status
+                        )),
+                    ));
+                }
 
-            if stream.encryption_type != EncryptionType::Kms {
-                return Err(KinesisErrorResponse::client_error(
-                    constants::INVALID_ARGUMENT,
-                    Some(&format!(
-                        "Stream {} under account {} is not encrypted with KMS.",
-                        stream_name, store.aws_account_id
-                    )),
-                ));
-            }
+                if stream.encryption_type != EncryptionType::Kms {
+                    return Err(KinesisErrorResponse::client_error(
+                        constants::INVALID_ARGUMENT,
+                        Some(&format!(
+                            "Stream {} under account {} is not encrypted with KMS.",
+                            stream_name, store.aws_account_id
+                        )),
+                    ));
+                }
 
-            stream.stream_status = StreamStatus::Updating;
-            Ok(())
-        })
+                stream.stream_status = StreamStatus::Updating;
+                Ok(())
+            },
+        )
         .await?;
     tracing::info!(stream = stream_name, "encryption stopped");
-
-    let store_clone = store.clone();
-    let name = stream_name.to_string();
-    let delay = store.options.update_stream_ms;
-    crate::runtime::spawn_background(async move {
-        crate::runtime::sleep_ms(delay).await;
-        let _ = store_clone
-            .update_stream(&name, |stream| {
-                stream.stream_status = StreamStatus::Active;
-                stream.encryption_type = EncryptionType::None;
-                stream.key_id = None;
-                Ok(())
-            })
-            .await;
-    });
+    store.schedule_transition(transition);
 
     Ok(None)
 }

--- a/src/actions/tag_resource.rs
+++ b/src/actions/tag_resource.rs
@@ -82,7 +82,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
             Some("A resource cannot have more than 50 tags."),
         ));
     }
-    store.put_resource_tags(resource_arn, &existing).await;
+    store.put_resource_tags(resource_arn, &existing).await?;
 
     tracing::trace!(resource_arn, tags = tags.len(), "resource tagged");
     Ok(None)

--- a/src/actions/untag_resource.rs
+++ b/src/actions/untag_resource.rs
@@ -47,7 +47,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     for key in &tag_keys {
         existing.remove(key);
     }
-    store.put_resource_tags(resource_arn, &existing).await;
+    store.put_resource_tags(resource_arn, &existing).await?;
 
     tracing::trace!(resource_arn, tags = tag_keys.len(), "resource untagged");
     Ok(None)

--- a/src/actions/update_account_settings.rs
+++ b/src/actions/update_account_settings.rs
@@ -35,7 +35,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         settings = commitment.clone();
     }
 
-    store.put_account_settings(&settings).await;
+    store.put_account_settings(&settings).await?;
 
     tracing::trace!("account settings updated");
     Ok(Some(json!({

--- a/src/actions/update_shard_count.rs
+++ b/src/actions/update_shard_count.rs
@@ -1,150 +1,58 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
-use crate::sequence;
-use crate::store::Store;
+use crate::store::{PendingTransition, Store, TransitionMutation};
 use crate::types::*;
 use crate::util::current_time_ms;
-use num_bigint::BigUint;
-use num_traits::One;
 use serde_json::{Value, json};
 
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
     let stream_name = data[constants::STREAM_NAME].as_str().unwrap_or("");
     let target_shard_count = data[constants::TARGET_SHARD_COUNT].as_i64().unwrap_or(0) as u32;
 
-    let (current_count, stream_name_owned) = store
-        .update_stream(stream_name, |stream| {
-            if stream.stream_status != StreamStatus::Active {
-                return Err(KinesisErrorResponse::client_error(
-                    constants::RESOURCE_IN_USE,
-                    Some(&format!(
-                        "Stream {} under account {} not ACTIVE, instead in state {}",
-                        stream_name, store.aws_account_id, stream.stream_status
-                    )),
-                ));
-            }
-
-            let current_count = stream
-                .shards
-                .iter()
-                .filter(|s| s.sequence_number_range.ending_sequence_number.is_none())
-                .count() as u32;
-
-            if target_shard_count == current_count {
-                return Err(KinesisErrorResponse::client_error(
-                    constants::INVALID_ARGUMENT,
-                    Some(&format!(
-                        "TargetShardCount {} is the same as the current shard count {}.",
-                        target_shard_count, current_count
-                    )),
-                ));
-            }
-
-            stream.stream_status = StreamStatus::Updating;
-            Ok((current_count, stream.stream_name.clone()))
-        })
-        .await?;
-
-    // Perform the resharding asynchronously
-    let store_clone = store.clone();
     let delay = store.options.update_stream_ms;
+    let transition = PendingTransition::UpdateShardCount {
+        stream_name: stream_name.to_string(),
+        ready_at_ms: current_time_ms().saturating_add(delay),
+        target_shard_count,
+    };
 
-    crate::runtime::spawn_background(async move {
-        crate::runtime::sleep_ms(delay).await;
+    let current_count = store
+        .update_stream_with_transition(
+            stream_name,
+            TransitionMutation::Upsert(transition.clone()),
+            |stream| {
+                if stream.stream_status != StreamStatus::Active {
+                    return Err(KinesisErrorResponse::client_error(
+                        constants::RESOURCE_IN_USE,
+                        Some(&format!(
+                            "Stream {} under account {} not ACTIVE, instead in state {}",
+                            stream_name, store.aws_account_id, stream.stream_status
+                        )),
+                    ));
+                }
 
-        if let Ok(closed_shard_ids) = store_clone
-            .update_stream(&stream_name_owned, |stream| {
-                let now = current_time_ms();
-                // Use the maximum possible seq_ix for the closing sequence number.
-                // This ensures no future record written to this shard could ever
-                // produce a sequence number that compares as ≥ the ending sequence,
-                // making the shard-closed invariant unconditionally safe.
-
-                // Close all current open shards
-                let open_indices: Vec<usize> = stream
+                let current_count = stream
                     .shards
                     .iter()
-                    .enumerate()
-                    .filter(|(_, s)| s.sequence_number_range.ending_sequence_number.is_none())
-                    .map(|(i, _)| i)
-                    .collect();
-                let closed_shard_ids = open_indices
-                    .iter()
-                    .map(|&ix| stream.shards[ix].shard_id.clone())
-                    .collect::<Vec<_>>();
+                    .filter(|s| s.sequence_number_range.ending_sequence_number.is_none())
+                    .count() as u32;
 
-                for &ix in &open_indices {
-                    let create_time = sequence::parse_sequence(
-                        &stream.shards[ix]
-                            .sequence_number_range
-                            .starting_sequence_number,
-                    )
-                    .map(|s| s.shard_create_time)
-                    .unwrap_or(0);
-
-                    stream.shards[ix]
-                        .sequence_number_range
-                        .ending_sequence_number =
-                        Some(sequence::stringify_sequence(&sequence::SeqObj {
-                            shard_create_time: create_time,
-                            shard_ix: ix as i64,
-                            seq_ix: Some(sequence::MAX_SEQ_IX),
-                            seq_time: Some(now),
-                            byte1: None,
-                            seq_rand: None,
-                            version: 2,
-                        }));
+                if target_shard_count == current_count {
+                    return Err(KinesisErrorResponse::client_error(
+                        constants::INVALID_ARGUMENT,
+                        Some(&format!(
+                            "TargetShardCount {} is the same as the current shard count {}.",
+                            target_shard_count, current_count
+                        )),
+                    ));
                 }
 
-                // Create new shards with uniform hash distribution
-                let pow_128 = BigUint::one() << 128;
-                let shard_hash = &pow_128 / BigUint::from(target_shard_count);
-
-                for i in 0..target_shard_count {
-                    let new_ix = stream.shards.len() as i64;
-                    let start: BigUint = &shard_hash * BigUint::from(i);
-                    let end: BigUint = if i < target_shard_count - 1 {
-                        &shard_hash * BigUint::from(i + 1) - BigUint::one()
-                    } else {
-                        &pow_128 - BigUint::one()
-                    };
-
-                    stream.shards.push(Shard {
-                        shard_id: sequence::shard_id_name(new_ix),
-                        // UpdateShardCount is a full reshard, not a split/merge; new shards have
-                        // no parent lineage relationship with the old shards.
-                        parent_shard_id: None,
-                        adjacent_parent_shard_id: None,
-                        hash_key_range: HashKeyRange::new(start.to_string(), end.to_string()),
-                        sequence_number_range: SequenceNumberRange {
-                            starting_sequence_number: sequence::stringify_sequence(
-                                &sequence::SeqObj {
-                                    // Child's create_time is 1 second ahead of the parent's closing
-                                    // timestamp so child sequence numbers always sort lexically after
-                                    // the parent's last sequence (the token format encodes create_time
-                                    // in hex[1..10], so a higher create_time produces a larger number).
-                                    shard_create_time: now + 1000,
-                                    shard_ix: new_ix,
-                                    seq_ix: None,
-                                    seq_time: None,
-                                    byte1: None,
-                                    seq_rand: None,
-                                    version: 2,
-                                },
-                            ),
-                            ending_sequence_number: None,
-                        },
-                    });
-                }
-
-                stream.stream_status = StreamStatus::Active;
-                Ok(closed_shard_ids)
-            })
-            .await
-        {
-            store_clone.clear_throughput_windows_for_shards(&stream_name_owned, &closed_shard_ids);
-        }
-    });
+                stream.stream_status = StreamStatus::Updating;
+                Ok(current_count)
+            },
+        )
+        .await?;
+    store.schedule_transition(transition);
 
     tracing::trace!(
         stream = %stream_name,

--- a/src/actions/update_shard_count.rs
+++ b/src/actions/update_shard_count.rs
@@ -1,7 +1,6 @@
 use crate::constants;
 use crate::error::KinesisErrorResponse;
-use crate::store::{PendingTransition, Store, TransitionMutation};
-use crate::types::*;
+use crate::store::{PendingTransition, Store};
 use crate::util::current_time_ms;
 use serde_json::{Value, json};
 
@@ -17,40 +16,7 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     };
 
     let current_count = store
-        .update_stream_with_transition(
-            stream_name,
-            TransitionMutation::Upsert(transition.clone()),
-            |stream| {
-                if stream.stream_status != StreamStatus::Active {
-                    return Err(KinesisErrorResponse::client_error(
-                        constants::RESOURCE_IN_USE,
-                        Some(&format!(
-                            "Stream {} under account {} not ACTIVE, instead in state {}",
-                            stream_name, store.aws_account_id, stream.stream_status
-                        )),
-                    ));
-                }
-
-                let current_count = stream
-                    .shards
-                    .iter()
-                    .filter(|s| s.sequence_number_range.ending_sequence_number.is_none())
-                    .count() as u32;
-
-                if target_shard_count == current_count {
-                    return Err(KinesisErrorResponse::client_error(
-                        constants::INVALID_ARGUMENT,
-                        Some(&format!(
-                            "TargetShardCount {} is the same as the current shard count {}.",
-                            target_shard_count, current_count
-                        )),
-                    ));
-                }
-
-                stream.stream_status = StreamStatus::Updating;
-                Ok(current_count)
-            },
-        )
+        .update_shard_count_with_reservation(stream_name, target_shard_count, transition.clone())
         .await?;
     store.schedule_transition(transition);
 

--- a/src/bin/wasi.rs
+++ b/src/bin/wasi.rs
@@ -215,6 +215,11 @@ impl WasiConfig {
                 .unwrap_or(defaults.retention_check_interval_secs),
                 enforce_limits: read_parsed_env(&mut read, "FERROKINESIS_ENFORCE_LIMITS")?
                     .unwrap_or(defaults.enforce_limits),
+                state_dir: read_env("FERROKINESIS_STATE_DIR")?.or(defaults.state_dir.clone()),
+                snapshot_interval_secs: read_env("FERROKINESIS_SNAPSHOT_INTERVAL_SECS")?
+                    .unwrap_or(defaults.snapshot_interval_secs),
+                max_retained_bytes: read_env("FERROKINESIS_MAX_RETAINED_BYTES")?
+                    .or(defaults.max_retained_bytes),
                 aws_account_id: read("AWS_ACCOUNT_ID")?
                     .unwrap_or_else(|| defaults.aws_account_id.clone()),
                 aws_region,

--- a/src/bin/wasi.rs
+++ b/src/bin/wasi.rs
@@ -215,10 +215,15 @@ impl WasiConfig {
                 .unwrap_or(defaults.retention_check_interval_secs),
                 enforce_limits: read_parsed_env(&mut read, "FERROKINESIS_ENFORCE_LIMITS")?
                     .unwrap_or(defaults.enforce_limits),
-                state_dir: read_env("FERROKINESIS_STATE_DIR")?.or(defaults.state_dir.clone()),
-                snapshot_interval_secs: read_env("FERROKINESIS_SNAPSHOT_INTERVAL_SECS")?
-                    .unwrap_or(defaults.snapshot_interval_secs),
-                max_retained_bytes: read_env("FERROKINESIS_MAX_RETAINED_BYTES")?
+                state_dir: read("FERROKINESIS_STATE_DIR")?
+                    .map(std::path::PathBuf::from)
+                    .or(defaults.state_dir.clone()),
+                snapshot_interval_secs: read_parsed_env(
+                    &mut read,
+                    "FERROKINESIS_SNAPSHOT_INTERVAL_SECS",
+                )?
+                .unwrap_or(defaults.snapshot_interval_secs),
+                max_retained_bytes: read_parsed_env(&mut read, "FERROKINESIS_MAX_RETAINED_BYTES")?
                     .or(defaults.max_retained_bytes),
                 aws_account_id: read("AWS_ACCOUNT_ID")?
                     .unwrap_or_else(|| defaults.aws_account_id.clone()),
@@ -692,5 +697,31 @@ mod tests {
             .try_reserve_shard_throughput("stream", "shardId-000000000000", 1_000, 2_000)
             .await;
         assert!(second.is_err(), "WASI env parsing should enable throttling");
+    }
+
+    #[test]
+    fn from_reader_uses_injected_reader_for_state_dir_snapshot_and_retained_bytes() {
+        let mut env = std::collections::HashMap::from([
+            (
+                "FERROKINESIS_STATE_DIR".to_string(),
+                "/tmp/ferrokinesis-state".to_string(),
+            ),
+            (
+                "FERROKINESIS_SNAPSHOT_INTERVAL_SECS".to_string(),
+                "17".to_string(),
+            ),
+            (
+                "FERROKINESIS_MAX_RETAINED_BYTES".to_string(),
+                "2048".to_string(),
+            ),
+        ]);
+
+        let config = WasiConfig::from_reader(|key| Ok(env.remove(key))).unwrap();
+        assert_eq!(
+            config.store_options.state_dir,
+            Some(std::path::PathBuf::from("/tmp/ferrokinesis-state"))
+        );
+        assert_eq!(config.store_options.snapshot_interval_secs, 17);
+        assert_eq!(config.store_options.max_retained_bytes, Some(2048));
     }
 }

--- a/src/bin/wasi.rs
+++ b/src/bin/wasi.rs
@@ -1,7 +1,10 @@
 use axum::body::{Body, to_bytes};
 use axum::extract::DefaultBodyLimit;
 use axum::http::{HeaderName, HeaderValue, Request, StatusCode, Version};
-use ferrokinesis::store::StoreOptions;
+use ferrokinesis::store::{
+    DEFAULT_DURABLE_SNAPSHOT_INTERVAL_SECS, DurableStateOptions, StoreOptions,
+    validate_durable_settings,
+};
 use std::env;
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -188,6 +191,22 @@ impl WasiConfig {
         let aws_region = read("AWS_REGION")?
             .or(read("AWS_DEFAULT_REGION")?)
             .unwrap_or_else(|| defaults.aws_region.clone());
+        let state_dir = read("FERROKINESIS_STATE_DIR")?.map(std::path::PathBuf::from);
+        let snapshot_interval_secs =
+            read_parsed_env(&mut read, "FERROKINESIS_SNAPSHOT_INTERVAL_SECS")?.unwrap_or_else(
+                || {
+                    defaults
+                        .durable
+                        .as_ref()
+                        .map_or(DEFAULT_DURABLE_SNAPSHOT_INTERVAL_SECS, |durable| {
+                            durable.snapshot_interval_secs
+                        })
+                },
+            );
+        let max_retained_bytes = read_parsed_env(&mut read, "FERROKINESIS_MAX_RETAINED_BYTES")?
+            .or(defaults.max_retained_bytes);
+        validate_durable_settings(Some(snapshot_interval_secs), max_retained_bytes)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
 
         Ok(Self {
             port,
@@ -215,16 +234,12 @@ impl WasiConfig {
                 .unwrap_or(defaults.retention_check_interval_secs),
                 enforce_limits: read_parsed_env(&mut read, "FERROKINESIS_ENFORCE_LIMITS")?
                     .unwrap_or(defaults.enforce_limits),
-                state_dir: read("FERROKINESIS_STATE_DIR")?
-                    .map(std::path::PathBuf::from)
-                    .or(defaults.state_dir.clone()),
-                snapshot_interval_secs: read_parsed_env(
-                    &mut read,
-                    "FERROKINESIS_SNAPSHOT_INTERVAL_SECS",
-                )?
-                .unwrap_or(defaults.snapshot_interval_secs),
-                max_retained_bytes: read_parsed_env(&mut read, "FERROKINESIS_MAX_RETAINED_BYTES")?
-                    .or(defaults.max_retained_bytes),
+                durable: state_dir.map(|state_dir| DurableStateOptions {
+                    state_dir,
+                    snapshot_interval_secs,
+                    max_retained_bytes,
+                }),
+                max_retained_bytes,
                 aws_account_id: read("AWS_ACCOUNT_ID")?
                     .unwrap_or_else(|| defaults.aws_account_id.clone()),
                 aws_region,
@@ -717,11 +732,41 @@ mod tests {
         ]);
 
         let config = WasiConfig::from_reader(|key| Ok(env.remove(key))).unwrap();
+        let durable = config.store_options.durable.expect("durable settings");
         assert_eq!(
-            config.store_options.state_dir,
-            Some(std::path::PathBuf::from("/tmp/ferrokinesis-state"))
+            durable.state_dir,
+            std::path::PathBuf::from("/tmp/ferrokinesis-state")
         );
-        assert_eq!(config.store_options.snapshot_interval_secs, 17);
+        assert_eq!(durable.snapshot_interval_secs, 17);
+        assert_eq!(durable.max_retained_bytes, Some(2048));
         assert_eq!(config.store_options.max_retained_bytes, Some(2048));
+    }
+
+    #[test]
+    fn from_reader_rejects_zero_max_retained_bytes() {
+        let mut env = std::collections::HashMap::from([(
+            "FERROKINESIS_MAX_RETAINED_BYTES".to_string(),
+            "0".to_string(),
+        )]);
+
+        let err = WasiConfig::from_reader(|key| Ok(env.remove(key))).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("max_retained_bytes must be greater than 0")
+        );
+    }
+
+    #[test]
+    fn from_reader_rejects_out_of_range_snapshot_interval() {
+        let mut env = std::collections::HashMap::from([(
+            "FERROKINESIS_SNAPSHOT_INTERVAL_SECS".to_string(),
+            "86401".to_string(),
+        )]);
+
+        let err = WasiConfig::from_reader(|key| Ok(env.remove(key))).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("snapshot_interval_secs must be between 0 and 86400")
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,12 @@ pub struct FileConfig {
     pub retention_check_interval_secs: Option<u64>,
     /// Enable AWS-like shard write throughput throttling.
     pub enforce_limits: Option<bool>,
+    /// Directory used to persist runtime state with WAL + snapshots.
+    pub state_dir: Option<PathBuf>,
+    /// Snapshot interval in seconds when durable mode is enabled.
+    pub snapshot_interval_secs: Option<u64>,
+    /// Hard cap on retained serialized record bytes.
+    pub max_retained_bytes: Option<u64>,
     /// Maximum request body size in megabytes. Defaults to `5`.
     pub max_request_body_mb: Option<u64>,
     /// Log level (`off`, `error`, `warn`, `info`, `debug`, `trace`). Defaults to `"info"`.
@@ -144,6 +150,22 @@ pub fn load_config(path: &Path) -> Result<FileConfig, ConfigError> {
         return Err(ConfigError::Validation {
             path: path.display().to_string(),
             message: format!("retention_check_interval_secs must be between 0 and 86400, got {v}"),
+        });
+    }
+    if let Some(v) = config.snapshot_interval_secs
+        && v > 86400
+    {
+        return Err(ConfigError::Validation {
+            path: path.display().to_string(),
+            message: format!("snapshot_interval_secs must be between 0 and 86400, got {v}"),
+        });
+    }
+    if let Some(v) = config.max_retained_bytes
+        && v == 0
+    {
+        return Err(ConfigError::Validation {
+            path: path.display().to_string(),
+            message: "max_retained_bytes must be greater than 0".into(),
         });
     }
     if let Some(ref level) = config.log_level

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 //! [`FileConfig`] mirrors the TOML configuration file structure. Use [`load_config`]
 //! to parse a config file path into a validated [`FileConfig`].
 
+use crate::store::validate_durable_settings;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
@@ -152,20 +153,12 @@ pub fn load_config(path: &Path) -> Result<FileConfig, ConfigError> {
             message: format!("retention_check_interval_secs must be between 0 and 86400, got {v}"),
         });
     }
-    if let Some(v) = config.snapshot_interval_secs
-        && v > 86400
+    if let Err(err) =
+        validate_durable_settings(config.snapshot_interval_secs, config.max_retained_bytes)
     {
         return Err(ConfigError::Validation {
             path: path.display().to_string(),
-            message: format!("snapshot_interval_secs must be between 0 and 86400, got {v}"),
-        });
-    }
-    if let Some(v) = config.max_retained_bytes
-        && v == 0
-    {
-        return Err(ConfigError::Validation {
-            path: path.display().to_string(),
-            message: "max_retained_bytes must be greater than 0".into(),
+            message: err.to_string(),
         });
     }
     if let Some(ref level) = config.log_level
@@ -222,4 +215,42 @@ pub fn load_config(path: &Path) -> Result<FileConfig, ConfigError> {
         _ => {}
     }
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn load_config_rejects_zero_max_retained_bytes() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "max_retained_bytes = 0\n").unwrap();
+
+        let err = match load_config(file.path()) {
+            Ok(_) => panic!("expected config validation error"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, ConfigError::Validation { .. }));
+        assert!(
+            err.to_string()
+                .contains("max_retained_bytes must be greater than 0")
+        );
+    }
+
+    #[test]
+    fn load_config_rejects_out_of_range_snapshot_interval() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "snapshot_interval_secs = 86401\n").unwrap();
+
+        let err = match load_config(file.path()) {
+            Ok(_) => panic!("expected config validation error"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, ConfigError::Validation { .. }));
+        assert!(
+            err.to_string()
+                .contains("snapshot_interval_secs must be between 0 and 86400")
+        );
+    }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -7,6 +7,7 @@
 
 use axum::extract::State;
 use axum::http::StatusCode;
+use axum::http::header;
 use axum::response::{IntoResponse, Response};
 use serde_json::json;
 
@@ -49,4 +50,17 @@ pub async fn ready(State(store): State<Store>) -> (StatusCode, &'static str) {
         Ok(()) => (StatusCode::OK, "OK"),
         Err(_) => (StatusCode::SERVICE_UNAVAILABLE, "Service Unavailable"),
     }
+}
+
+/// `GET /metrics` - Prometheus text-format metrics.
+pub async fn metrics(State(store): State<Store>) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        store.render_metrics().await,
+    )
+        .into_response()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,14 @@ pub mod error;
 #[doc(hidden)]
 pub mod event_stream;
 pub mod health;
+#[doc(hidden)]
+pub mod metrics;
 #[cfg(feature = "mirror")]
 #[doc(hidden)]
 pub mod mirror;
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(hidden)]
+pub mod persistence;
 #[cfg(any(
     not(target_arch = "wasm32"),
     all(target_arch = "wasm32", feature = "wasm"),
@@ -170,6 +175,7 @@ pub fn create_router(store: Store) -> Router {
         .route("/_health", get(health::health))
         .route("/_health/live", get(health::live))
         .route("/_health/ready", get(health::ready))
+        .route("/metrics", get(health::metrics))
         .fallback(any(server::handler))
         .with_state(store)
         .layer(middleware::from_fn(server::kinesis_413_middleware));
@@ -314,7 +320,16 @@ mod tests {
             .unwrap();
         assert_eq!(stream.stream_status, StreamStatus::Creating);
 
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        for _ in 0..50 {
+            let stream = store
+                .get_stream("native-no-default-features")
+                .await
+                .unwrap();
+            if stream.stream_status == StreamStatus::Active {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
 
         let stream = store
             .get_stream("native-no-default-features")

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,17 @@ struct ServeArgs {
     #[arg(long, env = "FERROKINESIS_ENFORCE_LIMITS",
           default_missing_value = "true", num_args = 0..=1)]
     enforce_limits: Option<bool>,
+    /// Directory used to persist state with WAL + snapshots
+    #[arg(long, env = "FERROKINESIS_STATE_DIR")]
+    state_dir: Option<PathBuf>,
+
+    /// Snapshot interval in seconds when durable mode is enabled (0 = disabled)
+    #[arg(long, env = "FERROKINESIS_SNAPSHOT_INTERVAL_SECS", value_parser = clap::value_parser!(u64).range(0..=86400))]
+    snapshot_interval_secs: Option<u64>,
+
+    /// Hard cap on retained serialized record bytes
+    #[arg(long, env = "FERROKINESIS_MAX_RETAINED_BYTES", value_parser = clap::value_parser!(u64).range(1..))]
+    max_retained_bytes: Option<u64>,
 
     /// Log level (off, error, warn, info, debug, trace)
     #[arg(long, env = "FERROKINESIS_LOG_LEVEL",
@@ -193,6 +204,20 @@ fn resolve_store_options(
         enforce_limits: resolve(args.enforce_limits, file_cfg.enforce_limits, || {
             defaults.enforce_limits
         }),
+        state_dir: args
+            .state_dir
+            .clone()
+            .or(file_cfg.state_dir.clone())
+            .or(defaults.state_dir.clone()),
+        snapshot_interval_secs: resolve(
+            args.snapshot_interval_secs,
+            file_cfg.snapshot_interval_secs,
+            || defaults.snapshot_interval_secs,
+        ),
+        max_retained_bytes: args
+            .max_retained_bytes
+            .or(file_cfg.max_retained_bytes)
+            .or(defaults.max_retained_bytes),
         aws_account_id: resolve(args.account_id.clone(), file_cfg.account_id.clone(), || {
             defaults.aws_account_id.clone()
         }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 use axum::extract::DefaultBodyLimit;
 use clap::{Args, Parser, Subcommand};
 use ferrokinesis::config::{FileConfig, load_config};
-use ferrokinesis::store::StoreOptions;
+use ferrokinesis::store::{
+    DEFAULT_DURABLE_SNAPSHOT_INTERVAL_SECS, DurableStateOptions, StoreOptions,
+    validate_durable_settings,
+};
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::path::PathBuf;
@@ -177,8 +180,42 @@ fn resolve_store_options(
     args: &ServeArgs,
     file_cfg: &FileConfig,
     defaults: &StoreOptions,
-) -> StoreOptions {
-    StoreOptions {
+) -> Result<StoreOptions, String> {
+    let max_retained_bytes = args
+        .max_retained_bytes
+        .or(file_cfg.max_retained_bytes)
+        .or(defaults.max_retained_bytes);
+    let snapshot_interval_secs = resolve(
+        args.snapshot_interval_secs,
+        file_cfg.snapshot_interval_secs,
+        || {
+            defaults
+                .durable
+                .as_ref()
+                .map_or(DEFAULT_DURABLE_SNAPSHOT_INTERVAL_SECS, |durable| {
+                    durable.snapshot_interval_secs
+                })
+        },
+    );
+    validate_durable_settings(Some(snapshot_interval_secs), max_retained_bytes)
+        .map_err(|err| err.to_string())?;
+    let durable = args
+        .state_dir
+        .clone()
+        .or(file_cfg.state_dir.clone())
+        .or_else(|| {
+            defaults
+                .durable
+                .as_ref()
+                .map(|durable| durable.state_dir.clone())
+        })
+        .map(|state_dir| DurableStateOptions {
+            state_dir,
+            snapshot_interval_secs,
+            max_retained_bytes,
+        });
+
+    Ok(StoreOptions {
         create_stream_ms: resolve(args.create_stream_ms, file_cfg.create_stream_ms, || {
             defaults.create_stream_ms
         }),
@@ -204,20 +241,8 @@ fn resolve_store_options(
         enforce_limits: resolve(args.enforce_limits, file_cfg.enforce_limits, || {
             defaults.enforce_limits
         }),
-        state_dir: args
-            .state_dir
-            .clone()
-            .or(file_cfg.state_dir.clone())
-            .or(defaults.state_dir.clone()),
-        snapshot_interval_secs: resolve(
-            args.snapshot_interval_secs,
-            file_cfg.snapshot_interval_secs,
-            || defaults.snapshot_interval_secs,
-        ),
-        max_retained_bytes: args
-            .max_retained_bytes
-            .or(file_cfg.max_retained_bytes)
-            .or(defaults.max_retained_bytes),
+        durable,
+        max_retained_bytes,
         aws_account_id: resolve(args.account_id.clone(), file_cfg.account_id.clone(), || {
             defaults.aws_account_id.clone()
         }),
@@ -226,7 +251,7 @@ fn resolve_store_options(
             file_cfg.region.clone(),
             || defaults.aws_region.clone(),
         ),
-    }
+    })
 }
 
 #[derive(Args, Debug)]
@@ -710,7 +735,10 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
         .unwrap_or_default();
 
     let defaults = StoreOptions::default();
-    let options = resolve_store_options(&args, &file_cfg, &defaults);
+    let options = resolve_store_options(&args, &file_cfg, &defaults).unwrap_or_else(|err| {
+        eprintln!("{err}");
+        process::exit(1);
+    });
     let port = resolve(args.port, file_cfg.port, || 4567);
     let max_request_body_mb = resolve(args.max_request_body_mb, file_cfg.max_request_body_mb, || 7);
     let log_level: String = resolve(args.log_level, file_cfg.log_level, || "info".into());
@@ -939,7 +967,7 @@ mod tests {
             enforce_limits: Some(true),
             ..Default::default()
         };
-        let options = resolve_store_options(&args, &file_cfg, &StoreOptions::default());
+        let options = resolve_store_options(&args, &file_cfg, &StoreOptions::default()).unwrap();
         let store = Store::new(options);
 
         let first = store
@@ -961,12 +989,28 @@ mod tests {
             enforce_limits: Some(true),
             ..Default::default()
         };
-        let options = resolve_store_options(&args, &file_cfg, &StoreOptions::default());
+        let options = resolve_store_options(&args, &file_cfg, &StoreOptions::default()).unwrap();
         let store = Store::new(options);
 
         let result = store
             .try_reserve_shard_throughput("stream", "shardId-000000000000", 2 * 1024 * 1024, 1_000)
             .await;
         assert!(result.is_ok(), "CLI flag should disable throttling");
+    }
+
+    #[test]
+    fn resolve_store_options_maps_flat_durable_inputs_into_nested_settings() {
+        let mut args = serve_args();
+        args.state_dir = Some(PathBuf::from("/tmp/ferrokinesis-state"));
+        args.snapshot_interval_secs = Some(17);
+        args.max_retained_bytes = Some(2048);
+
+        let options =
+            resolve_store_options(&args, &FileConfig::default(), &StoreOptions::default()).unwrap();
+        let durable = options.durable.expect("durable settings");
+        assert_eq!(durable.state_dir, PathBuf::from("/tmp/ferrokinesis-state"));
+        assert_eq!(durable.snapshot_interval_secs, 17);
+        assert_eq!(durable.max_retained_bytes, Some(2048));
+        assert_eq!(options.max_retained_bytes, Some(2048));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -905,6 +905,9 @@ mod tests {
             max_request_body_mb: None,
             retention_check_interval_secs: None,
             enforce_limits: None,
+            state_dir: None,
+            snapshot_interval_secs: None,
+            max_retained_bytes: None,
             log_level: None,
             #[cfg(feature = "access-log")]
             access_log: None,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -46,6 +46,25 @@ const ALL_OPERATIONS: &[Operation] = &[
     Operation::UpdateStreamWarmThroughput,
 ];
 
+const ALL_PRE_OPERATION_FAILURE_REASONS: &[PreOperationFailureReason] = &[
+    PreOperationFailureReason::AccessDenied,
+    PreOperationFailureReason::IncompleteSignature,
+    PreOperationFailureReason::InvalidSignature,
+    PreOperationFailureReason::MissingAuthToken,
+    PreOperationFailureReason::SerializationException,
+    PreOperationFailureReason::UnknownOperation,
+];
+
+#[derive(Debug, Clone, Copy)]
+pub enum PreOperationFailureReason {
+    AccessDenied,
+    IncompleteSignature,
+    InvalidSignature,
+    MissingAuthToken,
+    SerializationException,
+    UnknownOperation,
+}
+
 #[derive(Debug)]
 pub struct AppMetrics {
     retained_bytes: AtomicU64,
@@ -58,6 +77,7 @@ pub struct AppMetrics {
     current_streams: AtomicU64,
     current_shards: AtomicU64,
     request_counters: Vec<OperationMetrics>,
+    pre_operation_failure_counters: Vec<AtomicU64>,
     active_iterators: Mutex<VecDeque<u64>>,
     iterator_ttl_ms: u64,
 }
@@ -106,6 +126,17 @@ fn operation_name(operation: &Operation) -> &'static str {
     }
 }
 
+fn pre_operation_failure_reason_name(reason: PreOperationFailureReason) -> &'static str {
+    match reason {
+        PreOperationFailureReason::AccessDenied => "access_denied",
+        PreOperationFailureReason::IncompleteSignature => "incomplete_signature",
+        PreOperationFailureReason::InvalidSignature => "invalid_signature",
+        PreOperationFailureReason::MissingAuthToken => "missing_auth_token",
+        PreOperationFailureReason::SerializationException => "serialization_exception",
+        PreOperationFailureReason::UnknownOperation => "unknown_operation",
+    }
+}
+
 #[derive(Debug)]
 struct OperationMetrics {
     ok_total: AtomicU64,
@@ -128,7 +159,7 @@ impl Default for OperationMetrics {
 impl AppMetrics {
     pub fn new(iterator_ttl_seconds: u64) -> Arc<Self> {
         let request_counters = std::iter::repeat_with(OperationMetrics::default)
-            .take(39)
+            .take(ALL_OPERATIONS.len())
             .collect();
         Arc::new(Self {
             retained_bytes: AtomicU64::new(0),
@@ -141,6 +172,9 @@ impl AppMetrics {
             current_streams: AtomicU64::new(0),
             current_shards: AtomicU64::new(0),
             request_counters,
+            pre_operation_failure_counters: std::iter::repeat_with(|| AtomicU64::new(0))
+                .take(ALL_PRE_OPERATION_FAILURE_REASONS.len())
+                .collect(),
             active_iterators: Mutex::new(VecDeque::new()),
             iterator_ttl_ms: iterator_ttl_seconds.saturating_mul(1000),
         })
@@ -212,6 +246,16 @@ impl AppMetrics {
             .store(duration_micros, Ordering::Relaxed);
     }
 
+    pub fn record_pre_operation_failure(
+        &self,
+        reason: PreOperationFailureReason,
+        duration_micros: u64,
+    ) {
+        self.pre_operation_failure_counters[reason as usize].fetch_add(1, Ordering::Relaxed);
+        self.last_request_duration_micros
+            .store(duration_micros, Ordering::Relaxed);
+    }
+
     pub async fn record_iterator(&self, now_ms: u64) {
         let mut active = self.active_iterators.lock().await;
         active.push_back(now_ms);
@@ -272,6 +316,14 @@ impl AppMetrics {
             "ferrokinesis_active_iterators {}\n",
             active_iterators
         ));
+        out.push_str("# TYPE ferrokinesis_request_failures_total counter\n");
+        for (index, reason) in ALL_PRE_OPERATION_FAILURE_REASONS.iter().enumerate() {
+            out.push_str(&format!(
+                "ferrokinesis_request_failures_total{{reason=\"{}\"}} {}\n",
+                pre_operation_failure_reason_name(*reason),
+                self.pre_operation_failure_counters[index].load(Ordering::Relaxed)
+            ));
+        }
 
         for (index, operation) in ALL_OPERATIONS.iter().enumerate() {
             let metrics = &self.request_counters[index];

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,300 @@
+use crate::actions::Operation;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use tokio::sync::Mutex;
+
+const ALL_OPERATIONS: &[Operation] = &[
+    Operation::AddTagsToStream,
+    Operation::CreateStream,
+    Operation::DecreaseStreamRetentionPeriod,
+    Operation::DeleteResourcePolicy,
+    Operation::DeleteStream,
+    Operation::DeregisterStreamConsumer,
+    Operation::DescribeAccountSettings,
+    Operation::DescribeLimits,
+    Operation::DescribeStream,
+    Operation::DescribeStreamConsumer,
+    Operation::DescribeStreamSummary,
+    Operation::DisableEnhancedMonitoring,
+    Operation::EnableEnhancedMonitoring,
+    Operation::GetRecords,
+    Operation::GetResourcePolicy,
+    Operation::GetShardIterator,
+    Operation::IncreaseStreamRetentionPeriod,
+    Operation::ListShards,
+    Operation::ListStreamConsumers,
+    Operation::ListStreams,
+    Operation::ListTagsForResource,
+    Operation::ListTagsForStream,
+    Operation::MergeShards,
+    Operation::PutRecord,
+    Operation::PutRecords,
+    Operation::PutResourcePolicy,
+    Operation::RegisterStreamConsumer,
+    Operation::RemoveTagsFromStream,
+    Operation::SplitShard,
+    Operation::StartStreamEncryption,
+    Operation::StopStreamEncryption,
+    Operation::SubscribeToShard,
+    Operation::TagResource,
+    Operation::UntagResource,
+    Operation::UpdateAccountSettings,
+    Operation::UpdateMaxRecordSize,
+    Operation::UpdateShardCount,
+    Operation::UpdateStreamMode,
+    Operation::UpdateStreamWarmThroughput,
+];
+
+#[derive(Debug)]
+pub struct AppMetrics {
+    retained_bytes: AtomicU64,
+    retained_records: AtomicU64,
+    rejected_writes_total: AtomicU64,
+    mirror_dropped_total: AtomicU64,
+    replay_complete: AtomicBool,
+    last_snapshot_ms: AtomicU64,
+    last_request_duration_micros: AtomicU64,
+    current_streams: AtomicU64,
+    current_shards: AtomicU64,
+    request_counters: Vec<OperationMetrics>,
+    active_iterators: Mutex<VecDeque<u64>>,
+    iterator_ttl_ms: u64,
+}
+
+fn operation_name(operation: &Operation) -> &'static str {
+    match operation {
+        Operation::AddTagsToStream => "AddTagsToStream",
+        Operation::CreateStream => "CreateStream",
+        Operation::DecreaseStreamRetentionPeriod => "DecreaseStreamRetentionPeriod",
+        Operation::DeleteResourcePolicy => "DeleteResourcePolicy",
+        Operation::DeleteStream => "DeleteStream",
+        Operation::DeregisterStreamConsumer => "DeregisterStreamConsumer",
+        Operation::DescribeAccountSettings => "DescribeAccountSettings",
+        Operation::DescribeLimits => "DescribeLimits",
+        Operation::DescribeStream => "DescribeStream",
+        Operation::DescribeStreamConsumer => "DescribeStreamConsumer",
+        Operation::DescribeStreamSummary => "DescribeStreamSummary",
+        Operation::DisableEnhancedMonitoring => "DisableEnhancedMonitoring",
+        Operation::EnableEnhancedMonitoring => "EnableEnhancedMonitoring",
+        Operation::GetRecords => "GetRecords",
+        Operation::GetResourcePolicy => "GetResourcePolicy",
+        Operation::GetShardIterator => "GetShardIterator",
+        Operation::IncreaseStreamRetentionPeriod => "IncreaseStreamRetentionPeriod",
+        Operation::ListShards => "ListShards",
+        Operation::ListStreamConsumers => "ListStreamConsumers",
+        Operation::ListStreams => "ListStreams",
+        Operation::ListTagsForResource => "ListTagsForResource",
+        Operation::ListTagsForStream => "ListTagsForStream",
+        Operation::MergeShards => "MergeShards",
+        Operation::PutRecord => "PutRecord",
+        Operation::PutRecords => "PutRecords",
+        Operation::PutResourcePolicy => "PutResourcePolicy",
+        Operation::RegisterStreamConsumer => "RegisterStreamConsumer",
+        Operation::RemoveTagsFromStream => "RemoveTagsFromStream",
+        Operation::SplitShard => "SplitShard",
+        Operation::StartStreamEncryption => "StartStreamEncryption",
+        Operation::StopStreamEncryption => "StopStreamEncryption",
+        Operation::SubscribeToShard => "SubscribeToShard",
+        Operation::TagResource => "TagResource",
+        Operation::UntagResource => "UntagResource",
+        Operation::UpdateAccountSettings => "UpdateAccountSettings",
+        Operation::UpdateMaxRecordSize => "UpdateMaxRecordSize",
+        Operation::UpdateShardCount => "UpdateShardCount",
+        Operation::UpdateStreamMode => "UpdateStreamMode",
+        Operation::UpdateStreamWarmThroughput => "UpdateStreamWarmThroughput",
+    }
+}
+
+#[derive(Debug)]
+struct OperationMetrics {
+    ok_total: AtomicU64,
+    error_total: AtomicU64,
+    duration_count: AtomicU64,
+    duration_micros_sum: AtomicU64,
+}
+
+impl Default for OperationMetrics {
+    fn default() -> Self {
+        Self {
+            ok_total: AtomicU64::new(0),
+            error_total: AtomicU64::new(0),
+            duration_count: AtomicU64::new(0),
+            duration_micros_sum: AtomicU64::new(0),
+        }
+    }
+}
+
+impl AppMetrics {
+    pub fn new(iterator_ttl_seconds: u64) -> Arc<Self> {
+        let request_counters = std::iter::repeat_with(OperationMetrics::default)
+            .take(39)
+            .collect();
+        Arc::new(Self {
+            retained_bytes: AtomicU64::new(0),
+            retained_records: AtomicU64::new(0),
+            rejected_writes_total: AtomicU64::new(0),
+            mirror_dropped_total: AtomicU64::new(0),
+            replay_complete: AtomicBool::new(true),
+            last_snapshot_ms: AtomicU64::new(0),
+            last_request_duration_micros: AtomicU64::new(0),
+            current_streams: AtomicU64::new(0),
+            current_shards: AtomicU64::new(0),
+            request_counters,
+            active_iterators: Mutex::new(VecDeque::new()),
+            iterator_ttl_ms: iterator_ttl_seconds.saturating_mul(1000),
+        })
+    }
+
+    pub fn set_retained(&self, bytes: u64, records: u64) {
+        self.retained_bytes.store(bytes, Ordering::Relaxed);
+        self.retained_records.store(records, Ordering::Relaxed);
+    }
+
+    pub fn add_retained(&self, bytes: u64, records: u64) {
+        self.retained_bytes.fetch_add(bytes, Ordering::Relaxed);
+        self.retained_records.fetch_add(records, Ordering::Relaxed);
+    }
+
+    pub fn remove_retained(&self, bytes: u64, records: u64) {
+        self.retained_bytes.fetch_sub(bytes, Ordering::Relaxed);
+        self.retained_records.fetch_sub(records, Ordering::Relaxed);
+    }
+
+    pub fn retained_bytes(&self) -> u64 {
+        self.retained_bytes.load(Ordering::Relaxed)
+    }
+
+    pub fn retained_records(&self) -> u64 {
+        self.retained_records.load(Ordering::Relaxed)
+    }
+
+    pub fn increment_rejected_writes(&self) {
+        self.rejected_writes_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn increment_mirror_dropped(&self) {
+        self.mirror_dropped_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn set_replay_complete(&self, value: bool) {
+        self.replay_complete.store(value, Ordering::Relaxed);
+    }
+
+    pub fn set_last_snapshot_ms(&self, value: u64) {
+        self.last_snapshot_ms.store(value, Ordering::Relaxed);
+    }
+
+    pub fn set_topology(&self, streams: u64, shards: u64) {
+        self.current_streams.store(streams, Ordering::Relaxed);
+        self.current_shards.store(shards, Ordering::Relaxed);
+    }
+
+    pub fn record_request(&self, operation: Operation, ok: bool, duration_micros: u64) {
+        let op = &self.request_counters[operation as usize];
+        if ok {
+            op.ok_total.fetch_add(1, Ordering::Relaxed);
+        } else {
+            op.error_total.fetch_add(1, Ordering::Relaxed);
+        }
+        op.duration_count.fetch_add(1, Ordering::Relaxed);
+        op.duration_micros_sum
+            .fetch_add(duration_micros, Ordering::Relaxed);
+        self.last_request_duration_micros
+            .store(duration_micros, Ordering::Relaxed);
+    }
+
+    pub async fn record_iterator(&self, now_ms: u64) {
+        let mut active = self.active_iterators.lock().await;
+        active.push_back(now_ms);
+        self.prune_iterators_locked(&mut active, now_ms);
+    }
+
+    pub async fn active_iterator_count(&self, now_ms: u64) -> usize {
+        let mut active = self.active_iterators.lock().await;
+        self.prune_iterators_locked(&mut active, now_ms);
+        active.len()
+    }
+
+    pub async fn render(&self, now_ms: u64) -> String {
+        let active_iterators = self.active_iterator_count(now_ms).await;
+        let mut out = String::new();
+        out.push_str("# TYPE ferrokinesis_retained_bytes gauge\n");
+        out.push_str(&format!(
+            "ferrokinesis_retained_bytes {}\n",
+            self.retained_bytes()
+        ));
+        out.push_str("# TYPE ferrokinesis_retained_records gauge\n");
+        out.push_str(&format!(
+            "ferrokinesis_retained_records {}\n",
+            self.retained_records()
+        ));
+        out.push_str("# TYPE ferrokinesis_rejected_writes_total counter\n");
+        out.push_str(&format!(
+            "ferrokinesis_rejected_writes_total {}\n",
+            self.rejected_writes_total.load(Ordering::Relaxed)
+        ));
+        out.push_str("# TYPE ferrokinesis_mirror_dropped_total counter\n");
+        out.push_str(&format!(
+            "ferrokinesis_mirror_dropped_total {}\n",
+            self.mirror_dropped_total.load(Ordering::Relaxed)
+        ));
+        out.push_str("# TYPE ferrokinesis_replay_complete gauge\n");
+        out.push_str(&format!(
+            "ferrokinesis_replay_complete {}\n",
+            u8::from(self.replay_complete.load(Ordering::Relaxed))
+        ));
+        out.push_str("# TYPE ferrokinesis_last_snapshot_timestamp_ms gauge\n");
+        out.push_str(&format!(
+            "ferrokinesis_last_snapshot_timestamp_ms {}\n",
+            self.last_snapshot_ms.load(Ordering::Relaxed)
+        ));
+        out.push_str("# TYPE ferrokinesis_streams gauge\n");
+        out.push_str(&format!(
+            "ferrokinesis_streams {}\n",
+            self.current_streams.load(Ordering::Relaxed)
+        ));
+        out.push_str("# TYPE ferrokinesis_open_shards gauge\n");
+        out.push_str(&format!(
+            "ferrokinesis_open_shards {}\n",
+            self.current_shards.load(Ordering::Relaxed)
+        ));
+        out.push_str("# TYPE ferrokinesis_active_iterators gauge\n");
+        out.push_str(&format!(
+            "ferrokinesis_active_iterators {}\n",
+            active_iterators
+        ));
+
+        for (index, operation) in ALL_OPERATIONS.iter().enumerate() {
+            let metrics = &self.request_counters[index];
+            let op = operation_name(operation);
+            out.push_str(&format!(
+                "ferrokinesis_requests_total{{operation=\"{op}\",result=\"ok\"}} {}\n",
+                metrics.ok_total.load(Ordering::Relaxed)
+            ));
+            out.push_str(&format!(
+                "ferrokinesis_requests_total{{operation=\"{op}\",result=\"error\"}} {}\n",
+                metrics.error_total.load(Ordering::Relaxed)
+            ));
+            out.push_str(&format!(
+                "ferrokinesis_request_duration_seconds_count{{operation=\"{op}\"}} {}\n",
+                metrics.duration_count.load(Ordering::Relaxed)
+            ));
+            out.push_str(&format!(
+                "ferrokinesis_request_duration_seconds_sum{{operation=\"{op}\"}} {}\n",
+                metrics.duration_micros_sum.load(Ordering::Relaxed) as f64 / 1_000_000.0
+            ));
+        }
+
+        out
+    }
+
+    fn prune_iterators_locked(&self, active: &mut VecDeque<u64>, now_ms: u64) {
+        while let Some(created_at) = active.front().copied() {
+            if now_ms.saturating_sub(created_at) <= self.iterator_ttl_ms {
+                break;
+            }
+            active.pop_front();
+        }
+    }
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -157,8 +157,16 @@ impl AppMetrics {
     }
 
     pub fn remove_retained(&self, bytes: u64, records: u64) {
-        self.retained_bytes.fetch_sub(bytes, Ordering::Relaxed);
-        self.retained_records.fetch_sub(records, Ordering::Relaxed);
+        let _ = self
+            .retained_bytes
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                Some(current.saturating_sub(bytes))
+            });
+        let _ =
+            self.retained_records
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                    Some(current.saturating_sub(records))
+                });
     }
 
     pub fn retained_bytes(&self) -> u64 {

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -13,6 +13,7 @@ use crate::types::{
 const SNAPSHOT_FILE: &str = "snapshot.bin";
 const SNAPSHOT_TMP_FILE: &str = "snapshot.bin.tmp";
 const WAL_FILE: &str = "wal.log";
+const WAL_TMP_FILE: &str = "wal.log.tmp";
 const WAL_MAGIC: &[u8; 8] = b"FKWALv2\n";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -177,17 +178,23 @@ impl Persistence {
                 "serialized wal entry exceeds u64 length prefix",
             )
         })?;
+        let wal_path = self.state_dir.join(WAL_FILE);
+        let created_wal = !wal_path.exists();
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
             .read(true)
-            .open(self.state_dir.join(WAL_FILE))?;
+            .open(&wal_path)?;
         if file.metadata()?.len() == 0 {
             file.write_all(WAL_MAGIC)?;
         }
         file.write_all(&len.to_le_bytes())?;
         file.write_all(&bytes)?;
-        file.sync_all()
+        file.sync_all()?;
+        if created_wal {
+            sync_directory(&self.state_dir)?;
+        }
+        Ok(())
     }
 
     pub fn write_snapshot(&self, snapshot: &PersistentSnapshot) -> io::Result<()> {
@@ -206,10 +213,13 @@ impl Persistence {
         sync_directory(&self.state_dir)?;
 
         let wal_path = self.state_dir.join(WAL_FILE);
-        let mut wal = File::create(wal_path)?;
-        wal.write_all(WAL_MAGIC)?;
-        wal.flush()?;
-        wal.sync_all()?;
+        let wal_tmp_path = self.state_dir.join(WAL_TMP_FILE);
+        {
+            let mut wal = File::create(&wal_tmp_path)?;
+            wal.write_all(WAL_MAGIC)?;
+            wal.sync_all()?;
+        }
+        fs::rename(&wal_tmp_path, &wal_path)?;
         sync_directory(&self.state_dir)
     }
 
@@ -230,6 +240,9 @@ impl Persistence {
         }
 
         let file = File::open(path)?;
+        if file.metadata()?.len() == 0 {
+            return Ok(Vec::new());
+        }
         let mut reader = BufReader::new(file);
         let mut entries = Vec::new();
         let mut magic = [0u8; WAL_MAGIC.len()];
@@ -248,29 +261,23 @@ impl Persistence {
 
         loop {
             let mut len_buf = [0u8; 8];
-            let read = match reader.read(&mut len_buf) {
-                Ok(0) => break,
-                Ok(read) => read,
-                Err(err) => return Err(LoadError::Io(err)),
-            };
-            if read < len_buf.len() {
-                reader
-                    .read_exact(&mut len_buf[read..])
-                    .map_err(|err| match err.kind() {
-                        io::ErrorKind::UnexpectedEof => LoadError::TruncatedWal,
-                        _ => LoadError::Io(err),
-                    })?;
+            if let Err(err) = reader.read_exact(&mut len_buf) {
+                return match err.kind() {
+                    io::ErrorKind::UnexpectedEof => Ok(entries),
+                    _ => Err(LoadError::Io(err)),
+                };
             }
             let len = decode_wal_entry_len(len_buf)?;
             let mut entry_buf = vec![0u8; len];
-            if reader.read_exact(&mut entry_buf).is_err() {
-                return Err(LoadError::TruncatedWal);
+            if let Err(err) = reader.read_exact(&mut entry_buf) {
+                return match err.kind() {
+                    io::ErrorKind::UnexpectedEof => Ok(entries),
+                    _ => Err(LoadError::Io(err)),
+                };
             }
             let entry = serde_json::from_slice(&entry_buf).map_err(LoadError::Wal)?;
             entries.push(entry);
         }
-
-        Ok(entries)
     }
 }
 
@@ -376,7 +383,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let persistence = Persistence::new(dir.path().to_path_buf()).unwrap();
 
-        fs::write(dir.path().join(WAL_FILE), []).unwrap();
+        fs::write(dir.path().join(WAL_FILE), b"FKWALv2").unwrap();
 
         let err = persistence.load().unwrap_err();
         assert!(matches!(err, LoadError::UnsupportedWalFormat));
@@ -384,6 +391,72 @@ mod tests {
             err.to_string(),
             "unsupported wal format; recreate state dir"
         );
+    }
+
+    #[test]
+    fn empty_wal_is_treated_as_no_entries() {
+        let dir = tempdir().unwrap();
+        let persistence = Persistence::new(dir.path().to_path_buf()).unwrap();
+
+        fs::write(dir.path().join(WAL_FILE), []).unwrap();
+
+        assert!(persistence.load().unwrap().is_none());
+    }
+
+    #[test]
+    fn truncated_final_wal_entry_is_ignored() {
+        let dir = tempdir().unwrap();
+        let persistence = Persistence::new(dir.path().to_path_buf()).unwrap();
+        let first_snapshot = PersistentSnapshot {
+            created_at_ms: 1,
+            ..PersistentSnapshot::default()
+        };
+        let second_snapshot = PersistentSnapshot {
+            created_at_ms: 2,
+            ..PersistentSnapshot::default()
+        };
+
+        persistence
+            .append_wal_entry(&WalEntry::Snapshot(first_snapshot.clone()))
+            .unwrap();
+        persistence
+            .append_wal_entry(&WalEntry::Snapshot(second_snapshot.clone()))
+            .unwrap();
+
+        let wal_path = dir.path().join(WAL_FILE);
+        let wal_bytes = fs::read(&wal_path).unwrap();
+        fs::write(&wal_path, &wal_bytes[..wal_bytes.len() - 3]).unwrap();
+
+        let (loaded_snapshot, loaded_entries) = persistence.load().unwrap().unwrap();
+        assert_eq!(loaded_snapshot.created_at_ms, 0);
+        assert_eq!(loaded_entries.len(), 1);
+        assert!(matches!(
+            &loaded_entries[0],
+            WalEntry::Snapshot(entry) if entry.created_at_ms == first_snapshot.created_at_ms
+        ));
+    }
+
+    #[test]
+    fn write_snapshot_replaces_wal_with_header_only_file() {
+        let dir = tempdir().unwrap();
+        let persistence = Persistence::new(dir.path().to_path_buf()).unwrap();
+        let snapshot = PersistentSnapshot {
+            created_at_ms: 99,
+            ..PersistentSnapshot::default()
+        };
+
+        persistence
+            .append_wal_entry(&WalEntry::Snapshot(PersistentSnapshot {
+                created_at_ms: 1,
+                ..PersistentSnapshot::default()
+            }))
+            .unwrap();
+        persistence.write_snapshot(&snapshot).unwrap();
+
+        assert_eq!(fs::read(dir.path().join(WAL_FILE)).unwrap(), WAL_MAGIC);
+        let (loaded_snapshot, loaded_entries) = persistence.load().unwrap().unwrap();
+        assert_eq!(loaded_snapshot.created_at_ms, 99);
+        assert!(loaded_entries.is_empty());
     }
 
     #[cfg(target_pointer_width = "64")]

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,3 +1,4 @@
+use crate::store::PendingTransition;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
@@ -22,6 +23,8 @@ pub struct PersistentSnapshot {
     pub policies: Vec<(String, String)>,
     pub resource_tags: Vec<(String, BTreeMap<String, String>)>,
     pub account_settings_json: Vec<u8>,
+    #[serde(default)]
+    pub(crate) pending_transitions: Vec<PendingTransition>,
     pub retained_bytes: u64,
     pub retained_records: u64,
 }
@@ -178,11 +181,13 @@ impl Persistence {
         }
 
         fs::rename(&tmp_path, &final_path)?;
+        sync_directory(&self.state_dir)?;
 
         let wal_path = self.state_dir.join(WAL_FILE);
         let mut wal = File::create(wal_path)?;
         wal.flush()?;
-        wal.sync_all()
+        wal.sync_all()?;
+        sync_directory(&self.state_dir)
     }
 
     fn read_snapshot(&self) -> Result<Option<PersistentSnapshot>, LoadError> {
@@ -232,6 +237,16 @@ impl Persistence {
         Ok(entries)
     }
 }
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,6 +286,7 @@ mod tests {
             policies: vec![],
             resource_tags: vec![],
             account_settings_json: vec![],
+            pending_transitions: vec![],
             retained_bytes: 0,
             retained_records: 0,
         };

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -13,6 +13,7 @@ use crate::types::{
 const SNAPSHOT_FILE: &str = "snapshot.bin";
 const SNAPSHOT_TMP_FILE: &str = "snapshot.bin.tmp";
 const WAL_FILE: &str = "wal.log";
+const WAL_MAGIC: &[u8; 8] = b"FKWALv2\n";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PersistentSnapshot {
@@ -110,7 +111,9 @@ pub enum LoadError {
     Io(io::Error),
     Snapshot(serde_json::Error),
     Wal(serde_json::Error),
+    WalEntryTooLarge(u64),
     TruncatedWal,
+    UnsupportedWalFormat,
 }
 
 impl std::fmt::Display for LoadError {
@@ -119,7 +122,16 @@ impl std::fmt::Display for LoadError {
             Self::Io(err) => write!(f, "{err}"),
             Self::Snapshot(err) => write!(f, "failed to decode snapshot: {err}"),
             Self::Wal(err) => write!(f, "failed to decode wal entry: {err}"),
+            Self::WalEntryTooLarge(len) => {
+                write!(
+                    f,
+                    "wal entry length {len} exceeds this platform's address space"
+                )
+            }
             Self::TruncatedWal => write!(f, "wal is truncated"),
+            Self::UnsupportedWalFormat => {
+                write!(f, "unsupported wal format; recreate state dir")
+            }
         }
     }
 }
@@ -159,11 +171,21 @@ impl Persistence {
     pub fn append_wal_entry(&self, entry: &WalEntry) -> io::Result<()> {
         let bytes = serde_json::to_vec(entry)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let len = u64::try_from(bytes.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "serialized wal entry exceeds u64 length prefix",
+            )
+        })?;
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
+            .read(true)
             .open(self.state_dir.join(WAL_FILE))?;
-        file.write_all(&(bytes.len() as u32).to_le_bytes())?;
+        if file.metadata()?.len() == 0 {
+            file.write_all(WAL_MAGIC)?;
+        }
+        file.write_all(&len.to_le_bytes())?;
         file.write_all(&bytes)?;
         file.sync_all()
     }
@@ -185,6 +207,7 @@ impl Persistence {
 
         let wal_path = self.state_dir.join(WAL_FILE);
         let mut wal = File::create(wal_path)?;
+        wal.write_all(WAL_MAGIC)?;
         wal.flush()?;
         wal.sync_all()?;
         sync_directory(&self.state_dir)
@@ -209,9 +232,22 @@ impl Persistence {
         let file = File::open(path)?;
         let mut reader = BufReader::new(file);
         let mut entries = Vec::new();
+        let mut magic = [0u8; WAL_MAGIC.len()];
+
+        match reader.read_exact(&mut magic) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => {
+                return Err(LoadError::UnsupportedWalFormat);
+            }
+            Err(err) => return Err(LoadError::Io(err)),
+        }
+
+        if magic != *WAL_MAGIC {
+            return Err(LoadError::UnsupportedWalFormat);
+        }
 
         loop {
-            let mut len_buf = [0u8; 4];
+            let mut len_buf = [0u8; 8];
             let read = match reader.read(&mut len_buf) {
                 Ok(0) => break,
                 Ok(read) => read,
@@ -225,7 +261,7 @@ impl Persistence {
                         _ => LoadError::Io(err),
                     })?;
             }
-            let len = u32::from_le_bytes(len_buf) as usize;
+            let len = decode_wal_entry_len(len_buf)?;
             let mut entry_buf = vec![0u8; len];
             if reader.read_exact(&mut entry_buf).is_err() {
                 return Err(LoadError::TruncatedWal);
@@ -236,6 +272,11 @@ impl Persistence {
 
         Ok(entries)
     }
+}
+
+fn decode_wal_entry_len(len_buf: [u8; 8]) -> Result<usize, LoadError> {
+    let len = u64::from_le_bytes(len_buf);
+    usize::try_from(len).map_err(|_| LoadError::WalEntryTooLarge(len))
 }
 
 #[cfg(unix)]
@@ -253,6 +294,7 @@ mod tests {
     use crate::types::{
         EncryptionType, EpochSeconds, StreamBuilder, StreamMode, StreamModeDetails, StreamStatus,
     };
+    use tempfile::tempdir;
 
     #[test]
     fn persistent_snapshot_round_trips() {
@@ -302,5 +344,62 @@ mod tests {
         assert_eq!(decoded.streams[0].warm_throughput_mibps, 9);
         assert_eq!(decoded.streams[0].max_record_size_kib, 2048);
         assert_eq!(decoded.streams[0].shard_counters, vec![7]);
+    }
+
+    #[test]
+    fn wal_round_trips_with_header_and_u64_length_prefix() {
+        let dir = tempdir().unwrap();
+        let persistence = Persistence::new(dir.path().to_path_buf()).unwrap();
+        let snapshot = PersistentSnapshot {
+            created_at_ms: 42,
+            ..PersistentSnapshot::default()
+        };
+
+        persistence
+            .append_wal_entry(&WalEntry::Snapshot(snapshot.clone()))
+            .unwrap();
+
+        let wal_bytes = fs::read(dir.path().join(WAL_FILE)).unwrap();
+        assert!(wal_bytes.starts_with(WAL_MAGIC));
+
+        let (loaded_snapshot, loaded_entries) = persistence.load().unwrap().unwrap();
+        assert_eq!(loaded_snapshot.created_at_ms, 0);
+        assert_eq!(loaded_entries.len(), 1);
+        assert!(matches!(
+            &loaded_entries[0],
+            WalEntry::Snapshot(entry) if entry.created_at_ms == snapshot.created_at_ms
+        ));
+    }
+
+    #[test]
+    fn legacy_wal_without_header_is_rejected() {
+        let dir = tempdir().unwrap();
+        let persistence = Persistence::new(dir.path().to_path_buf()).unwrap();
+
+        fs::write(dir.path().join(WAL_FILE), []).unwrap();
+
+        let err = persistence.load().unwrap_err();
+        assert!(matches!(err, LoadError::UnsupportedWalFormat));
+        assert_eq!(
+            err.to_string(),
+            "unsupported wal format; recreate state dir"
+        );
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn wal_entry_length_helper_supports_lengths_larger_than_u32_max() {
+        let len = u64::from(u32::MAX) + 1;
+        assert_eq!(
+            decode_wal_entry_len(len.to_le_bytes()).unwrap(),
+            len as usize
+        );
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn wal_entry_length_overflow_is_reported_without_allocating() {
+        let err = decode_wal_entry_len(u64::MAX.to_le_bytes()).unwrap_err();
+        assert!(matches!(err, LoadError::WalEntryTooLarge(u64::MAX)));
     }
 }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,290 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::types::{
+    EncryptionType, EnhancedMonitoring, EpochSeconds, Shard, Stream, StreamBuilder,
+    StreamModeDetails, StreamStatus,
+};
+
+const SNAPSHOT_FILE: &str = "snapshot.bin";
+const SNAPSHOT_TMP_FILE: &str = "snapshot.bin.tmp";
+const WAL_FILE: &str = "wal.log";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PersistentSnapshot {
+    pub created_at_ms: u64,
+    pub streams: Vec<PersistentStream>,
+    pub records: Vec<SnapshotShardRecords>,
+    pub consumers: Vec<(String, Vec<u8>)>,
+    pub policies: Vec<(String, String)>,
+    pub resource_tags: Vec<(String, BTreeMap<String, String>)>,
+    pub account_settings_json: Vec<u8>,
+    pub retained_bytes: u64,
+    pub retained_records: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistentStream {
+    pub name: String,
+    pub retention_period_hours: u32,
+    pub enhanced_monitoring: Vec<EnhancedMonitoring>,
+    pub encryption_type: EncryptionType,
+    pub has_more_shards: bool,
+    pub shards: Vec<Shard>,
+    pub stream_arn: String,
+    pub stream_name: String,
+    pub stream_status: StreamStatus,
+    pub stream_creation_timestamp: EpochSeconds,
+    pub stream_mode_details: StreamModeDetails,
+    pub tags: BTreeMap<String, String>,
+    pub key_id: Option<String>,
+    pub warm_throughput_mibps: u32,
+    pub max_record_size_kib: u32,
+    pub shard_counters: Vec<u64>,
+}
+
+impl PersistentStream {
+    pub fn from_stream(name: String, stream: &Stream, shard_counters: Vec<u64>) -> Self {
+        Self {
+            name,
+            retention_period_hours: stream.retention_period_hours,
+            enhanced_monitoring: stream.enhanced_monitoring.clone(),
+            encryption_type: stream.encryption_type,
+            has_more_shards: stream.has_more_shards,
+            shards: stream.shards.clone(),
+            stream_arn: stream.stream_arn.clone(),
+            stream_name: stream.stream_name.clone(),
+            stream_status: stream.stream_status,
+            stream_creation_timestamp: stream.stream_creation_timestamp,
+            stream_mode_details: stream.stream_mode_details.clone(),
+            tags: stream.tags.clone(),
+            key_id: stream.key_id.clone(),
+            warm_throughput_mibps: stream.warm_throughput_mibps,
+            max_record_size_kib: stream.max_record_size_kib,
+            shard_counters,
+        }
+    }
+
+    pub fn into_parts(self) -> (String, Stream, Vec<u64>) {
+        let stream = StreamBuilder::new(
+            self.stream_name,
+            self.stream_arn,
+            self.stream_status,
+            self.stream_creation_timestamp,
+            self.shards,
+        )
+        .retention_period_hours(self.retention_period_hours)
+        .enhanced_monitoring(self.enhanced_monitoring)
+        .encryption_type(self.encryption_type)
+        .has_more_shards(self.has_more_shards)
+        .stream_mode_details(self.stream_mode_details)
+        .tags(self.tags)
+        .key_id(self.key_id)
+        .warm_throughput_mibps(self.warm_throughput_mibps)
+        .max_record_size_kib(self.max_record_size_kib)
+        .build();
+        (self.name, stream, self.shard_counters)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotShardRecords {
+    pub stream_name: String,
+    pub shard_hex: String,
+    pub records: Vec<(String, Vec<u8>)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum WalEntry {
+    Snapshot(PersistentSnapshot),
+}
+
+#[derive(Debug)]
+pub enum LoadError {
+    Io(io::Error),
+    Snapshot(serde_json::Error),
+    Wal(serde_json::Error),
+    TruncatedWal,
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "{err}"),
+            Self::Snapshot(err) => write!(f, "failed to decode snapshot: {err}"),
+            Self::Wal(err) => write!(f, "failed to decode wal entry: {err}"),
+            Self::TruncatedWal => write!(f, "wal is truncated"),
+        }
+    }
+}
+
+impl std::error::Error for LoadError {}
+
+impl From<io::Error> for LoadError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Persistence {
+    state_dir: PathBuf,
+}
+
+impl Persistence {
+    pub fn new(state_dir: PathBuf) -> io::Result<Self> {
+        fs::create_dir_all(&state_dir)?;
+        Ok(Self { state_dir })
+    }
+
+    pub fn state_dir(&self) -> &Path {
+        &self.state_dir
+    }
+
+    pub fn load(&self) -> Result<Option<(PersistentSnapshot, Vec<WalEntry>)>, LoadError> {
+        let snapshot = self.read_snapshot()?;
+        let wal_entries = self.read_wal()?;
+        if snapshot.is_none() && wal_entries.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some((snapshot.unwrap_or_default(), wal_entries)))
+    }
+
+    pub fn append_wal_entry(&self, entry: &WalEntry) -> io::Result<()> {
+        let bytes = serde_json::to_vec(entry)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.state_dir.join(WAL_FILE))?;
+        file.write_all(&(bytes.len() as u32).to_le_bytes())?;
+        file.write_all(&bytes)?;
+        file.sync_all()
+    }
+
+    pub fn write_snapshot(&self, snapshot: &PersistentSnapshot) -> io::Result<()> {
+        let bytes = serde_json::to_vec(snapshot)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let tmp_path = self.state_dir.join(SNAPSHOT_TMP_FILE);
+        let final_path = self.state_dir.join(SNAPSHOT_FILE);
+
+        {
+            let mut file = File::create(&tmp_path)?;
+            file.write_all(&bytes)?;
+            file.sync_all()?;
+        }
+
+        fs::rename(&tmp_path, &final_path)?;
+
+        let wal_path = self.state_dir.join(WAL_FILE);
+        let mut wal = File::create(wal_path)?;
+        wal.flush()?;
+        wal.sync_all()
+    }
+
+    fn read_snapshot(&self) -> Result<Option<PersistentSnapshot>, LoadError> {
+        let path = self.state_dir.join(SNAPSHOT_FILE);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let bytes = fs::read(path)?;
+        let snapshot = serde_json::from_slice(&bytes).map_err(LoadError::Snapshot)?;
+        Ok(Some(snapshot))
+    }
+
+    fn read_wal(&self) -> Result<Vec<WalEntry>, LoadError> {
+        let path = self.state_dir.join(WAL_FILE);
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let file = File::open(path)?;
+        let mut reader = BufReader::new(file);
+        let mut entries = Vec::new();
+
+        loop {
+            let mut len_buf = [0u8; 4];
+            let read = match reader.read(&mut len_buf) {
+                Ok(0) => break,
+                Ok(read) => read,
+                Err(err) => return Err(LoadError::Io(err)),
+            };
+            if read < len_buf.len() {
+                reader
+                    .read_exact(&mut len_buf[read..])
+                    .map_err(|err| match err.kind() {
+                        io::ErrorKind::UnexpectedEof => LoadError::TruncatedWal,
+                        _ => LoadError::Io(err),
+                    })?;
+            }
+            let len = u32::from_le_bytes(len_buf) as usize;
+            let mut entry_buf = vec![0u8; len];
+            if reader.read_exact(&mut entry_buf).is_err() {
+                return Err(LoadError::TruncatedWal);
+            }
+            let entry = serde_json::from_slice(&entry_buf).map_err(LoadError::Wal)?;
+            entries.push(entry);
+        }
+
+        Ok(entries)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        EncryptionType, EpochSeconds, StreamBuilder, StreamMode, StreamModeDetails, StreamStatus,
+    };
+
+    #[test]
+    fn persistent_snapshot_round_trips() {
+        let stream = StreamBuilder::new(
+            "stream-a".to_string(),
+            "arn:aws:kinesis:eu-west-1:123456789012:stream/stream-a".to_string(),
+            StreamStatus::Active,
+            EpochSeconds(1_700_000_000.0),
+            vec![],
+        )
+        .retention_period_hours(48)
+        .encryption_type(EncryptionType::Kms)
+        .stream_mode_details(StreamModeDetails {
+            stream_mode: StreamMode::OnDemand,
+        })
+        .tags(BTreeMap::from([("env".to_string(), "prod".to_string())]))
+        .key_id(Some("key-123".to_string()))
+        .warm_throughput_mibps(9)
+        .max_record_size_kib(2048)
+        .build();
+
+        let snapshot = PersistentSnapshot {
+            created_at_ms: 1,
+            streams: vec![PersistentStream::from_stream(
+                "stream-a".to_string(),
+                &stream,
+                vec![7],
+            )],
+            records: vec![],
+            consumers: vec![],
+            policies: vec![],
+            resource_tags: vec![],
+            account_settings_json: vec![],
+            retained_bytes: 0,
+            retained_records: 0,
+        };
+
+        let bytes = serde_json::to_vec(&snapshot).unwrap();
+        let decoded: PersistentSnapshot = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.streams[0].name, "stream-a");
+        assert_eq!(
+            decoded.streams[0].tags.get("env").map(String::as_str),
+            Some("prod")
+        );
+        assert_eq!(decoded.streams[0].key_id.as_deref(), Some("key-123"));
+        assert_eq!(decoded.streams[0].warm_throughput_mibps, 9);
+        assert_eq!(decoded.streams[0].max_record_size_kib, 2048);
+        assert_eq!(decoded.streams[0].shard_counters, vec![7]);
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,6 +12,7 @@
 use crate::actions::{self, Operation};
 use crate::constants;
 use crate::error::KinesisErrorResponse;
+use crate::metrics::PreOperationFailureReason;
 #[cfg(feature = "mirror")]
 use crate::mirror::Mirror;
 use crate::store::Store;
@@ -88,7 +89,13 @@ pub async fn handler(
             }
             response_headers.insert("Access-Control-Max-Age", "172800".parse().unwrap());
             response_headers.insert("Content-Length", "0".parse().unwrap());
-            return (StatusCode::OK, response_headers, "").into_response();
+            return finalize_response(
+                &store,
+                None,
+                None,
+                request_started_ms,
+                (StatusCode::OK, response_headers, "").into_response(),
+            );
         }
 
         response_headers.insert(
@@ -104,11 +111,17 @@ pub async fn handler(
             "x-amzn-ErrorType",
             constants::ACCESS_DENIED.parse().unwrap(),
         );
-        return send_xml_error(
-            h,
-            constants::ACCESS_DENIED,
-            "Unable to determine service/operation name to be authorized",
-            403,
+        return finalize_response(
+            &store,
+            None,
+            Some(PreOperationFailureReason::AccessDenied),
+            request_started_ms,
+            send_xml_error(
+                h,
+                constants::ACCESS_DENIED,
+                "Unable to determine service/operation name to be authorized",
+                403,
+            ),
         );
     }
 
@@ -155,7 +168,15 @@ pub async fn handler(
             constants::UNKNOWN_OPERATION
         };
         let err = KinesisErrorResponse::client_error(error_type, None);
-        return send_kinesis_error(&response_headers, response_content_type, &err);
+        return finalize_response(
+            &store,
+            operation,
+            operation
+                .is_none()
+                .then_some(PreOperationFailureReason::UnknownOperation),
+            request_started_ms,
+            send_kinesis_error(&response_headers, response_content_type, &err),
+        );
     }
 
     if !content_valid {
@@ -165,11 +186,19 @@ pub async fn handler(
                 "x-amzn-ErrorType",
                 constants::ACCESS_DENIED.parse().unwrap(),
             );
-            return send_xml_error(
-                h,
-                constants::ACCESS_DENIED,
-                "Unable to determine service/operation name to be authorized",
-                403,
+            return finalize_response(
+                &store,
+                operation,
+                operation
+                    .is_none()
+                    .then_some(PreOperationFailureReason::AccessDenied),
+                request_started_ms,
+                send_xml_error(
+                    h,
+                    constants::ACCESS_DENIED,
+                    "Unable to determine service/operation name to be authorized",
+                    403,
+                ),
             );
         }
         let mut h = response_headers.clone();
@@ -177,7 +206,15 @@ pub async fn handler(
             "x-amzn-ErrorType",
             constants::UNKNOWN_OPERATION.parse().unwrap(),
         );
-        return send_xml_error_code(h, constants::UNKNOWN_OPERATION, 404);
+        return finalize_response(
+            &store,
+            operation,
+            operation
+                .is_none()
+                .then_some(PreOperationFailureReason::UnknownOperation),
+            request_started_ms,
+            send_xml_error_code(h, constants::UNKNOWN_OPERATION, 404),
+        );
     }
 
     // Parse body
@@ -195,42 +232,78 @@ pub async fn handler(
         Some(Value::Object(map)) => Value::Object(map),
         Some(_) | None => {
             if content_type == "application/json" {
-                return send_json_response(
-                    response_headers.clone(),
-                    "application/json",
-                    &json!({
-                        "Output": {"__type": "com.amazon.coral.service#SerializationException"},
-                        "Version": "1.0",
-                    }),
-                    400,
+                return finalize_response(
+                    &store,
+                    operation,
+                    operation
+                        .is_none()
+                        .then_some(PreOperationFailureReason::SerializationException),
+                    request_started_ms,
+                    send_json_response(
+                        response_headers.clone(),
+                        "application/json",
+                        &json!({
+                            "Output": {"__type": "com.amazon.coral.service#SerializationException"},
+                            "Version": "1.0",
+                        }),
+                        400,
+                    ),
                 );
             }
             let err = KinesisErrorResponse::client_error(constants::SERIALIZATION_EXCEPTION, None);
-            return send_kinesis_error(&response_headers, response_content_type, &err);
+            return finalize_response(
+                &store,
+                operation,
+                operation
+                    .is_none()
+                    .then_some(PreOperationFailureReason::SerializationException),
+                request_started_ms,
+                send_kinesis_error(&response_headers, response_content_type, &err),
+            );
         }
     };
 
     // After this point, application/json doesn't progress further
     if content_type == "application/json" {
-        return send_json_response(
-            response_headers.clone(),
-            "application/json",
-            &json!({
-                "Output": {"__type": "com.amazon.coral.service#UnknownOperationException"},
-                "Version": "1.0",
-            }),
-            404,
+        return finalize_response(
+            &store,
+            operation,
+            operation
+                .is_none()
+                .then_some(PreOperationFailureReason::UnknownOperation),
+            request_started_ms,
+            send_json_response(
+                response_headers.clone(),
+                "application/json",
+                &json!({
+                    "Output": {"__type": "com.amazon.coral.service#UnknownOperationException"},
+                    "Version": "1.0",
+                }),
+                404,
+            ),
         );
     }
 
     let Some(operation) = operation else {
         let err = KinesisErrorResponse::client_error(constants::UNKNOWN_OPERATION, None);
-        return send_kinesis_error(&response_headers, response_content_type, &err);
+        return finalize_response(
+            &store,
+            None,
+            Some(PreOperationFailureReason::UnknownOperation),
+            request_started_ms,
+            send_kinesis_error(&response_headers, response_content_type, &err),
+        );
     };
 
     if !service_valid {
         let err = KinesisErrorResponse::client_error(constants::UNKNOWN_OPERATION, None);
-        return send_kinesis_error(&response_headers, response_content_type, &err);
+        return finalize_response(
+            &store,
+            Some(operation),
+            None,
+            request_started_ms,
+            send_kinesis_error(&response_headers, response_content_type, &err),
+        );
     }
 
     // Auth checking
@@ -239,24 +312,36 @@ pub async fn handler(
     let auth_query = query_string.contains("X-Amz-Algorithm");
 
     if auth_header.is_some() && auth_query {
-        return send_error_response(
-            &response_headers,
-            content_valid,
-            response_content_type,
-            constants::INVALID_SIGNATURE,
-            "Found both 'X-Amz-Algorithm' as a query-string param and 'Authorization' as HTTP header.",
-            400,
+        return finalize_response(
+            &store,
+            Some(operation),
+            None,
+            request_started_ms,
+            send_error_response(
+                &response_headers,
+                content_valid,
+                response_content_type,
+                constants::INVALID_SIGNATURE,
+                "Found both 'X-Amz-Algorithm' as a query-string param and 'Authorization' as HTTP header.",
+                400,
+            ),
         );
     }
 
     if auth_header.is_none() && !auth_query {
-        return send_error_response(
-            &response_headers,
-            content_valid,
-            response_content_type,
-            constants::MISSING_AUTH_TOKEN,
-            "Missing Authentication Token",
-            400,
+        return finalize_response(
+            &store,
+            Some(operation),
+            None,
+            request_started_ms,
+            send_error_response(
+                &response_headers,
+                content_valid,
+                response_content_type,
+                constants::MISSING_AUTH_TOKEN,
+                "Missing Authentication Token",
+                400,
+            ),
         );
     }
 
@@ -286,13 +371,19 @@ pub async fn handler(
         }
         if !msg.is_empty() {
             msg += &format!("Authorization={auth}");
-            return send_error_response(
-                &response_headers,
-                content_valid,
-                response_content_type,
-                constants::INCOMPLETE_SIGNATURE,
-                &msg,
-                403,
+            return finalize_response(
+                &store,
+                Some(operation),
+                None,
+                request_started_ms,
+                send_error_response(
+                    &response_headers,
+                    content_valid,
+                    response_content_type,
+                    constants::INCOMPLETE_SIGNATURE,
+                    &msg,
+                    403,
+                ),
             );
         }
     } else {
@@ -327,13 +418,19 @@ pub async fn handler(
         }
         if !msg.is_empty() {
             msg += "Re-examine the query-string parameters.";
-            return send_error_response(
-                &response_headers,
-                content_valid,
-                response_content_type,
-                constants::INCOMPLETE_SIGNATURE,
-                &msg,
-                403,
+            return finalize_response(
+                &store,
+                Some(operation),
+                None,
+                request_started_ms,
+                send_error_response(
+                    &response_headers,
+                    content_valid,
+                    response_content_type,
+                    constants::INCOMPLETE_SIGNATURE,
+                    &msg,
+                    403,
+                ),
             );
         }
     }
@@ -346,12 +443,24 @@ pub async fn handler(
     let data = match validation::check_types(&data, &field_refs) {
         Ok(d) => d,
         Err(err) => {
-            return send_kinesis_error(&response_headers, response_content_type, &err);
+            return finalize_response(
+                &store,
+                Some(operation),
+                None,
+                request_started_ms,
+                send_kinesis_error(&response_headers, response_content_type, &err),
+            );
         }
     };
 
     if let Err(err) = validation::check_validations(&data, &field_refs, None) {
-        return send_kinesis_error(&response_headers, response_content_type, &err);
+        return finalize_response(
+            &store,
+            Some(operation),
+            None,
+            request_started_ms,
+            send_kinesis_error(&response_headers, response_content_type, &err),
+        );
     }
 
     let span = tracing::info_span!("kinesis", %operation, %request_id);
@@ -360,32 +469,32 @@ pub async fn handler(
     if operation == Operation::SubscribeToShard {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            let response = match actions::subscribe_to_shard::execute_streaming(
-                &store,
-                data,
-                response_content_type,
-            )
-            .instrument(span.clone())
-            .await
-            {
-                Ok(body) => {
-                    tracing::debug!(parent: &span, "ok");
-                    response_headers.insert(
-                        "Content-Type",
-                        "application/vnd.amazon.eventstream".parse().unwrap(),
-                    );
-                    (StatusCode::OK, response_headers, body).into_response()
-                }
-                Err(ref err) => {
-                    log_and_send_error(&span, &response_headers, response_content_type, err)
+            let response = match store.check_available() {
+                Ok(()) => match actions::subscribe_to_shard::execute_streaming(
+                    &store,
+                    data,
+                    response_content_type,
+                )
+                .instrument(span.clone())
+                .await
+                {
+                    Ok(body) => {
+                        tracing::debug!(parent: &span, "ok");
+                        response_headers.insert(
+                            "Content-Type",
+                            "application/vnd.amazon.eventstream".parse().unwrap(),
+                        );
+                        (StatusCode::OK, response_headers, body).into_response()
+                    }
+                    Err(ref err) => {
+                        log_and_send_error(&span, &response_headers, response_content_type, err)
+                    }
+                },
+                Err(err) => {
+                    log_and_send_error(&span, &response_headers, response_content_type, &err)
                 }
             };
-            store.metrics().record_request(
-                operation,
-                response.status().is_success(),
-                elapsed_request_micros(request_started_ms),
-            );
-            return response;
+            return finalize_response(&store, Some(operation), None, request_started_ms, response);
         }
 
         #[cfg(target_arch = "wasm32")]
@@ -396,12 +505,7 @@ pub async fn handler(
             );
             let response =
                 log_and_send_error(&span, &response_headers, response_content_type, &err);
-            store.metrics().record_request(
-                operation,
-                false,
-                elapsed_request_micros(request_started_ms),
-            );
-            return response;
+            return finalize_response(&store, Some(operation), None, request_started_ms, response);
         }
     }
 
@@ -456,19 +560,33 @@ pub async fn handler(
         let _ = (mirror, mirrorable_result);
     }
 
-    store.metrics().record_request(
-        operation,
-        response.status().is_success(),
-        elapsed_request_micros(request_started_ms),
-    );
-
-    response
+    finalize_response(&store, Some(operation), None, request_started_ms, response)
 }
 
 fn elapsed_request_micros(request_started_ms: u64) -> u64 {
     crate::util::current_time_ms()
         .saturating_sub(request_started_ms)
         .saturating_mul(1000)
+}
+
+fn finalize_response(
+    store: &Store,
+    operation: Option<Operation>,
+    pre_operation_failure: Option<PreOperationFailureReason>,
+    request_started_ms: u64,
+    response: Response,
+) -> Response {
+    let duration_micros = elapsed_request_micros(request_started_ms);
+    if let Some(operation) = operation {
+        store
+            .metrics()
+            .record_request(operation, response.status().is_success(), duration_micros);
+    } else if let Some(reason) = pre_operation_failure {
+        store
+            .metrics()
+            .record_pre_operation_failure(reason, duration_micros);
+    }
+    response
 }
 
 fn send_kinesis_error(

--- a/src/server.rs
+++ b/src/server.rs
@@ -60,6 +60,7 @@ pub async fn handler(
     body: Bytes,
 ) -> Response {
     let request_id = uuid::Uuid::new_v4().to_string();
+    let request_started_ms = crate::util::current_time_ms();
 
     let mut response_headers = HeaderMap::new();
     response_headers.insert("x-amzn-RequestId", request_id.parse().unwrap());
@@ -358,26 +359,34 @@ pub async fn handler(
     // Handle SubscribeToShard separately (streaming response)
     if operation == Operation::SubscribeToShard {
         #[cfg(not(target_arch = "wasm32"))]
-        return match actions::subscribe_to_shard::execute_streaming(
-            &store,
-            data,
-            response_content_type,
-        )
-        .instrument(span.clone())
-        .await
         {
-            Ok(body) => {
-                tracing::debug!(parent: &span, "ok");
-                response_headers.insert(
-                    "Content-Type",
-                    "application/vnd.amazon.eventstream".parse().unwrap(),
-                );
-                (StatusCode::OK, response_headers, body).into_response()
-            }
-            Err(ref err) => {
-                log_and_send_error(&span, &response_headers, response_content_type, err)
-            }
-        };
+            let response = match actions::subscribe_to_shard::execute_streaming(
+                &store,
+                data,
+                response_content_type,
+            )
+            .instrument(span.clone())
+            .await
+            {
+                Ok(body) => {
+                    tracing::debug!(parent: &span, "ok");
+                    response_headers.insert(
+                        "Content-Type",
+                        "application/vnd.amazon.eventstream".parse().unwrap(),
+                    );
+                    (StatusCode::OK, response_headers, body).into_response()
+                }
+                Err(ref err) => {
+                    log_and_send_error(&span, &response_headers, response_content_type, err)
+                }
+            };
+            store.metrics().record_request(
+                operation,
+                response.status().is_success(),
+                elapsed_request_micros(request_started_ms),
+            );
+            return response;
+        }
 
         #[cfg(target_arch = "wasm32")]
         {
@@ -385,7 +394,14 @@ pub async fn handler(
                 constants::INVALID_ARGUMENT,
                 Some("SubscribeToShard is not supported in this build."),
             );
-            return log_and_send_error(&span, &response_headers, response_content_type, &err);
+            let response =
+                log_and_send_error(&span, &response_headers, response_content_type, &err);
+            store.metrics().record_request(
+                operation,
+                false,
+                elapsed_request_micros(request_started_ms),
+            );
+            return response;
         }
     }
 
@@ -440,7 +456,19 @@ pub async fn handler(
         let _ = (mirror, mirrorable_result);
     }
 
+    store.metrics().record_request(
+        operation,
+        response.status().is_success(),
+        elapsed_request_micros(request_started_ms),
+    );
+
     response
+}
+
+fn elapsed_request_micros(request_started_ms: u64) -> u64 {
+    crate::util::current_time_ms()
+        .saturating_sub(request_started_ms)
+        .saturating_mul(1000)
 }
 
 fn send_kinesis_error(

--- a/src/server.rs
+++ b/src/server.rs
@@ -295,6 +295,16 @@ pub async fn handler(
         );
     };
 
+    if let Err(err) = store.check_available() {
+        return finalize_response(
+            &store,
+            Some(operation),
+            None,
+            request_started_ms,
+            send_kinesis_error(&response_headers, response_content_type, &err),
+        );
+    }
+
     if !service_valid {
         let err = KinesisErrorResponse::client_error(constants::UNKNOWN_OPERATION, None);
         return finalize_response(
@@ -315,7 +325,7 @@ pub async fn handler(
         return finalize_response(
             &store,
             Some(operation),
-            None,
+            Some(PreOperationFailureReason::InvalidSignature),
             request_started_ms,
             send_error_response(
                 &response_headers,
@@ -332,7 +342,7 @@ pub async fn handler(
         return finalize_response(
             &store,
             Some(operation),
-            None,
+            Some(PreOperationFailureReason::MissingAuthToken),
             request_started_ms,
             send_error_response(
                 &response_headers,
@@ -374,7 +384,7 @@ pub async fn handler(
             return finalize_response(
                 &store,
                 Some(operation),
-                None,
+                Some(PreOperationFailureReason::IncompleteSignature),
                 request_started_ms,
                 send_error_response(
                     &response_headers,
@@ -421,7 +431,7 @@ pub async fn handler(
             return finalize_response(
                 &store,
                 Some(operation),
-                None,
+                Some(PreOperationFailureReason::IncompleteSignature),
                 request_started_ms,
                 send_error_response(
                     &response_headers,
@@ -581,7 +591,8 @@ fn finalize_response(
         store
             .metrics()
             .record_request(operation, response.status().is_success(), duration_micros);
-    } else if let Some(reason) = pre_operation_failure {
+    }
+    if let Some(reason) = pre_operation_failure {
         store
             .metrics()
             .record_pre_operation_failure(reason, duration_micros);

--- a/src/store.rs
+++ b/src/store.rs
@@ -880,6 +880,81 @@ impl Store {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    fn check_persistent_mutation_allowed(&self) -> Result<(), KinesisErrorResponse> {
+        if self.persistence.is_none() {
+            return Ok(());
+        }
+        if !self.health.durable_ok.load(Ordering::Relaxed) {
+            let detail = self
+                .health
+                .last_error
+                .read()
+                .ok()
+                .and_then(|guard| guard.clone())
+                .unwrap_or_else(|| "durable state is not ready".to_string());
+            return Err(KinesisErrorResponse::server_error(None, Some(&detail)));
+        }
+        if !self.health.replay_complete.load(Ordering::Relaxed) {
+            return Err(KinesisErrorResponse::server_error(
+                None,
+                Some("durable replay is not complete"),
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn capture_transition_state(
+        &self,
+        update: &TransitionMutation,
+    ) -> Option<(String, Option<PendingTransition>)> {
+        match update {
+            TransitionMutation::None => None,
+            TransitionMutation::Upsert(transition) => {
+                let key = transition.key();
+                let previous = self
+                    .inner
+                    .pending_transitions
+                    .read()
+                    .await
+                    .get(&key)
+                    .cloned();
+                Some((key, previous))
+            }
+            TransitionMutation::Remove(key) => {
+                let previous = self
+                    .inner
+                    .pending_transitions
+                    .read()
+                    .await
+                    .get(key)
+                    .cloned();
+                Some((key.clone(), previous))
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn restore_transition_state(
+        &self,
+        snapshot: Option<(String, Option<PendingTransition>)>,
+    ) {
+        let Some((key, previous)) = snapshot else {
+            return;
+        };
+
+        let mut transitions = self.inner.pending_transitions.write().await;
+        match previous {
+            Some(transition) => {
+                transitions.insert(key, transition);
+            }
+            None => {
+                transitions.remove(&key);
+            }
+        }
+    }
+
     async fn apply_transition_mutation(&self, update: TransitionMutation) {
         let mut transitions = self.inner.pending_transitions.write().await;
         match update {
@@ -911,9 +986,9 @@ impl Store {
     }
 
     /// Inserts or replaces a stream by name.
-    pub async fn put_stream(&self, name: &str, stream: Stream) {
+    pub async fn put_stream(&self, name: &str, stream: Stream) -> Result<(), KinesisErrorResponse> {
         self.put_stream_with_transition(name, stream, TransitionMutation::None)
-            .await;
+            .await
     }
 
     pub(crate) async fn put_stream_with_transition(
@@ -921,11 +996,32 @@ impl Store {
         name: &str,
         stream: Stream,
         transition: TransitionMutation,
-    ) {
-        if let Some(existing) = self.inner.streams.get(name) {
-            // Update metadata, preserve existing records and seq state.
-            let mut guard = existing.stream.write().await;
-            *guard = stream;
+    ) -> Result<(), KinesisErrorResponse> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            self.check_persistent_mutation_allowed()?;
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let transition_snapshot = self.capture_transition_state(&transition).await;
+        let existing = self
+            .inner
+            .streams
+            .get(name)
+            .map(|entry| entry.value().clone());
+        #[cfg(not(target_arch = "wasm32"))]
+        let previous_stream = if let Some(entry) = existing.as_ref() {
+            Some(entry.stream.read().await.clone())
+        } else {
+            None
+        };
+
+        if let Some(entry) = existing.as_ref() {
+            let mut guard = entry.stream.write().await;
+            *guard = stream.clone();
         } else {
             let shard_seq = build_shard_seq(&stream);
             let entry = Arc::new(StreamEntry {
@@ -936,40 +1032,91 @@ impl Store {
         }
         self.apply_transition_mutation(transition).await;
         self.refresh_topology_metrics().await;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            if let Some(entry) = existing {
+                let mut guard = entry.stream.write().await;
+                *guard = previous_stream.expect("existing stream snapshot");
+            } else {
+                self.inner.streams.remove(name);
+            }
+            self.restore_transition_state(transition_snapshot).await;
+            self.refresh_topology_metrics().await;
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
+
+        Ok(())
     }
 
     /// Deletes a stream and all of its records.
-    pub async fn delete_stream(&self, name: &str) {
+    pub async fn delete_stream(&self, name: &str) -> Result<(), KinesisErrorResponse> {
         self.delete_stream_with_transition(name, TransitionMutation::None)
-            .await;
+            .await
     }
 
     pub(crate) async fn delete_stream_with_transition(
         &self,
         name: &str,
         transition: TransitionMutation,
-    ) {
-        if let Some(records) = self.inner.stream_records.get(name) {
-            let mut bytes = 0u64;
-            let mut count = 0u64;
+    ) -> Result<(), KinesisErrorResponse> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            self.check_persistent_mutation_allowed()?;
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let transition_snapshot = self.capture_transition_state(&transition).await;
+        let removed_stream = self.inner.streams.remove(name).map(|(_, entry)| entry);
+        let removed_records = self
+            .inner
+            .stream_records
+            .remove(name)
+            .map(|(_, records)| records);
+        let mut removed_bytes = 0u64;
+        let mut removed_count = 0u64;
+        if let Some(records) = removed_records.as_ref() {
             for shard in records.iter() {
-                if let Ok(shard_records) = shard.value().try_read() {
-                    count += shard_records.len() as u64;
-                    bytes += shard_records
-                        .values()
-                        .map(|value| value.len() as u64)
-                        .sum::<u64>();
-                }
+                let shard_records = shard.value().read().await;
+                removed_count += shard_records.len() as u64;
+                removed_bytes += shard_records
+                    .values()
+                    .map(|value| value.len() as u64)
+                    .sum::<u64>();
             }
-            self.metrics.remove_retained(bytes, count);
+            self.metrics.remove_retained(removed_bytes, removed_count);
         }
-        self.inner.streams.remove(name);
-        self.inner.stream_records.remove(name);
-        self.clear_throughput_windows_for_stream(name);
         self.apply_transition_mutation(transition).await;
         self.refresh_topology_metrics().await;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            if let Some(entry) = removed_stream {
+                self.inner.streams.insert(name.to_string(), entry);
+            }
+            if let Some(records) = removed_records {
+                self.inner.stream_records.insert(name.to_string(), records);
+            }
+            if removed_count > 0 {
+                self.metrics.add_retained(removed_bytes, removed_count);
+            }
+            self.restore_transition_state(transition_snapshot).await;
+            self.refresh_topology_metrics().await;
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
+
+        self.clear_throughput_windows_for_stream(name);
+
+        Ok(())
     }
 
     /// Returns `true` if a stream with the given name exists.
@@ -1023,20 +1170,59 @@ impl Store {
     where
         F: FnOnce(&mut Stream) -> Result<R, KinesisErrorResponse>,
     {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            self.check_persistent_mutation_allowed()?;
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+
         let entry = self
             .inner
             .streams
             .get(name)
             .map(|e| e.value().clone())
             .ok_or_else(|| KinesisErrorResponse::stream_not_found(name, &self.aws_account_id))?;
-        let mut stream = entry.stream.write().await;
-        let result = f(&mut stream)?;
-        // Sync shard_seq if the closure added shards (split/merge/reshard).
-        sync_shard_seq(&entry, &stream).await;
-        drop(stream);
+        let previous_stream = entry.stream.read().await.clone();
+        let previous_counters = entry
+            .shard_seq
+            .read()
+            .await
+            .iter()
+            .map(|state| state.counter.load(Ordering::Relaxed))
+            .collect::<Vec<_>>();
+        let mut candidate = previous_stream.clone();
+        let result = f(&mut candidate)?;
+
+        {
+            let mut stream = entry.stream.write().await;
+            *stream = candidate.clone();
+        }
+        sync_shard_seq(&entry, &candidate).await;
+        #[cfg(not(target_arch = "wasm32"))]
+        let transition_snapshot = self.capture_transition_state(&transition).await;
         self.apply_transition_mutation(transition).await;
         self.refresh_topology_metrics().await;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            {
+                let mut stream = entry.stream.write().await;
+                *stream = previous_stream;
+            }
+            {
+                let mut shard_seq = entry.shard_seq.write().await;
+                *shard_seq = build_shard_seq_from_counters(&previous_counters);
+            }
+            self.restore_transition_state(transition_snapshot).await;
+            self.refresh_topology_metrics().await;
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
+
         Ok(result)
     }
 
@@ -1221,6 +1407,13 @@ impl Store {
     /// Deletes records whose sequence-number–embedded timestamp is older than
     /// the retention cutoff. Returns the number of records removed.
     pub async fn delete_expired_records(&self, stream_name: &str, retention_hours: u32) -> usize {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+
         let now = crate::util::current_time_ms();
         let cutoff_time = now - (retention_hours as u64 * 60 * 60 * 1000);
 
@@ -1273,6 +1466,13 @@ impl Store {
 
     /// Deletes records by their shard keys within a stream.
     pub async fn delete_record_keys(&self, stream_name: &str, keys: &[String]) {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+
         // Phase 1: collect Arc refs while holding the DashMap Ref.
         let pending: Vec<_> = {
             let shard_map = match self.inner.stream_records.get(stream_name) {
@@ -1390,9 +1590,13 @@ impl Store {
     // --- Consumer operations ---
 
     /// Inserts or replaces a consumer keyed by its ARN.
-    pub async fn put_consumer(&self, consumer_arn: &str, consumer: Consumer) {
+    pub async fn put_consumer(
+        &self,
+        consumer_arn: &str,
+        consumer: Consumer,
+    ) -> Result<(), KinesisErrorResponse> {
         self.put_consumer_with_transition(consumer_arn, consumer, TransitionMutation::None)
-            .await;
+            .await
     }
 
     pub(crate) async fn put_consumer_with_transition(
@@ -1400,11 +1604,37 @@ impl Store {
         consumer_arn: &str,
         consumer: Consumer,
         transition: TransitionMutation,
-    ) {
+    ) -> Result<(), KinesisErrorResponse> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            self.check_persistent_mutation_allowed()?;
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
         let bytes = serde_json::to_vec(&consumer).unwrap();
-        self.inner.consumers.insert(consumer_arn.to_string(), bytes);
+        let previous = self.inner.consumers.insert(consumer_arn.to_string(), bytes);
+        #[cfg(not(target_arch = "wasm32"))]
+        let transition_snapshot = self.capture_transition_state(&transition).await;
         self.apply_transition_mutation(transition).await;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            if let Some(previous) = previous {
+                self.inner
+                    .consumers
+                    .insert(consumer_arn.to_string(), previous);
+            } else {
+                self.inner.consumers.remove(consumer_arn);
+            }
+            self.restore_transition_state(transition_snapshot).await;
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
+
+        Ok(())
     }
 
     /// Returns the consumer with the given ARN, or `None` if not found.
@@ -1416,19 +1646,47 @@ impl Store {
     }
 
     /// Deletes the consumer with the given ARN.
-    pub async fn delete_consumer(&self, consumer_arn: &str) {
+    pub async fn delete_consumer(&self, consumer_arn: &str) -> Result<(), KinesisErrorResponse> {
         self.delete_consumer_with_transition(consumer_arn, TransitionMutation::None)
-            .await;
+            .await
     }
 
     pub(crate) async fn delete_consumer_with_transition(
         &self,
         consumer_arn: &str,
         transition: TransitionMutation,
-    ) {
-        self.inner.consumers.remove(consumer_arn);
+    ) -> Result<(), KinesisErrorResponse> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            self.check_persistent_mutation_allowed()?;
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+        let previous = self
+            .inner
+            .consumers
+            .remove(consumer_arn)
+            .map(|(_, value)| value);
+        #[cfg(not(target_arch = "wasm32"))]
+        let transition_snapshot = self.capture_transition_state(&transition).await;
         self.apply_transition_mutation(transition).await;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            if let Some(previous) = previous {
+                self.inner
+                    .consumers
+                    .insert(consumer_arn.to_string(), previous);
+            }
+            self.restore_transition_state(transition_snapshot).await;
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
+
+        Ok(())
     }
 
     /// Returns all consumers whose ARN belongs to the given stream ARN.
@@ -1455,11 +1713,39 @@ impl Store {
     // --- Resource policy operations ---
 
     /// Stores a resource policy JSON string for the given resource ARN.
-    pub async fn put_policy(&self, resource_arn: &str, policy: &str) {
-        self.inner
+    pub async fn put_policy(
+        &self,
+        resource_arn: &str,
+        policy: &str,
+    ) -> Result<(), KinesisErrorResponse> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            self.check_persistent_mutation_allowed()?;
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+        let previous = self
+            .inner
             .policies
             .insert(resource_arn.to_string(), policy.to_string());
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            if let Some(previous) = previous {
+                self.inner
+                    .policies
+                    .insert(resource_arn.to_string(), previous);
+            } else {
+                self.inner.policies.remove(resource_arn);
+            }
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
+
+        Ok(())
     }
 
     /// Returns the resource policy for the given ARN, or `None` if none is set.
@@ -1471,9 +1757,34 @@ impl Store {
     }
 
     /// Deletes the resource policy for the given ARN.
-    pub async fn delete_policy(&self, resource_arn: &str) {
-        self.inner.policies.remove(resource_arn);
+    pub async fn delete_policy(&self, resource_arn: &str) -> Result<(), KinesisErrorResponse> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            self.check_persistent_mutation_allowed()?;
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+        let previous = self
+            .inner
+            .policies
+            .remove(resource_arn)
+            .map(|(_, value)| value);
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            if let Some(previous) = previous {
+                self.inner
+                    .policies
+                    .insert(resource_arn.to_string(), previous);
+            }
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
+
+        Ok(())
     }
 
     /// Extracts the stream name from a Kinesis stream ARN.
@@ -1536,11 +1847,39 @@ impl Store {
     }
 
     /// Replaces the tag map for the given resource ARN.
-    pub async fn put_resource_tags(&self, resource_arn: &str, tags: &BTreeMap<String, String>) {
-        self.inner
+    pub async fn put_resource_tags(
+        &self,
+        resource_arn: &str,
+        tags: &BTreeMap<String, String>,
+    ) -> Result<(), KinesisErrorResponse> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            self.check_persistent_mutation_allowed()?;
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+        let previous = self
+            .inner
             .resource_tags
             .insert(resource_arn.to_string(), tags.clone());
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            if let Some(previous) = previous {
+                self.inner
+                    .resource_tags
+                    .insert(resource_arn.to_string(), previous);
+            } else {
+                self.inner.resource_tags.remove(resource_arn);
+            }
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
+
+        Ok(())
     }
 
     // --- Account settings operations ---
@@ -1551,11 +1890,30 @@ impl Store {
     }
 
     /// Stores the account-level settings object.
-    pub async fn put_account_settings(&self, settings: &Value) {
+    pub async fn put_account_settings(&self, settings: &Value) -> Result<(), KinesisErrorResponse> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            self.check_persistent_mutation_allowed()?;
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+        let previous = self.inner.account_settings.read().await.clone();
         let mut guard = self.inner.account_settings.write().await;
         *guard = settings.clone();
         drop(guard);
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            let mut guard = self.inner.account_settings.write().await;
+            *guard = previous;
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
+
+        Ok(())
     }
 
     /// Probes store health. Always succeeds for the in-memory store.
@@ -1807,7 +2165,8 @@ impl Store {
                     ));
                 }
                 self.delete_stream_with_transition(&stream_name, TransitionMutation::Remove(key))
-                    .await;
+                    .await
+                    .map_err(|err| err.to_string())?;
                 Ok(())
             }
             PendingTransition::RegisterConsumer { consumer_arn, .. } => {
@@ -1831,7 +2190,8 @@ impl Store {
                     consumer,
                     TransitionMutation::Remove(key),
                 )
-                .await;
+                .await
+                .map_err(|err| err.to_string())?;
                 Ok(())
             }
             PendingTransition::DeregisterConsumer { consumer_arn, .. } => {
@@ -1853,7 +2213,8 @@ impl Store {
                     &consumer_arn,
                     TransitionMutation::Remove(key),
                 )
-                .await;
+                .await
+                .map_err(|err| err.to_string())?;
                 Ok(())
             }
             PendingTransition::UpdateShardCount {
@@ -2283,15 +2644,15 @@ impl Store {
 
 /// Build per-shard sequence state from a stream's shard list.
 fn build_shard_seq(stream: &Stream) -> Vec<ShardSeqState> {
-    stream
-        .shards
+    build_shard_seq_from_counters(&vec![1; stream.shards.len()])
+}
+
+fn build_shard_seq_from_counters(counters: &[u64]) -> Vec<ShardSeqState> {
+    counters
         .iter()
-        .map(|_| ShardSeqState {
-            // Skip index 0: the shard's starting_sequence_number is generated with
-            // seq_ix=0. If the first PutRecord lands in the same millisecond as shard
-            // creation, seq_time would also match, so seq_ix must be ≥1 to guarantee
-            // every record's sequence number is strictly greater than the starting one.
-            counter: AtomicU64::new(1),
+        .copied()
+        .map(|counter| ShardSeqState {
+            counter: AtomicU64::new(counter),
         })
         .collect()
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -17,6 +17,11 @@
 
 use crate::constants;
 use crate::error::KinesisErrorResponse;
+use crate::metrics::AppMetrics;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::persistence::{
+    Persistence, PersistentSnapshot, PersistentStream, SnapshotShardRecords, WalEntry,
+};
 use crate::sequence;
 use crate::types::{Consumer, StoredRecord, Stream, StreamStatus};
 use crate::util::current_time_ms;
@@ -24,8 +29,10 @@ use dashmap::DashMap;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::RwLock as StdRwLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::{Mutex, RwLock};
 
 const DEFAULT_SHARD_WRITE_BYTES_PER_SEC: u64 = 1024 * 1024;
@@ -40,6 +47,21 @@ pub enum StoreHealthError {
     /// A required table could not be opened within the read transaction.
     #[error("table open failed: {0}")]
     TableOpenFailed(String),
+}
+
+#[derive(Default)]
+struct StoreHealthState {
+    replay_complete: AtomicBool,
+    durable_ok: AtomicBool,
+    last_error: StdRwLock<Option<String>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct PersistenceState {
+    backend: Persistence,
+    io_lock: Mutex<()>,
+    snapshot_interval_secs: u64,
+    last_snapshot_ms: AtomicU64,
 }
 
 /// Runtime configuration passed to [`crate::create_app`].
@@ -74,6 +96,12 @@ pub struct StoreOptions {
     pub retention_check_interval_secs: u64,
     /// Enable AWS-like shard write throughput throttling. Disabled by default.
     pub enforce_limits: bool,
+    /// Directory used to persist state with WAL + snapshots.
+    pub state_dir: Option<PathBuf>,
+    /// Snapshot interval in seconds when durable mode is enabled.
+    pub snapshot_interval_secs: u64,
+    /// Hard cap on retained serialized record bytes.
+    pub max_retained_bytes: Option<u64>,
     /// Simulated AWS account ID (12 digits). Defaults to `"000000000000"`.
     pub aws_account_id: String,
     /// Simulated AWS region. Defaults to `"us-east-1"`.
@@ -90,6 +118,9 @@ impl Default for StoreOptions {
             iterator_ttl_seconds: 300,
             retention_check_interval_secs: 0,
             enforce_limits: false,
+            state_dir: None,
+            snapshot_interval_secs: 30,
+            max_retained_bytes: None,
             aws_account_id: "000000000000".to_string(),
             aws_region: "us-east-1".to_string(),
         }
@@ -162,6 +193,10 @@ pub struct Store {
     /// The simulated AWS region.
     pub aws_region: String,
     inner: Arc<StoreInner>,
+    metrics: Arc<AppMetrics>,
+    health: Arc<StoreHealthState>,
+    #[cfg(not(target_arch = "wasm32"))]
+    persistence: Option<Arc<PersistenceState>>,
     /// Optional capture writer for recording PutRecord/PutRecords calls.
     #[cfg(feature = "server")]
     pub(crate) capture_writer: Option<crate::capture::CaptureWriter>,
@@ -231,23 +266,350 @@ impl Store {
         }
 
         let aws_region = options.aws_region.clone();
+        let metrics = AppMetrics::new(options.iterator_ttl_seconds);
+        let health = Arc::new(StoreHealthState {
+            replay_complete: AtomicBool::new(true),
+            durable_ok: AtomicBool::new(true),
+            last_error: StdRwLock::new(None),
+        });
 
-        Self {
+        let inner = Arc::new(StoreInner {
+            streams: DashMap::new(),
+            stream_records: DashMap::new(),
+            consumers: DashMap::new(),
+            policies: DashMap::new(),
+            resource_tags: DashMap::new(),
+            account_settings: RwLock::new(Value::Object(Default::default())),
+        });
+
+        let store = Self {
             options,
             aws_account_id,
             aws_region,
-            inner: Arc::new(StoreInner {
-                streams: DashMap::new(),
-                stream_records: DashMap::new(),
-                consumers: DashMap::new(),
-                policies: DashMap::new(),
-                resource_tags: DashMap::new(),
-                account_settings: RwLock::new(Value::Object(Default::default())),
-                throughput_windows: DashMap::new(),
-            }),
+            inner,
+            metrics,
+            health,
+            #[cfg(not(target_arch = "wasm32"))]
+            persistence: None,
             #[cfg(feature = "server")]
             capture_writer,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut store = store;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(state_dir) = store.options.state_dir.clone() {
+            match Persistence::new(state_dir) {
+                Ok(backend) => {
+                    let persistence = Arc::new(PersistenceState {
+                        backend,
+                        io_lock: Mutex::new(()),
+                        snapshot_interval_secs: store.options.snapshot_interval_secs,
+                        last_snapshot_ms: AtomicU64::new(0),
+                    });
+                    if let Err(err) = store.load_persistent_state(&persistence) {
+                        store.mark_unhealthy(err);
+                    }
+                    store.persistence = Some(persistence);
+                }
+                Err(err) => {
+                    store.mark_unhealthy(format!("failed to initialize durable state: {err}"))
+                }
+            }
         }
+
+        store.refresh_topology_metrics_sync();
+        store
+    }
+
+    /// Returns the shared application metrics registry.
+    pub fn metrics(&self) -> Arc<AppMetrics> {
+        Arc::clone(&self.metrics)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn load_persistent_state(&mut self, persistence: &Arc<PersistenceState>) -> Result<(), String> {
+        let Some((snapshot, entries)) =
+            persistence.backend.load().map_err(|err| err.to_string())?
+        else {
+            return Ok(());
+        };
+
+        persistence
+            .last_snapshot_ms
+            .store(snapshot.created_at_ms, Ordering::Relaxed);
+        self.metrics.set_last_snapshot_ms(snapshot.created_at_ms);
+        self.restore_snapshot(snapshot)?;
+        self.metrics.set_replay_complete(false);
+        self.health.replay_complete.store(false, Ordering::Relaxed);
+
+        for entry in entries {
+            self.apply_wal_entry(entry)?;
+        }
+
+        self.metrics.set_replay_complete(true);
+        self.health.replay_complete.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn apply_wal_entry(&self, entry: WalEntry) -> Result<(), String> {
+        match entry {
+            WalEntry::Snapshot(snapshot) => self.restore_snapshot(snapshot),
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn restore_snapshot(&self, snapshot: PersistentSnapshot) -> Result<(), String> {
+        self.inner.streams.clear();
+        self.inner.stream_records.clear();
+        self.inner.consumers.clear();
+        self.inner.policies.clear();
+        self.inner.resource_tags.clear();
+        if let Ok(mut settings) = self.inner.account_settings.try_write() {
+            *settings = if snapshot.account_settings_json.is_empty() {
+                Value::Object(Default::default())
+            } else {
+                serde_json::from_slice(&snapshot.account_settings_json)
+                    .map_err(|err| format!("failed to decode persisted account settings: {err}"))?
+            };
+        }
+
+        for stream in snapshot.streams {
+            let (name, stream_value, shard_counters) = stream.into_parts();
+            let entry = Arc::new(StreamEntry {
+                stream: RwLock::new(stream_value),
+                shard_seq: RwLock::new(
+                    shard_counters
+                        .into_iter()
+                        .map(|counter| ShardSeqState {
+                            counter: AtomicU64::new(counter),
+                        })
+                        .collect(),
+                ),
+            });
+            self.inner.streams.insert(name, entry);
+        }
+
+        for shard_records in snapshot.records {
+            let shard_map = self
+                .inner
+                .stream_records
+                .entry(shard_records.stream_name)
+                .or_default();
+            let records = shard_records.records.into_iter().collect();
+            shard_map.insert(shard_records.shard_hex, Arc::new(RwLock::new(records)));
+        }
+
+        for (consumer_arn, bytes) in snapshot.consumers {
+            self.inner.consumers.insert(consumer_arn, bytes);
+        }
+        for (resource_arn, policy) in snapshot.policies {
+            self.inner.policies.insert(resource_arn, policy);
+        }
+        for (resource_arn, tags) in snapshot.resource_tags {
+            self.inner.resource_tags.insert(resource_arn, tags);
+        }
+
+        self.metrics
+            .set_retained(snapshot.retained_bytes, snapshot.retained_records);
+        self.refresh_topology_metrics_sync();
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn export_snapshot(&self) -> Result<PersistentSnapshot, String> {
+        let mut streams = Vec::new();
+        for entry in self.inner.streams.iter() {
+            let stream = entry.value().stream.read().await.clone();
+            let shard_seq = entry
+                .value()
+                .shard_seq
+                .read()
+                .await
+                .iter()
+                .map(|state| state.counter.load(Ordering::Relaxed))
+                .collect();
+            streams.push(PersistentStream::from_stream(
+                entry.key().clone(),
+                &stream,
+                shard_seq,
+            ));
+        }
+
+        let mut records = Vec::new();
+        for stream_entry in self.inner.stream_records.iter() {
+            for shard_entry in stream_entry.value().iter() {
+                let shard_records_map = shard_entry.value().read().await.clone();
+                let shard_records = shard_records_map.into_iter().collect();
+                records.push(SnapshotShardRecords {
+                    stream_name: stream_entry.key().clone(),
+                    shard_hex: shard_entry.key().clone(),
+                    records: shard_records,
+                });
+            }
+        }
+
+        Ok(PersistentSnapshot {
+            created_at_ms: current_time_ms(),
+            streams,
+            records,
+            consumers: self
+                .inner
+                .consumers
+                .iter()
+                .map(|entry| (entry.key().clone(), entry.value().clone()))
+                .collect(),
+            policies: self
+                .inner
+                .policies
+                .iter()
+                .map(|entry| (entry.key().clone(), entry.value().clone()))
+                .collect(),
+            resource_tags: self
+                .inner
+                .resource_tags
+                .iter()
+                .map(|entry| (entry.key().clone(), entry.value().clone()))
+                .collect(),
+            account_settings_json: {
+                let account_settings = self.inner.account_settings.read().await.clone();
+                serde_json::to_vec(&account_settings)
+                    .map_err(|err| format!("failed to encode snapshot account settings: {err}"))?
+            },
+            retained_bytes: self.metrics.retained_bytes(),
+            retained_records: self.metrics.retained_records(),
+        })
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn persist_snapshot(&self, snapshot: &PersistentSnapshot) {
+        let Some(persistence) = &self.persistence else {
+            return;
+        };
+        let backend = persistence.backend.clone();
+        let snapshot = snapshot.clone();
+        if let Err(err) = tokio::task::spawn_blocking(move || {
+            backend.append_wal_entry(&WalEntry::Snapshot(snapshot))
+        })
+        .await
+        .map_err(|err| err.to_string())
+        .and_then(|res| res.map_err(|err| err.to_string()))
+        {
+            self.mark_unhealthy(format!("failed to persist wal entry: {err}"));
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn persist_current_state(&self) {
+        if self.persistence.is_none() {
+            return;
+        }
+        let Some(persistence) = &self.persistence else {
+            return;
+        };
+        let _guard = persistence.io_lock.lock().await;
+        let snapshot = match self.export_snapshot().await {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                self.mark_unhealthy(err.clone());
+                tracing::warn!("{err}");
+                return;
+            }
+        };
+
+        self.persist_snapshot(&snapshot).await;
+        if !self.health.durable_ok.load(Ordering::Relaxed) {
+            return;
+        }
+
+        if persistence.snapshot_interval_secs == 0 {
+            return;
+        }
+
+        let now = snapshot.created_at_ms;
+        let last_snapshot = persistence.last_snapshot_ms.load(Ordering::Relaxed);
+        if now.saturating_sub(last_snapshot)
+            < persistence.snapshot_interval_secs.saturating_mul(1000)
+        {
+            return;
+        }
+
+        let backend = persistence.backend.clone();
+        match tokio::task::spawn_blocking(move || backend.write_snapshot(&snapshot)).await {
+            Ok(Ok(())) => {
+                persistence.last_snapshot_ms.store(now, Ordering::Relaxed);
+                self.metrics.set_last_snapshot_ms(now);
+            }
+            Ok(Err(err)) => {
+                let message = format!("failed to write snapshot: {err}");
+                self.mark_unhealthy(message.clone());
+                tracing::warn!("{message}");
+            }
+            Err(err) => {
+                let message = format!("snapshot task failed: {err}");
+                self.mark_unhealthy(message.clone());
+                tracing::warn!("{message}");
+            }
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    async fn persist_current_state(&self) {}
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn mark_unhealthy(&self, message: String) {
+        self.health.durable_ok.store(false, Ordering::Relaxed);
+        if let Ok(mut guard) = self.health.last_error.write() {
+            *guard = Some(message);
+        }
+        self.health.replay_complete.store(false, Ordering::Relaxed);
+        self.metrics.set_replay_complete(false);
+    }
+
+    fn refresh_topology_metrics_sync(&self) {
+        let streams = self.inner.streams.len() as u64;
+        let mut open_shards = 0u64;
+        for entry in self.inner.streams.iter() {
+            if let Ok(stream) = entry.value().stream.try_read() {
+                open_shards += stream
+                    .shards
+                    .iter()
+                    .filter(|s| s.sequence_number_range.ending_sequence_number.is_none())
+                    .count() as u64;
+            }
+        }
+        self.metrics.set_topology(streams, open_shards);
+    }
+
+    async fn refresh_topology_metrics(&self) {
+        let streams = self.inner.streams.len() as u64;
+        let mut open_shards = 0u64;
+        for entry in self.inner.streams.iter() {
+            let stream = entry.value().stream.read().await;
+            open_shards += stream
+                .shards
+                .iter()
+                .filter(|s| s.sequence_number_range.ending_sequence_number.is_none())
+                .count() as u64;
+        }
+        self.metrics.set_topology(streams, open_shards);
+    }
+
+    /// Renders the current metrics registry in Prometheus text format.
+    pub async fn render_metrics(&self) -> String {
+        self.metrics.render(current_time_ms()).await
+    }
+
+    /// Records the creation time for a new shard iterator.
+    pub async fn record_iterator_created(&self, now_ms: u64) {
+        self.metrics.record_iterator(now_ms).await;
+    }
+
+    fn retained_capacity_exceeded(&self) -> bool {
+        self.options
+            .max_retained_bytes
+            .is_some_and(|limit| self.metrics.retained_bytes() > limit)
     }
 
     // --- Stream operations ---
@@ -281,13 +643,33 @@ impl Store {
             });
             self.inner.streams.insert(name.to_string(), entry);
         }
+        self.refresh_topology_metrics().await;
+        self.persist_current_state().await;
     }
 
     /// Deletes a stream and all of its records.
     pub async fn delete_stream(&self, name: &str) {
+        if let Some(records) = self.inner.stream_records.get(name) {
+            let mut bytes = 0u64;
+            let mut count = 0u64;
+            for shard in records.iter() {
+                if let Ok(shard_records) = shard.value().try_read() {
+                    count += shard_records.len() as u64;
+                    bytes += shard_records
+                        .values()
+                        .map(|value| value.len() as u64)
+                        .sum::<u64>();
+                }
+            }
+            self.metrics.remove_retained(bytes, count);
+        }
         self.inner.streams.remove(name);
         self.inner.stream_records.remove(name);
         self.clear_throughput_windows_for_stream(name);
+        self.refresh_topology_metrics().await;
+        self.persist_current_state().await;
+        self.refresh_topology_metrics().await;
+        self.persist_current_state().await;
     }
 
     /// Returns `true` if a stream with the given name exists.
@@ -338,6 +720,9 @@ impl Store {
         let result = f(&mut stream)?;
         // Sync shard_seq if the closure added shards (split/merge/reshard).
         sync_shard_seq(&entry, &stream).await;
+        drop(stream);
+        self.refresh_topology_metrics().await;
+        self.persist_current_state().await;
         Ok(result)
     }
 
@@ -401,7 +786,12 @@ impl Store {
             .clone();
         drop(shard_map);
         let mut records = records_arc.write().await;
-        records.insert(key.to_string(), bytes);
+        if let Some(previous) = records.insert(key.to_string(), bytes.clone()) {
+            self.metrics.remove_retained(previous.len() as u64, 1);
+        }
+        self.metrics.add_retained(bytes.len() as u64, 1);
+        drop(records);
+        self.persist_current_state().await;
         Ok(())
     }
 
@@ -436,8 +826,12 @@ impl Store {
         // Phase 2: insert records under per-shard write locks only.
         for (records_arc, key, bytes) in pending {
             let mut records = records_arc.write().await;
-            records.insert(key, bytes);
+            if let Some(previous) = records.insert(key, bytes.clone()) {
+                self.metrics.remove_retained(previous.len() as u64, 1);
+            }
+            self.metrics.add_retained(bytes.len() as u64, 1);
         }
+        self.persist_current_state().await;
         Ok(())
     }
 
@@ -455,6 +849,7 @@ impl Store {
 
         // Phase 2: scan and delete under per-shard locks only.
         let mut total_deleted = 0;
+        let mut bytes_deleted = 0u64;
         for records_arc in shard_arcs {
             let keys_to_delete: Vec<String> = {
                 let records = records_arc.read().await;
@@ -475,12 +870,19 @@ impl Store {
             if !keys_to_delete.is_empty() {
                 let mut records = records_arc.write().await;
                 for key in &keys_to_delete {
-                    records.remove(key);
+                    if let Some(bytes) = records.remove(key) {
+                        bytes_deleted += bytes.len() as u64;
+                    }
                 }
                 total_deleted += keys_to_delete.len();
             }
         }
 
+        if total_deleted > 0 {
+            self.metrics
+                .remove_retained(bytes_deleted, total_deleted as u64);
+            self.persist_current_state().await;
+        }
         total_deleted
     }
 
@@ -503,9 +905,17 @@ impl Store {
         }; // DashMap Ref dropped here.
 
         // Phase 2: delete under per-shard write locks only.
+        let pending_len = pending.len() as u64;
+        let mut bytes_deleted = 0u64;
         for (records_arc, key) in pending {
             let mut records = records_arc.write().await;
-            records.remove(&key);
+            if let Some(bytes) = records.remove(&key) {
+                bytes_deleted += bytes.len() as u64;
+            }
+        }
+        if pending_len > 0 {
+            self.metrics.remove_retained(bytes_deleted, pending_len);
+            self.persist_current_state().await;
         }
     }
 
@@ -597,6 +1007,7 @@ impl Store {
     pub async fn put_consumer(&self, consumer_arn: &str, consumer: Consumer) {
         let bytes = serde_json::to_vec(&consumer).unwrap();
         self.inner.consumers.insert(consumer_arn.to_string(), bytes);
+        self.persist_current_state().await;
     }
 
     /// Returns the consumer with the given ARN, or `None` if not found.
@@ -610,6 +1021,7 @@ impl Store {
     /// Deletes the consumer with the given ARN.
     pub async fn delete_consumer(&self, consumer_arn: &str) {
         self.inner.consumers.remove(consumer_arn);
+        self.persist_current_state().await;
     }
 
     /// Returns all consumers whose ARN belongs to the given stream ARN.
@@ -640,6 +1052,7 @@ impl Store {
         self.inner
             .policies
             .insert(resource_arn.to_string(), policy.to_string());
+        self.persist_current_state().await;
     }
 
     /// Returns the resource policy for the given ARN, or `None` if none is set.
@@ -653,6 +1066,7 @@ impl Store {
     /// Deletes the resource policy for the given ARN.
     pub async fn delete_policy(&self, resource_arn: &str) {
         self.inner.policies.remove(resource_arn);
+        self.persist_current_state().await;
     }
 
     /// Extracts the stream name from a Kinesis stream ARN.
@@ -719,6 +1133,7 @@ impl Store {
         self.inner
             .resource_tags
             .insert(resource_arn.to_string(), tags.clone());
+        self.persist_current_state().await;
     }
 
     // --- Account settings operations ---
@@ -732,6 +1147,8 @@ impl Store {
     pub async fn put_account_settings(&self, settings: &Value) {
         let mut guard = self.inner.account_settings.write().await;
         *guard = settings.clone();
+        drop(guard);
+        self.persist_current_state().await;
     }
 
     /// Probes store health. Always succeeds for the in-memory store.
@@ -742,6 +1159,29 @@ impl Store {
     /// in-memory implementation this never happens, but the signature is kept
     /// for API compatibility.
     pub fn check_ready(&self) -> Result<(), StoreHealthError> {
+        if !self.health.durable_ok.load(Ordering::Relaxed) {
+            let detail = self
+                .health
+                .last_error
+                .read()
+                .ok()
+                .and_then(|guard| guard.clone())
+                .unwrap_or_else(|| "durable state is not ready".to_string());
+            return Err(StoreHealthError::ReadFailed(detail));
+        }
+        if !self.health.replay_complete.load(Ordering::Relaxed) {
+            return Err(StoreHealthError::ReadFailed(
+                "durable replay is not complete".to_string(),
+            ));
+        }
+        if self.retained_capacity_exceeded() {
+            let limit = self.options.max_retained_bytes.unwrap();
+            return Err(StoreHealthError::ReadFailed(format!(
+                "retained bytes limit exceeded: {} > {}",
+                self.metrics.retained_bytes(),
+                limit
+            )));
+        }
         Ok(())
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -23,10 +23,15 @@ use crate::persistence::{
     Persistence, PersistentSnapshot, PersistentStream, SnapshotShardRecords, WalEntry,
 };
 use crate::sequence;
-use crate::types::{Consumer, StoredRecord, Stream, StreamStatus};
+use crate::types::{
+    Consumer, ConsumerStatus, EncryptionType, HashKeyRange, SequenceNumberRange, Shard,
+    StoredRecord, Stream, StreamStatus,
+};
 use crate::util::current_time_ms;
 use dashmap::DashMap;
-use serde::Serialize;
+use num_bigint::BigUint;
+use num_traits::One;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -62,6 +67,94 @@ struct PersistenceState {
     io_lock: Mutex<()>,
     snapshot_interval_secs: u64,
     last_snapshot_ms: AtomicU64,
+}
+
+/// Internal durable-transition ledger for async state changes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) enum PendingTransition {
+    CreateStream {
+        stream_name: String,
+        ready_at_ms: u64,
+        shards: Vec<Shard>,
+    },
+    DeleteStream {
+        stream_name: String,
+        ready_at_ms: u64,
+    },
+    RegisterConsumer {
+        consumer_arn: String,
+        ready_at_ms: u64,
+    },
+    DeregisterConsumer {
+        consumer_arn: String,
+        ready_at_ms: u64,
+    },
+    UpdateShardCount {
+        stream_name: String,
+        ready_at_ms: u64,
+        target_shard_count: u32,
+    },
+    SplitShard {
+        stream_name: String,
+        ready_at_ms: u64,
+        shard_to_split: String,
+        new_starting_hash_key: String,
+    },
+    MergeShards {
+        stream_name: String,
+        ready_at_ms: u64,
+        shard_to_merge: String,
+        adjacent_shard_to_merge: String,
+    },
+    StartStreamEncryption {
+        stream_name: String,
+        ready_at_ms: u64,
+    },
+    StopStreamEncryption {
+        stream_name: String,
+        ready_at_ms: u64,
+    },
+}
+
+impl PendingTransition {
+    fn key(&self) -> String {
+        match self {
+            Self::CreateStream { stream_name, .. }
+            | Self::DeleteStream { stream_name, .. }
+            | Self::UpdateShardCount { stream_name, .. }
+            | Self::SplitShard { stream_name, .. }
+            | Self::MergeShards { stream_name, .. }
+            | Self::StartStreamEncryption { stream_name, .. }
+            | Self::StopStreamEncryption { stream_name, .. } => {
+                format!("stream:{stream_name}")
+            }
+            Self::RegisterConsumer { consumer_arn, .. }
+            | Self::DeregisterConsumer { consumer_arn, .. } => {
+                format!("consumer:{consumer_arn}")
+            }
+        }
+    }
+
+    fn ready_at_ms(&self) -> u64 {
+        match self {
+            Self::CreateStream { ready_at_ms, .. }
+            | Self::DeleteStream { ready_at_ms, .. }
+            | Self::RegisterConsumer { ready_at_ms, .. }
+            | Self::DeregisterConsumer { ready_at_ms, .. }
+            | Self::UpdateShardCount { ready_at_ms, .. }
+            | Self::SplitShard { ready_at_ms, .. }
+            | Self::MergeShards { ready_at_ms, .. }
+            | Self::StartStreamEncryption { ready_at_ms, .. }
+            | Self::StopStreamEncryption { ready_at_ms, .. } => *ready_at_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum TransitionMutation {
+    None,
+    Upsert(PendingTransition),
+    Remove(String),
 }
 
 /// Runtime configuration passed to [`crate::create_app`].
@@ -166,6 +259,14 @@ struct ShardThroughputWindow {
     records: u64,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+struct AppliedRecordChange {
+    records_arc: Arc<RwLock<BTreeMap<String, Vec<u8>>>>,
+    key: String,
+    previous: Option<Vec<u8>>,
+    new_bytes_len: u64,
+}
+
 /// Shared inner state behind an [`Arc`] for cheap [`Store`] clones.
 struct StoreInner {
     /// Stream metadata entries.
@@ -178,6 +279,8 @@ struct StoreInner {
     resource_tags: DashMap<String, BTreeMap<String, String>>,
     account_settings: RwLock<Value>,
     throughput_windows: DashMap<String, Arc<Mutex<ShardThroughputWindow>>>,
+    pending_transitions: RwLock<BTreeMap<String, PendingTransition>>,
+    write_lock: Mutex<()>,
 }
 
 /// Handle to the concurrent in-memory stream store.
@@ -280,6 +383,8 @@ impl Store {
             policies: DashMap::new(),
             resource_tags: DashMap::new(),
             account_settings: RwLock::new(Value::Object(Default::default())),
+            pending_transitions: RwLock::new(BTreeMap::new()),
+            write_lock: Mutex::new(()),
         });
 
         let store = Self {
@@ -307,10 +412,12 @@ impl Store {
                         snapshot_interval_secs: store.options.snapshot_interval_secs,
                         last_snapshot_ms: AtomicU64::new(0),
                     });
+                    store.persistence = Some(Arc::clone(&persistence));
                     if let Err(err) = store.load_persistent_state(&persistence) {
                         store.mark_unhealthy(err);
+                    } else if let Err(err) = store.resume_persistent_transitions() {
+                        store.mark_unhealthy(err);
                     }
-                    store.persistence = Some(persistence);
                 }
                 Err(err) => {
                     store.mark_unhealthy(format!("failed to initialize durable state: {err}"))
@@ -361,21 +468,39 @@ impl Store {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn restore_snapshot(&self, snapshot: PersistentSnapshot) -> Result<(), String> {
+        let PersistentSnapshot {
+            streams,
+            records,
+            consumers,
+            policies,
+            resource_tags,
+            account_settings_json,
+            pending_transitions,
+            retained_bytes,
+            retained_records,
+            ..
+        } = snapshot;
         self.inner.streams.clear();
         self.inner.stream_records.clear();
         self.inner.consumers.clear();
         self.inner.policies.clear();
         self.inner.resource_tags.clear();
+        if let Ok(mut transitions) = self.inner.pending_transitions.try_write() {
+            transitions.clear();
+            for transition in pending_transitions {
+                transitions.insert(transition.key(), transition);
+            }
+        }
         if let Ok(mut settings) = self.inner.account_settings.try_write() {
-            *settings = if snapshot.account_settings_json.is_empty() {
+            *settings = if account_settings_json.is_empty() {
                 Value::Object(Default::default())
             } else {
-                serde_json::from_slice(&snapshot.account_settings_json)
+                serde_json::from_slice(&account_settings_json)
                     .map_err(|err| format!("failed to decode persisted account settings: {err}"))?
             };
         }
 
-        for stream in snapshot.streams {
+        for stream in streams {
             let (name, stream_value, shard_counters) = stream.into_parts();
             let entry = Arc::new(StreamEntry {
                 stream: RwLock::new(stream_value),
@@ -391,7 +516,7 @@ impl Store {
             self.inner.streams.insert(name, entry);
         }
 
-        for shard_records in snapshot.records {
+        for shard_records in records {
             let shard_map = self
                 .inner
                 .stream_records
@@ -401,19 +526,103 @@ impl Store {
             shard_map.insert(shard_records.shard_hex, Arc::new(RwLock::new(records)));
         }
 
-        for (consumer_arn, bytes) in snapshot.consumers {
+        for (consumer_arn, bytes) in consumers {
             self.inner.consumers.insert(consumer_arn, bytes);
         }
-        for (resource_arn, policy) in snapshot.policies {
+        for (resource_arn, policy) in policies {
             self.inner.policies.insert(resource_arn, policy);
         }
-        for (resource_arn, tags) in snapshot.resource_tags {
+        for (resource_arn, tags) in resource_tags {
             self.inner.resource_tags.insert(resource_arn, tags);
         }
 
-        self.metrics
-            .set_retained(snapshot.retained_bytes, snapshot.retained_records);
+        self.metrics.set_retained(retained_bytes, retained_records);
         self.refresh_topology_metrics_sync();
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn resume_persistent_transitions(&self) -> Result<(), String> {
+        let transitions_guard = self
+            .inner
+            .pending_transitions
+            .try_read()
+            .map_err(|_| "failed to read pending transitions during recovery".to_string())?;
+        let mut transitions: Vec<PendingTransition> = transitions_guard.values().cloned().collect();
+        drop(transitions_guard);
+
+        let existing_keys: std::collections::BTreeSet<String> =
+            transitions.iter().map(PendingTransition::key).collect();
+        let now = current_time_ms();
+
+        for entry in self.inner.streams.iter() {
+            let stream = entry
+                .value()
+                .stream
+                .try_read()
+                .map_err(|_| format!("failed to inspect recovered stream {}", entry.key()))?;
+            let key = format!("stream:{}", entry.key());
+            if existing_keys.contains(&key) {
+                continue;
+            }
+            match stream.stream_status {
+                StreamStatus::Deleting => transitions.push(PendingTransition::DeleteStream {
+                    stream_name: entry.key().clone(),
+                    ready_at_ms: now,
+                }),
+                StreamStatus::Creating => {
+                    return Err(format!(
+                        "ambiguous persisted stream transition for {}: CREATING without transition metadata",
+                        entry.key()
+                    ));
+                }
+                StreamStatus::Updating => {
+                    return Err(format!(
+                        "ambiguous persisted stream transition for {}: UPDATING without transition metadata",
+                        entry.key()
+                    ));
+                }
+                StreamStatus::Active => {}
+            }
+        }
+
+        for entry in self.inner.consumers.iter() {
+            let consumer: Consumer = serde_json::from_slice(entry.value()).map_err(|err| {
+                format!("failed to decode recovered consumer {}: {err}", entry.key())
+            })?;
+            let key = format!("consumer:{}", entry.key());
+            if existing_keys.contains(&key) {
+                continue;
+            }
+            match consumer.consumer_status {
+                ConsumerStatus::Creating => {
+                    transitions.push(PendingTransition::RegisterConsumer {
+                        consumer_arn: entry.key().clone(),
+                        ready_at_ms: now,
+                    });
+                }
+                ConsumerStatus::Deleting => {
+                    transitions.push(PendingTransition::DeregisterConsumer {
+                        consumer_arn: entry.key().clone(),
+                        ready_at_ms: now,
+                    });
+                }
+                ConsumerStatus::Active => {}
+            }
+        }
+
+        if let Ok(mut pending) = self.inner.pending_transitions.try_write() {
+            for transition in &transitions {
+                pending
+                    .entry(transition.key())
+                    .or_insert_with(|| transition.clone());
+            }
+        }
+
+        for transition in transitions {
+            self.schedule_transition(transition);
+        }
+
         Ok(())
     }
 
@@ -477,6 +686,14 @@ impl Store {
                 serde_json::to_vec(&account_settings)
                     .map_err(|err| format!("failed to encode snapshot account settings: {err}"))?
             },
+            pending_transitions: self
+                .inner
+                .pending_transitions
+                .read()
+                .await
+                .values()
+                .cloned()
+                .collect(),
             retained_bytes: self.metrics.retained_bytes(),
             retained_records: self.metrics.retained_records(),
         })
@@ -501,30 +718,33 @@ impl Store {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    async fn persist_current_state(&self) {
-        if self.persistence.is_none() {
-            return;
-        }
+    async fn persist_current_state_result(&self) -> Result<(), String> {
         let Some(persistence) = &self.persistence else {
-            return;
+            return Ok(());
         };
         let _guard = persistence.io_lock.lock().await;
         let snapshot = match self.export_snapshot().await {
             Ok(snapshot) => snapshot,
             Err(err) => {
                 self.mark_unhealthy(err.clone());
-                tracing::warn!("{err}");
-                return;
+                return Err(err);
             }
         };
 
         self.persist_snapshot(&snapshot).await;
         if !self.health.durable_ok.load(Ordering::Relaxed) {
-            return;
+            let detail = self
+                .health
+                .last_error
+                .read()
+                .ok()
+                .and_then(|guard| guard.clone())
+                .unwrap_or_else(|| "durable state is not ready".to_string());
+            return Err(detail);
         }
 
         if persistence.snapshot_interval_secs == 0 {
-            return;
+            return Ok(());
         }
 
         let now = snapshot.created_at_ms;
@@ -532,7 +752,7 @@ impl Store {
         if now.saturating_sub(last_snapshot)
             < persistence.snapshot_interval_secs.saturating_mul(1000)
         {
-            return;
+            return Ok(());
         }
 
         let backend = persistence.backend.clone();
@@ -551,6 +771,15 @@ impl Store {
                 self.mark_unhealthy(message.clone());
                 tracing::warn!("{message}");
             }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn persist_current_state(&self) {
+        if let Err(err) = self.persist_current_state_result().await {
+            tracing::warn!("{err}");
         }
     }
 
@@ -612,6 +841,58 @@ impl Store {
             .is_some_and(|limit| self.metrics.retained_bytes() > limit)
     }
 
+    fn retained_limit_error(
+        &self,
+        current_bytes: u64,
+        additional_bytes: u64,
+    ) -> KinesisErrorResponse {
+        self.metrics.increment_rejected_writes();
+        let limit = self.options.max_retained_bytes.unwrap();
+        KinesisErrorResponse::client_error(
+            constants::LIMIT_EXCEEDED,
+            Some(&format!(
+                "Retained bytes limit exceeded: {} + {} > {}.",
+                current_bytes, additional_bytes, limit
+            )),
+        )
+    }
+
+    pub(crate) fn check_writable(&self) -> Result<(), KinesisErrorResponse> {
+        if !self.health.durable_ok.load(Ordering::Relaxed) {
+            let detail = self
+                .health
+                .last_error
+                .read()
+                .ok()
+                .and_then(|guard| guard.clone())
+                .unwrap_or_else(|| "durable state is not ready".to_string());
+            return Err(KinesisErrorResponse::server_error(None, Some(&detail)));
+        }
+        if !self.health.replay_complete.load(Ordering::Relaxed) {
+            return Err(KinesisErrorResponse::server_error(
+                None,
+                Some("durable replay is not complete"),
+            ));
+        }
+        if self.retained_capacity_exceeded() {
+            return Err(self.retained_limit_error(self.metrics.retained_bytes(), 0));
+        }
+        Ok(())
+    }
+
+    async fn apply_transition_mutation(&self, update: TransitionMutation) {
+        let mut transitions = self.inner.pending_transitions.write().await;
+        match update {
+            TransitionMutation::None => {}
+            TransitionMutation::Upsert(transition) => {
+                transitions.insert(transition.key(), transition);
+            }
+            TransitionMutation::Remove(key) => {
+                transitions.remove(&key);
+            }
+        }
+    }
+
     // --- Stream operations ---
 
     /// Retrieves a stream by name.
@@ -631,6 +912,16 @@ impl Store {
 
     /// Inserts or replaces a stream by name.
     pub async fn put_stream(&self, name: &str, stream: Stream) {
+        self.put_stream_with_transition(name, stream, TransitionMutation::None)
+            .await;
+    }
+
+    pub(crate) async fn put_stream_with_transition(
+        &self,
+        name: &str,
+        stream: Stream,
+        transition: TransitionMutation,
+    ) {
         if let Some(existing) = self.inner.streams.get(name) {
             // Update metadata, preserve existing records and seq state.
             let mut guard = existing.stream.write().await;
@@ -643,12 +934,22 @@ impl Store {
             });
             self.inner.streams.insert(name.to_string(), entry);
         }
+        self.apply_transition_mutation(transition).await;
         self.refresh_topology_metrics().await;
         self.persist_current_state().await;
     }
 
     /// Deletes a stream and all of its records.
     pub async fn delete_stream(&self, name: &str) {
+        self.delete_stream_with_transition(name, TransitionMutation::None)
+            .await;
+    }
+
+    pub(crate) async fn delete_stream_with_transition(
+        &self,
+        name: &str,
+        transition: TransitionMutation,
+    ) {
         if let Some(records) = self.inner.stream_records.get(name) {
             let mut bytes = 0u64;
             let mut count = 0u64;
@@ -666,8 +967,7 @@ impl Store {
         self.inner.streams.remove(name);
         self.inner.stream_records.remove(name);
         self.clear_throughput_windows_for_stream(name);
-        self.refresh_topology_metrics().await;
-        self.persist_current_state().await;
+        self.apply_transition_mutation(transition).await;
         self.refresh_topology_metrics().await;
         self.persist_current_state().await;
     }
@@ -710,6 +1010,19 @@ impl Store {
     where
         F: FnOnce(&mut Stream) -> Result<R, KinesisErrorResponse>,
     {
+        self.update_stream_with_transition(name, TransitionMutation::None, f)
+            .await
+    }
+
+    pub(crate) async fn update_stream_with_transition<F, R>(
+        &self,
+        name: &str,
+        transition: TransitionMutation,
+        f: F,
+    ) -> Result<R, KinesisErrorResponse>
+    where
+        F: FnOnce(&mut Stream) -> Result<R, KinesisErrorResponse>,
+    {
         let entry = self
             .inner
             .streams
@@ -721,6 +1034,7 @@ impl Store {
         // Sync shard_seq if the closure added shards (split/merge/reshard).
         sync_shard_seq(&entry, &stream).await;
         drop(stream);
+        self.apply_transition_mutation(transition).await;
         self.refresh_topology_metrics().await;
         self.persist_current_state().await;
         Ok(result)
@@ -777,6 +1091,25 @@ impl Store {
             let message = err.to_string();
             KinesisErrorResponse::server_error(None, Some(&message))
         })?;
+        #[cfg(not(target_arch = "wasm32"))]
+        let needs_write_lock =
+            self.persistence.is_some() || self.options.max_retained_bytes.is_some();
+        #[cfg(target_arch = "wasm32")]
+        let needs_write_lock = self.options.max_retained_bytes.is_some();
+        let _write_guard = if needs_write_lock {
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+
+        self.check_writable()?;
+
+        let current_bytes = self.metrics.retained_bytes();
+        if let Some(limit) = self.options.max_retained_bytes
+            && current_bytes.saturating_add(bytes.len() as u64) > limit
+        {
+            return Err(self.retained_limit_error(current_bytes, bytes.len() as u64));
+        }
         let shard_hex = shard_hex_from_key(key);
         let shard_map = ensure_shard_map(&self.inner.stream_records, stream_name);
         let records_arc = shard_map
@@ -786,11 +1119,24 @@ impl Store {
             .clone();
         drop(shard_map);
         let mut records = records_arc.write().await;
-        if let Some(previous) = records.insert(key.to_string(), bytes.clone()) {
-            self.metrics.remove_retained(previous.len() as u64, 1);
+        let previous = records.insert(key.to_string(), bytes.clone());
+        if let Some(previous_bytes) = previous.as_ref() {
+            self.metrics.remove_retained(previous_bytes.len() as u64, 1);
         }
         self.metrics.add_retained(bytes.len() as u64, 1);
         drop(records);
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            self.rollback_record_change(AppliedRecordChange {
+                records_arc,
+                key: key.to_string(),
+                previous,
+                new_bytes_len: bytes.len() as u64,
+            })
+            .await;
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
         Ok(())
     }
@@ -801,6 +1147,18 @@ impl Store {
         stream_name: &str,
         batch: &[(String, R)],
     ) -> Result<(), KinesisErrorResponse> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let needs_write_lock =
+            self.persistence.is_some() || self.options.max_retained_bytes.is_some();
+        #[cfg(target_arch = "wasm32")]
+        let needs_write_lock = self.options.max_retained_bytes.is_some();
+        let _write_guard = if needs_write_lock {
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+
+        self.check_writable()?;
         // Phase 1: collect Arc refs and serialized bytes while holding the DashMap ref.
         let pending: Result<Vec<_>, KinesisErrorResponse> = {
             let shard_map = ensure_shard_map(&self.inner.stream_records, stream_name);
@@ -823,14 +1181,39 @@ impl Store {
         }; // shard_map Ref dropped here — no DashMap lock held across await.
         let pending = pending?;
 
+        let additional_bytes: u64 = pending.iter().map(|(_, _, bytes)| bytes.len() as u64).sum();
+        let current_bytes = self.metrics.retained_bytes();
+        if let Some(limit) = self.options.max_retained_bytes
+            && current_bytes.saturating_add(additional_bytes) > limit
+        {
+            return Err(self.retained_limit_error(current_bytes, additional_bytes));
+        }
+
         // Phase 2: insert records under per-shard write locks only.
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut applied = Vec::with_capacity(pending.len());
         for (records_arc, key, bytes) in pending {
             let mut records = records_arc.write().await;
-            if let Some(previous) = records.insert(key, bytes.clone()) {
-                self.metrics.remove_retained(previous.len() as u64, 1);
+            let previous = records.insert(key.clone(), bytes.clone());
+            if let Some(previous_bytes) = previous.as_ref() {
+                self.metrics.remove_retained(previous_bytes.len() as u64, 1);
             }
             self.metrics.add_retained(bytes.len() as u64, 1);
+            drop(records);
+            #[cfg(not(target_arch = "wasm32"))]
+            applied.push(AppliedRecordChange {
+                records_arc,
+                key,
+                previous,
+                new_bytes_len: bytes.len() as u64,
+            });
         }
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            self.rollback_record_changes(&applied).await;
+            return Err(KinesisErrorResponse::server_error(None, Some(&err)));
+        }
+        #[cfg(target_arch = "wasm32")]
         self.persist_current_state().await;
         Ok(())
     }
@@ -869,12 +1252,14 @@ impl Store {
 
             if !keys_to_delete.is_empty() {
                 let mut records = records_arc.write().await;
+                let mut removed = 0usize;
                 for key in &keys_to_delete {
                     if let Some(bytes) = records.remove(key) {
                         bytes_deleted += bytes.len() as u64;
+                        removed += 1;
                     }
                 }
-                total_deleted += keys_to_delete.len();
+                total_deleted += removed;
             }
         }
 
@@ -905,16 +1290,17 @@ impl Store {
         }; // DashMap Ref dropped here.
 
         // Phase 2: delete under per-shard write locks only.
-        let pending_len = pending.len() as u64;
+        let mut removed_count = 0u64;
         let mut bytes_deleted = 0u64;
         for (records_arc, key) in pending {
             let mut records = records_arc.write().await;
             if let Some(bytes) = records.remove(&key) {
                 bytes_deleted += bytes.len() as u64;
+                removed_count += 1;
             }
         }
-        if pending_len > 0 {
-            self.metrics.remove_retained(bytes_deleted, pending_len);
+        if removed_count > 0 {
+            self.metrics.remove_retained(bytes_deleted, removed_count);
             self.persist_current_state().await;
         }
     }
@@ -1005,8 +1391,19 @@ impl Store {
 
     /// Inserts or replaces a consumer keyed by its ARN.
     pub async fn put_consumer(&self, consumer_arn: &str, consumer: Consumer) {
+        self.put_consumer_with_transition(consumer_arn, consumer, TransitionMutation::None)
+            .await;
+    }
+
+    pub(crate) async fn put_consumer_with_transition(
+        &self,
+        consumer_arn: &str,
+        consumer: Consumer,
+        transition: TransitionMutation,
+    ) {
         let bytes = serde_json::to_vec(&consumer).unwrap();
         self.inner.consumers.insert(consumer_arn.to_string(), bytes);
+        self.apply_transition_mutation(transition).await;
         self.persist_current_state().await;
     }
 
@@ -1020,7 +1417,17 @@ impl Store {
 
     /// Deletes the consumer with the given ARN.
     pub async fn delete_consumer(&self, consumer_arn: &str) {
+        self.delete_consumer_with_transition(consumer_arn, TransitionMutation::None)
+            .await;
+    }
+
+    pub(crate) async fn delete_consumer_with_transition(
+        &self,
+        consumer_arn: &str,
+        transition: TransitionMutation,
+    ) {
         self.inner.consumers.remove(consumer_arn);
+        self.apply_transition_mutation(transition).await;
         self.persist_current_state().await;
     }
 
@@ -1307,6 +1714,488 @@ impl Store {
         }
 
         Ok(allocations)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn rollback_record_change(&self, change: AppliedRecordChange) {
+        let mut records = change.records_arc.write().await;
+        match change.previous {
+            Some(previous) => {
+                records.insert(change.key, previous.clone());
+                self.metrics.remove_retained(change.new_bytes_len, 1);
+                self.metrics.add_retained(previous.len() as u64, 1);
+            }
+            None => {
+                records.remove(&change.key);
+                self.metrics.remove_retained(change.new_bytes_len, 1);
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn rollback_record_changes(&self, changes: &[AppliedRecordChange]) {
+        for change in changes.iter().rev() {
+            self.rollback_record_change(AppliedRecordChange {
+                records_arc: Arc::clone(&change.records_arc),
+                key: change.key.clone(),
+                previous: change.previous.clone(),
+                new_bytes_len: change.new_bytes_len,
+            })
+            .await;
+        }
+    }
+
+    pub(crate) fn schedule_transition(&self, transition: PendingTransition) {
+        let store = self.clone();
+        crate::runtime::spawn_background(async move {
+            let delay = transition.ready_at_ms().saturating_sub(current_time_ms());
+            if delay > 0 {
+                crate::runtime::sleep_ms(delay).await;
+            }
+            if let Err(err) = store.finish_transition(transition).await {
+                #[cfg(not(target_arch = "wasm32"))]
+                store.mark_unhealthy(err.clone());
+                tracing::warn!("{err}");
+            }
+        });
+    }
+
+    async fn finish_transition(&self, transition: PendingTransition) -> Result<(), String> {
+        let key = transition.key();
+        let has_transition = self
+            .inner
+            .pending_transitions
+            .read()
+            .await
+            .contains_key(&key);
+        if !has_transition {
+            return Ok(());
+        }
+
+        match transition {
+            PendingTransition::CreateStream {
+                stream_name,
+                shards,
+                ..
+            } => self
+                .update_stream_with_transition(
+                    &stream_name,
+                    TransitionMutation::Remove(key),
+                    move |stream| {
+                        if stream.stream_status != StreamStatus::Creating {
+                            return Err(KinesisErrorResponse::server_error(
+                                None,
+                                Some("recovered CreateStream transition found stream in unexpected state"),
+                            ));
+                        }
+                        stream.stream_status = StreamStatus::Active;
+                        stream.shards = shards;
+                        Ok(())
+                    },
+                )
+                .await
+                .map_err(|err| err.to_string()),
+            PendingTransition::DeleteStream { stream_name, .. } => {
+                let stream = self
+                    .get_stream(&stream_name)
+                    .await
+                    .map_err(|err| err.to_string())?;
+                if stream.stream_status != StreamStatus::Deleting {
+                    return Err(format!(
+                        "recovered DeleteStream transition found {} in unexpected state {}",
+                        stream_name, stream.stream_status
+                    ));
+                }
+                self.delete_stream_with_transition(&stream_name, TransitionMutation::Remove(key))
+                    .await;
+                Ok(())
+            }
+            PendingTransition::RegisterConsumer { consumer_arn, .. } => {
+                let mut consumer = self
+                    .get_consumer(&consumer_arn)
+                    .await
+                    .ok_or_else(|| {
+                        format!(
+                            "recovered RegisterStreamConsumer transition missing {consumer_arn}"
+                        )
+                    })?;
+                if consumer.consumer_status != ConsumerStatus::Creating {
+                    return Err(format!(
+                        "recovered RegisterStreamConsumer transition found {} in unexpected state {}",
+                        consumer_arn, consumer.consumer_status
+                    ));
+                }
+                consumer.consumer_status = ConsumerStatus::Active;
+                self.put_consumer_with_transition(
+                    &consumer_arn,
+                    consumer,
+                    TransitionMutation::Remove(key),
+                )
+                .await;
+                Ok(())
+            }
+            PendingTransition::DeregisterConsumer { consumer_arn, .. } => {
+                let consumer = self
+                    .get_consumer(&consumer_arn)
+                    .await
+                    .ok_or_else(|| {
+                        format!(
+                            "recovered DeregisterStreamConsumer transition missing {consumer_arn}"
+                        )
+                    })?;
+                if consumer.consumer_status != ConsumerStatus::Deleting {
+                    return Err(format!(
+                        "recovered DeregisterStreamConsumer transition found {} in unexpected state {}",
+                        consumer_arn, consumer.consumer_status
+                    ));
+                }
+                self.delete_consumer_with_transition(
+                    &consumer_arn,
+                    TransitionMutation::Remove(key),
+                )
+                .await;
+                Ok(())
+            }
+            PendingTransition::UpdateShardCount {
+                stream_name,
+                target_shard_count,
+                ..
+            } => self
+                .update_stream_with_transition(
+                    &stream_name,
+                    TransitionMutation::Remove(key),
+                    move |stream| {
+                        if stream.stream_status != StreamStatus::Updating {
+                            return Err(KinesisErrorResponse::server_error(
+                                None,
+                                Some("recovered UpdateShardCount transition found stream in unexpected state"),
+                            ));
+                        }
+
+                        let now = current_time_ms();
+                        let open_indices: Vec<usize> = stream
+                            .shards
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, s)| s.sequence_number_range.ending_sequence_number.is_none())
+                            .map(|(i, _)| i)
+                            .collect();
+
+                        for &ix in &open_indices {
+                            let create_time = sequence::parse_sequence(
+                                &stream.shards[ix]
+                                    .sequence_number_range
+                                    .starting_sequence_number,
+                            )
+                            .map(|s| s.shard_create_time)
+                            .unwrap_or(0);
+
+                            stream.shards[ix]
+                                .sequence_number_range
+                                .ending_sequence_number =
+                                Some(sequence::stringify_sequence(&sequence::SeqObj {
+                                    shard_create_time: create_time,
+                                    shard_ix: ix as i64,
+                                    seq_ix: Some(sequence::MAX_SEQ_IX),
+                                    seq_time: Some(now),
+                                    byte1: None,
+                                    seq_rand: None,
+                                    version: 2,
+                                }));
+                        }
+
+                        let pow_128 = BigUint::one() << 128;
+                        let shard_hash = &pow_128 / BigUint::from(target_shard_count);
+
+                        for i in 0..target_shard_count {
+                            let new_ix = stream.shards.len() as i64;
+                            let start: BigUint = &shard_hash * BigUint::from(i);
+                            let end: BigUint = if i < target_shard_count - 1 {
+                                &shard_hash * BigUint::from(i + 1) - BigUint::one()
+                            } else {
+                                &pow_128 - BigUint::one()
+                            };
+
+                            stream.shards.push(Shard {
+                                shard_id: sequence::shard_id_name(new_ix),
+                                parent_shard_id: None,
+                                adjacent_parent_shard_id: None,
+                                hash_key_range: HashKeyRange::new(
+                                    start.to_string(),
+                                    end.to_string(),
+                                ),
+                                sequence_number_range: SequenceNumberRange {
+                                    starting_sequence_number: sequence::stringify_sequence(
+                                        &sequence::SeqObj {
+                                            shard_create_time: now + 1000,
+                                            shard_ix: new_ix,
+                                            seq_ix: None,
+                                            seq_time: None,
+                                            byte1: None,
+                                            seq_rand: None,
+                                            version: 2,
+                                        },
+                                    ),
+                                    ending_sequence_number: None,
+                                },
+                            });
+                        }
+
+                        stream.stream_status = StreamStatus::Active;
+                        Ok(())
+                    },
+                )
+                .await
+                .map_err(|err| err.to_string()),
+            PendingTransition::SplitShard {
+                stream_name,
+                shard_to_split,
+                new_starting_hash_key,
+                ..
+            } => self
+                .update_stream_with_transition(
+                    &stream_name,
+                    TransitionMutation::Remove(key),
+                    move |stream| {
+                        if stream.stream_status != StreamStatus::Updating {
+                            return Err(KinesisErrorResponse::server_error(
+                                None,
+                                Some("recovered SplitShard transition found stream in unexpected state"),
+                            ));
+                        }
+
+                        let (shard_id, shard_ix) = sequence::resolve_shard_id(&shard_to_split)
+                            .map_err(|_| {
+                                KinesisErrorResponse::server_error(
+                                    None,
+                                    Some("recovered SplitShard transition has invalid shard id"),
+                                )
+                            })?;
+                        if shard_ix >= stream.shards.len() as i64 {
+                            return Err(KinesisErrorResponse::server_error(
+                                None,
+                                Some("recovered SplitShard transition points to missing shard"),
+                            ));
+                        }
+
+                        let hash_key = new_starting_hash_key.parse::<u128>().map_err(|_| {
+                            KinesisErrorResponse::server_error(
+                                None,
+                                Some("recovered SplitShard transition has invalid hash key"),
+                            )
+                        })?;
+                        let shard_start = stream.shards[shard_ix as usize]
+                            .hash_key_range
+                            .start_u128();
+                        let shard_end = stream.shards[shard_ix as usize]
+                            .hash_key_range
+                            .end_u128();
+
+                        let now = current_time_ms();
+                        stream.stream_status = StreamStatus::Active;
+
+                        let shard = &mut stream.shards[shard_ix as usize];
+                        let create_time = sequence::parse_sequence(
+                            &shard.sequence_number_range.starting_sequence_number,
+                        )
+                        .map(|s| s.shard_create_time)
+                        .unwrap_or(0);
+
+                        shard.sequence_number_range.ending_sequence_number =
+                            Some(sequence::stringify_sequence(&sequence::SeqObj {
+                                shard_create_time: create_time,
+                                shard_ix,
+                                seq_ix: Some(sequence::MAX_SEQ_IX),
+                                seq_time: Some(now),
+                                byte1: None,
+                                seq_rand: None,
+                                version: 2,
+                            }));
+
+                        let new_ix1 = stream.shards.len() as i64;
+                        stream.shards.push(Shard {
+                            parent_shard_id: Some(shard_id.clone()),
+                            adjacent_parent_shard_id: None,
+                            hash_key_range: HashKeyRange::new(
+                                shard_start.to_string(),
+                                (hash_key - 1).to_string(),
+                            ),
+                            sequence_number_range: SequenceNumberRange {
+                                starting_sequence_number: sequence::stringify_sequence(
+                                    &sequence::SeqObj {
+                                        shard_create_time: now + 1000,
+                                        shard_ix: new_ix1,
+                                        seq_ix: None,
+                                        seq_time: None,
+                                        byte1: None,
+                                        seq_rand: None,
+                                        version: 2,
+                                    },
+                                ),
+                                ending_sequence_number: None,
+                            },
+                            shard_id: sequence::shard_id_name(new_ix1),
+                        });
+
+                        let new_ix2 = stream.shards.len() as i64;
+                        stream.shards.push(Shard {
+                            parent_shard_id: Some(shard_id),
+                            adjacent_parent_shard_id: None,
+                            hash_key_range: HashKeyRange::new(
+                                hash_key.to_string(),
+                                shard_end.to_string(),
+                            ),
+                            sequence_number_range: SequenceNumberRange {
+                                starting_sequence_number: sequence::stringify_sequence(
+                                    &sequence::SeqObj {
+                                        shard_create_time: now + 1000,
+                                        shard_ix: new_ix2,
+                                        seq_ix: None,
+                                        seq_time: None,
+                                        byte1: None,
+                                        seq_rand: None,
+                                        version: 2,
+                                    },
+                                ),
+                                ending_sequence_number: None,
+                            },
+                            shard_id: sequence::shard_id_name(new_ix2),
+                        });
+
+                        Ok(())
+                    },
+                )
+                .await
+                .map_err(|err| err.to_string()),
+            PendingTransition::MergeShards {
+                stream_name,
+                shard_to_merge,
+                adjacent_shard_to_merge,
+                ..
+            } => self
+                .update_stream_with_transition(
+                    &stream_name,
+                    TransitionMutation::Remove(key),
+                    move |stream| {
+                        if stream.stream_status != StreamStatus::Updating {
+                            return Err(KinesisErrorResponse::server_error(
+                                None,
+                                Some("recovered MergeShards transition found stream in unexpected state"),
+                            ));
+                        }
+
+                        let (shard_id0, shard_ix0) =
+                            sequence::resolve_shard_id(&shard_to_merge).map_err(|_| {
+                                KinesisErrorResponse::server_error(
+                                    None,
+                                    Some("recovered MergeShards transition has invalid shard id"),
+                                )
+                            })?;
+                        let (shard_id1, shard_ix1) =
+                            sequence::resolve_shard_id(&adjacent_shard_to_merge).map_err(|_| {
+                                KinesisErrorResponse::server_error(
+                                    None,
+                                    Some("recovered MergeShards transition has invalid adjacent shard id"),
+                                )
+                            })?;
+
+                        let now = current_time_ms();
+                        stream.stream_status = StreamStatus::Active;
+
+                        for &ix in &[shard_ix0, shard_ix1] {
+                            let shard = &mut stream.shards[ix as usize];
+                            let create_time = sequence::parse_sequence(
+                                &shard.sequence_number_range.starting_sequence_number,
+                            )
+                            .map(|s| s.shard_create_time)
+                            .unwrap_or(0);
+
+                            shard.sequence_number_range.ending_sequence_number =
+                                Some(sequence::stringify_sequence(&sequence::SeqObj {
+                                    shard_create_time: create_time,
+                                    shard_ix: ix,
+                                    seq_ix: Some(sequence::MAX_SEQ_IX),
+                                    seq_time: Some(now),
+                                    byte1: None,
+                                    seq_rand: None,
+                                    version: 2,
+                                }));
+                        }
+
+                        let new_ix = stream.shards.len() as i64;
+                        let starting_hash = stream.shards[shard_ix0 as usize]
+                            .hash_key_range
+                            .starting_hash_key
+                            .clone();
+                        let ending_hash = stream.shards[shard_ix1 as usize]
+                            .hash_key_range
+                            .ending_hash_key
+                            .clone();
+
+                        stream.shards.push(Shard {
+                            parent_shard_id: Some(shard_id0),
+                            adjacent_parent_shard_id: Some(shard_id1),
+                            hash_key_range: HashKeyRange::new(starting_hash, ending_hash),
+                            sequence_number_range: SequenceNumberRange {
+                                starting_sequence_number: sequence::stringify_sequence(
+                                    &sequence::SeqObj {
+                                        shard_create_time: now + 1000,
+                                        shard_ix: new_ix,
+                                        seq_ix: None,
+                                        seq_time: None,
+                                        byte1: None,
+                                        seq_rand: None,
+                                        version: 2,
+                                    },
+                                ),
+                                ending_sequence_number: None,
+                            },
+                            shard_id: sequence::shard_id_name(new_ix),
+                        });
+
+                        Ok(())
+                    },
+                )
+                .await
+                .map_err(|err| err.to_string()),
+            PendingTransition::StartStreamEncryption { stream_name, .. } => self
+                .update_stream_with_transition(
+                    &stream_name,
+                    TransitionMutation::Remove(key),
+                    |stream| {
+                        if stream.stream_status != StreamStatus::Updating {
+                            return Err(KinesisErrorResponse::server_error(
+                                None,
+                                Some("recovered StartStreamEncryption transition found stream in unexpected state"),
+                            ));
+                        }
+                        stream.stream_status = StreamStatus::Active;
+                        stream.encryption_type = EncryptionType::Kms;
+                        Ok(())
+                    },
+                )
+                .await
+                .map_err(|err| err.to_string()),
+            PendingTransition::StopStreamEncryption { stream_name, .. } => self
+                .update_stream_with_transition(
+                    &stream_name,
+                    TransitionMutation::Remove(key),
+                    |stream| {
+                        if stream.stream_status != StreamStatus::Updating {
+                            return Err(KinesisErrorResponse::server_error(
+                                None,
+                                Some("recovered StopStreamEncryption transition found stream in unexpected state"),
+                            ));
+                        }
+                        stream.stream_status = StreamStatus::Active;
+                        stream.encryption_type = EncryptionType::None;
+                        stream.key_id = None;
+                        Ok(())
+                    },
+                )
+                .await
+                .map_err(|err| err.to_string()),
+        }
     }
 
     /// Returns the current per-shard sequence counter (the next seq_ix that would

--- a/src/store.rs
+++ b/src/store.rs
@@ -42,6 +42,10 @@ use tokio::sync::{Mutex, RwLock};
 
 const DEFAULT_SHARD_WRITE_BYTES_PER_SEC: u64 = 1024 * 1024;
 const DEFAULT_SHARD_WRITE_RECORDS_PER_SEC: u64 = 1000;
+/// Default snapshot interval, in seconds, for durable mode.
+pub const DEFAULT_DURABLE_SNAPSHOT_INTERVAL_SECS: u64 = 30;
+/// Upper bound for externally configured durable snapshot intervals.
+pub const MAX_DURABLE_SNAPSHOT_INTERVAL_SECS: u64 = 86_400;
 
 /// Errors that can occur when probing store health.
 #[derive(Debug, thiserror::Error)]
@@ -52,6 +56,37 @@ pub enum StoreHealthError {
     /// A required table could not be opened within the read transaction.
     #[error("table open failed: {0}")]
     TableOpenFailed(String),
+}
+
+/// Errors that can occur when validating externally supplied durable settings.
+#[derive(Debug, thiserror::Error)]
+pub enum DurableSettingsValidationError {
+    /// Snapshot intervals must stay within the supported range.
+    #[error(
+        "snapshot_interval_secs must be between 0 and {MAX_DURABLE_SNAPSHOT_INTERVAL_SECS}, got {0}"
+    )]
+    SnapshotIntervalSecsOutOfRange(u64),
+    /// Zero would make the retained-cap parser silently disable the limit.
+    #[error("max_retained_bytes must be greater than 0")]
+    MaxRetainedBytesMustBePositive,
+}
+
+/// Validate snapshot and retained-byte settings loaded from config/env sources.
+pub fn validate_durable_settings(
+    snapshot_interval_secs: Option<u64>,
+    max_retained_bytes: Option<u64>,
+) -> Result<(), DurableSettingsValidationError> {
+    if let Some(snapshot_interval_secs) = snapshot_interval_secs
+        && snapshot_interval_secs > MAX_DURABLE_SNAPSHOT_INTERVAL_SECS
+    {
+        return Err(
+            DurableSettingsValidationError::SnapshotIntervalSecsOutOfRange(snapshot_interval_secs),
+        );
+    }
+    if max_retained_bytes == Some(0) {
+        return Err(DurableSettingsValidationError::MaxRetainedBytesMustBePositive);
+    }
+    Ok(())
 }
 
 #[derive(Default)]
@@ -164,14 +199,32 @@ pub(crate) enum TransitionMutation {
 /// # Examples
 ///
 /// ```rust
-/// use ferrokinesis::store::StoreOptions;
+/// use ferrokinesis::store::{DurableStateOptions, StoreOptions};
+/// use std::path::PathBuf;
 ///
 /// let opts = StoreOptions {
 ///     shard_limit: 50,
 ///     aws_region: "eu-west-1".to_string(),
+///     durable: Some(DurableStateOptions {
+///         state_dir: PathBuf::from("/tmp/ferrokinesis-state"),
+///         snapshot_interval_secs: 10,
+///         max_retained_bytes: Some(1024),
+///     }),
 ///     ..StoreOptions::default()
 /// };
 /// ```
+/// Configuration for on-disk durable state.
+#[derive(Debug, Clone)]
+pub struct DurableStateOptions {
+    /// Directory used to persist state with WAL + snapshots.
+    pub state_dir: PathBuf,
+    /// Snapshot interval in seconds when durable mode is enabled.
+    pub snapshot_interval_secs: u64,
+    /// Optional retained-bytes cap to apply alongside durable mode.
+    pub max_retained_bytes: Option<u64>,
+}
+
+/// Runtime configuration passed to [`crate::create_app`].
 #[derive(Debug, Clone)]
 pub struct StoreOptions {
     /// Simulated delay for `CreateStream` in milliseconds. Defaults to `500`.
@@ -189,10 +242,8 @@ pub struct StoreOptions {
     pub retention_check_interval_secs: u64,
     /// Enable AWS-like shard write throughput throttling. Disabled by default.
     pub enforce_limits: bool,
-    /// Directory used to persist state with WAL + snapshots.
-    pub state_dir: Option<PathBuf>,
-    /// Snapshot interval in seconds when durable mode is enabled.
-    pub snapshot_interval_secs: u64,
+    /// Durable persistence settings. When omitted, the store remains in-memory only.
+    pub durable: Option<DurableStateOptions>,
     /// Hard cap on retained serialized record bytes.
     pub max_retained_bytes: Option<u64>,
     /// Simulated AWS account ID (12 digits). Defaults to `"000000000000"`.
@@ -211,12 +262,20 @@ impl Default for StoreOptions {
             iterator_ttl_seconds: 300,
             retention_check_interval_secs: 0,
             enforce_limits: false,
-            state_dir: None,
-            snapshot_interval_secs: 30,
+            durable: None,
             max_retained_bytes: None,
             aws_account_id: "000000000000".to_string(),
             aws_region: "us-east-1".to_string(),
         }
+    }
+}
+
+impl StoreOptions {
+    fn effective_max_retained_bytes(&self) -> Option<u64> {
+        self.max_retained_bytes.or(self
+            .durable
+            .as_ref()
+            .and_then(|durable| durable.max_retained_bytes))
     }
 }
 
@@ -270,6 +329,10 @@ impl ThroughputReservation {
 
 /// Per-shard record map: shard_hex → sorted records.
 type ShardRecords = DashMap<String, Arc<RwLock<BTreeMap<String, Vec<u8>>>>>;
+#[cfg(not(target_arch = "wasm32"))]
+type RestoredShardRecords = Vec<(String, BTreeMap<String, Vec<u8>>)>;
+#[cfg(not(target_arch = "wasm32"))]
+type RestoredStreamRecords = Vec<(String, RestoredShardRecords)>;
 
 struct ShardThroughputWindow {
     window_start_ms: u64,
@@ -295,7 +358,7 @@ struct AppliedDeleteChange {
 #[cfg(not(target_arch = "wasm32"))]
 struct RestoredState {
     streams: Vec<(String, Stream, Vec<u64>)>,
-    records: Vec<(String, Vec<(String, BTreeMap<String, Vec<u8>>)>)>,
+    records: RestoredStreamRecords,
     consumers: Vec<(String, Vec<u8>)>,
     policies: Vec<(String, String)>,
     resource_tags: Vec<(String, BTreeMap<String, String>)>,
@@ -500,13 +563,13 @@ impl Store {
         let mut store = store;
 
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(state_dir) = store.options.state_dir.clone() {
-            match Persistence::new(state_dir) {
+        if let Some(durable) = store.options.durable.clone() {
+            match Persistence::new(durable.state_dir) {
                 Ok(backend) => {
                     let persistence = Arc::new(PersistenceState {
                         backend,
                         io_lock: Mutex::new(()),
-                        snapshot_interval_secs: store.options.snapshot_interval_secs,
+                        snapshot_interval_secs: durable.snapshot_interval_secs,
                         last_snapshot_ms: AtomicU64::new(0),
                     });
                     store.persistence = Some(Arc::clone(&persistence));
@@ -912,7 +975,7 @@ impl Store {
 
     fn retained_capacity_exceeded(&self) -> bool {
         self.options
-            .max_retained_bytes
+            .effective_max_retained_bytes()
             .is_some_and(|limit| self.metrics.retained_bytes() > limit)
     }
 
@@ -922,7 +985,7 @@ impl Store {
         additional_bytes: u64,
     ) -> KinesisErrorResponse {
         self.metrics.increment_rejected_writes();
-        let limit = self.options.max_retained_bytes.unwrap();
+        let limit = self.options.effective_max_retained_bytes().unwrap();
         KinesisErrorResponse::client_error(
             constants::LIMIT_EXCEEDED,
             Some(&format!(
@@ -933,7 +996,7 @@ impl Store {
     }
 
     fn durable_state_requested(&self) -> bool {
-        self.options.state_dir.is_some()
+        self.options.durable.is_some()
     }
 
     fn durable_state_error_detail(&self) -> String {
@@ -1654,9 +1717,9 @@ impl Store {
         })?;
         #[cfg(not(target_arch = "wasm32"))]
         let needs_write_lock =
-            self.persistence.is_some() || self.options.max_retained_bytes.is_some();
+            self.persistence.is_some() || self.options.effective_max_retained_bytes().is_some();
         #[cfg(target_arch = "wasm32")]
-        let needs_write_lock = self.options.max_retained_bytes.is_some();
+        let needs_write_lock = self.options.effective_max_retained_bytes().is_some();
         let _write_guard = if needs_write_lock {
             Some(self.inner.write_lock.lock().await)
         } else {
@@ -1666,7 +1729,7 @@ impl Store {
         self.check_writable()?;
 
         let current_bytes = self.metrics.retained_bytes();
-        if let Some(limit) = self.options.max_retained_bytes
+        if let Some(limit) = self.options.effective_max_retained_bytes()
             && current_bytes.saturating_add(bytes.len() as u64) > limit
         {
             return Err(self.retained_limit_error(current_bytes, bytes.len() as u64));
@@ -1710,9 +1773,9 @@ impl Store {
     ) -> Result<(), KinesisErrorResponse> {
         #[cfg(not(target_arch = "wasm32"))]
         let needs_write_lock =
-            self.persistence.is_some() || self.options.max_retained_bytes.is_some();
+            self.persistence.is_some() || self.options.effective_max_retained_bytes().is_some();
         #[cfg(target_arch = "wasm32")]
-        let needs_write_lock = self.options.max_retained_bytes.is_some();
+        let needs_write_lock = self.options.effective_max_retained_bytes().is_some();
         let _write_guard = if needs_write_lock {
             Some(self.inner.write_lock.lock().await)
         } else {
@@ -1744,7 +1807,7 @@ impl Store {
 
         let additional_bytes: u64 = pending.iter().map(|(_, _, bytes)| bytes.len() as u64).sum();
         let current_bytes = self.metrics.retained_bytes();
-        if let Some(limit) = self.options.max_retained_bytes
+        if let Some(limit) = self.options.effective_max_retained_bytes()
             && current_bytes.saturating_add(additional_bytes) > limit
         {
             return Err(self.retained_limit_error(current_bytes, additional_bytes));

--- a/src/store.rs
+++ b/src/store.rs
@@ -727,10 +727,16 @@ impl Store {
 
     #[cfg(not(target_arch = "wasm32"))]
     async fn persist_current_state_result(&self) -> Result<(), String> {
+        if let Some(detail) = self.persistent_mutation_block_reason() {
+            return Err(detail);
+        }
         let Some(persistence) = &self.persistence else {
             return Ok(());
         };
         let _guard = persistence.io_lock.lock().await;
+        if let Some(detail) = self.persistent_mutation_block_reason() {
+            return Err(detail);
+        }
         let snapshot = match self.export_snapshot().await {
             Ok(snapshot) => snapshot,
             Err(err) => {
@@ -741,13 +747,7 @@ impl Store {
 
         self.persist_snapshot(&snapshot).await;
         if !self.health.durable_ok.load(Ordering::Relaxed) {
-            let detail = self
-                .health
-                .last_error
-                .read()
-                .ok()
-                .and_then(|guard| guard.clone())
-                .unwrap_or_else(|| "durable state is not ready".to_string());
+            let detail = self.durable_state_error_detail();
             return Err(detail);
         }
 
@@ -858,15 +858,22 @@ impl Store {
         )
     }
 
+    fn durable_state_requested(&self) -> bool {
+        self.options.state_dir.is_some()
+    }
+
+    fn durable_state_error_detail(&self) -> String {
+        self.health
+            .last_error
+            .read()
+            .ok()
+            .and_then(|guard| guard.clone())
+            .unwrap_or_else(|| "durable state is not ready".to_string())
+    }
+
     pub(crate) fn check_writable(&self) -> Result<(), KinesisErrorResponse> {
         if !self.health.durable_ok.load(Ordering::Relaxed) {
-            let detail = self
-                .health
-                .last_error
-                .read()
-                .ok()
-                .and_then(|guard| guard.clone())
-                .unwrap_or_else(|| "durable state is not ready".to_string());
+            let detail = self.durable_state_error_detail();
             return Err(KinesisErrorResponse::server_error(None, Some(&detail)));
         }
         if !self.health.replay_complete.load(Ordering::Relaxed) {
@@ -882,25 +889,26 @@ impl Store {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn check_persistent_mutation_allowed(&self) -> Result<(), KinesisErrorResponse> {
-        if self.persistence.is_none() {
-            return Ok(());
+    fn persistent_mutation_block_reason(&self) -> Option<String> {
+        if !self.durable_state_requested() {
+            return None;
         }
         if !self.health.durable_ok.load(Ordering::Relaxed) {
-            let detail = self
-                .health
-                .last_error
-                .read()
-                .ok()
-                .and_then(|guard| guard.clone())
-                .unwrap_or_else(|| "durable state is not ready".to_string());
-            return Err(KinesisErrorResponse::server_error(None, Some(&detail)));
+            return Some(self.durable_state_error_detail());
         }
         if !self.health.replay_complete.load(Ordering::Relaxed) {
-            return Err(KinesisErrorResponse::server_error(
-                None,
-                Some("durable replay is not complete"),
-            ));
+            return Some("durable replay is not complete".to_string());
+        }
+        if self.persistence.is_none() {
+            return Some("durable state backend is unavailable".to_string());
+        }
+        None
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn check_persistent_mutation_allowed(&self) -> Result<(), KinesisErrorResponse> {
+        if let Some(detail) = self.persistent_mutation_block_reason() {
+            return Err(KinesisErrorResponse::server_error(None, Some(&detail)));
         }
         Ok(())
     }
@@ -966,12 +974,12 @@ impl Store {
         transition: &TransitionMutation,
         skip_write_lock: bool,
     ) -> Result<Option<tokio::sync::MutexGuard<'a, ()>>, KinesisErrorResponse> {
-        if self.persistence.is_some() {
+        if self.durable_state_requested() {
             self.check_persistent_mutation_allowed()?;
         }
 
         let needs_lock = !skip_write_lock
-            && (self.persistence.is_some() || Self::transition_requires_write_lock(transition));
+            && (self.durable_state_requested() || Self::transition_requires_write_lock(transition));
         if needs_lock {
             Ok(Some(self.inner.write_lock.lock().await))
         } else {
@@ -1696,7 +1704,12 @@ impl Store {
     /// the retention cutoff. Returns the number of records removed.
     pub async fn delete_expired_records(&self, stream_name: &str, retention_hours: u32) -> usize {
         #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
+        if self.durable_state_requested() && self.check_persistent_mutation_allowed().is_err() {
+            return 0;
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.durable_state_requested() {
             Some(self.inner.write_lock.lock().await)
         } else {
             None
@@ -1776,7 +1789,12 @@ impl Store {
     /// Deletes records by their shard keys within a stream.
     pub async fn delete_record_keys(&self, stream_name: &str, keys: &[String]) {
         #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
+        if self.durable_state_requested() && self.check_persistent_mutation_allowed().is_err() {
+            return;
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.durable_state_requested() {
             Some(self.inner.write_lock.lock().await)
         } else {
             None
@@ -1835,7 +1853,6 @@ impl Store {
             if let Err(err) = self.persist_current_state_result().await {
                 self.rollback_delete_changes(&applied).await;
                 tracing::warn!("{err}");
-                return;
             }
             #[cfg(target_arch = "wasm32")]
             self.persist_current_state().await;
@@ -2069,7 +2086,7 @@ impl Store {
         policy: &str,
     ) -> Result<(), KinesisErrorResponse> {
         #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
+        let _write_guard = if self.durable_state_requested() {
             self.check_persistent_mutation_allowed()?;
             Some(self.inner.write_lock.lock().await)
         } else {
@@ -2109,7 +2126,7 @@ impl Store {
     /// Deletes the resource policy for the given ARN.
     pub async fn delete_policy(&self, resource_arn: &str) -> Result<(), KinesisErrorResponse> {
         #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
+        let _write_guard = if self.durable_state_requested() {
             self.check_persistent_mutation_allowed()?;
             Some(self.inner.write_lock.lock().await)
         } else {
@@ -2203,7 +2220,7 @@ impl Store {
         tags: &BTreeMap<String, String>,
     ) -> Result<(), KinesisErrorResponse> {
         #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
+        let _write_guard = if self.durable_state_requested() {
             self.check_persistent_mutation_allowed()?;
             Some(self.inner.write_lock.lock().await)
         } else {
@@ -2242,7 +2259,7 @@ impl Store {
     /// Stores the account-level settings object.
     pub async fn put_account_settings(&self, settings: &Value) -> Result<(), KinesisErrorResponse> {
         #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
+        let _write_guard = if self.durable_state_requested() {
             self.check_persistent_mutation_allowed()?;
             Some(self.inner.write_lock.lock().await)
         } else {

--- a/src/store.rs
+++ b/src/store.rs
@@ -70,7 +70,7 @@ struct PersistenceState {
 }
 
 /// Internal durable-transition ledger for async state changes.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum PendingTransition {
     CreateStream {
         stream_name: String,
@@ -265,6 +265,13 @@ struct AppliedRecordChange {
     key: String,
     previous: Option<Vec<u8>>,
     new_bytes_len: u64,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct AppliedDeleteChange {
+    records_arc: Arc<RwLock<BTreeMap<String, Vec<u8>>>>,
+    key: String,
+    deleted_bytes: Vec<u8>,
 }
 
 /// Shared inner state behind an [`Arc`] for cheap [`Store`] clones.
@@ -777,13 +784,6 @@ impl Store {
         Ok(())
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    async fn persist_current_state(&self) {
-        if let Err(err) = self.persist_current_state_result().await {
-            tracing::warn!("{err}");
-        }
-    }
-
     #[cfg(target_arch = "wasm32")]
     async fn persist_current_state(&self) {}
 
@@ -956,6 +956,43 @@ impl Store {
         }
     }
 
+    fn transition_requires_write_lock(transition: &TransitionMutation) -> bool {
+        !matches!(transition, TransitionMutation::None)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn lock_transition_mutation<'a>(
+        &'a self,
+        transition: &TransitionMutation,
+        skip_write_lock: bool,
+    ) -> Result<Option<tokio::sync::MutexGuard<'a, ()>>, KinesisErrorResponse> {
+        if self.persistence.is_some() {
+            self.check_persistent_mutation_allowed()?;
+        }
+
+        let needs_lock = !skip_write_lock
+            && (self.persistence.is_some() || Self::transition_requires_write_lock(transition));
+        if needs_lock {
+            Ok(Some(self.inner.write_lock.lock().await))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    async fn lock_transition_mutation<'a>(
+        &'a self,
+        transition: &TransitionMutation,
+        skip_write_lock: bool,
+    ) -> Result<Option<tokio::sync::MutexGuard<'a, ()>>, KinesisErrorResponse> {
+        let needs_lock = !skip_write_lock && Self::transition_requires_write_lock(transition);
+        if needs_lock {
+            Ok(Some(self.inner.write_lock.lock().await))
+        } else {
+            Ok(None)
+        }
+    }
+
     async fn apply_transition_mutation(&self, update: TransitionMutation) {
         let mut transitions = self.inner.pending_transitions.write().await;
         match update {
@@ -1009,16 +1046,9 @@ impl Store {
         transition: TransitionMutation,
         skip_write_lock: bool,
     ) -> Result<(), KinesisErrorResponse> {
-        #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() && !skip_write_lock {
-            self.check_persistent_mutation_allowed()?;
-            Some(self.inner.write_lock.lock().await)
-        } else {
-            if self.persistence.is_some() {
-                self.check_persistent_mutation_allowed()?;
-            }
-            None
-        };
+        let _write_guard = self
+            .lock_transition_mutation(&transition, skip_write_lock)
+            .await?;
 
         #[cfg(not(target_arch = "wasm32"))]
         let transition_snapshot = self.capture_transition_state(&transition).await;
@@ -1306,14 +1336,19 @@ impl Store {
         name: &str,
         transition: TransitionMutation,
     ) -> Result<(), KinesisErrorResponse> {
-        #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
-            self.check_persistent_mutation_allowed()?;
-            Some(self.inner.write_lock.lock().await)
-        } else {
-            None
-        };
+        self.delete_stream_with_transition_internal(name, transition, false)
+            .await
+    }
 
+    async fn delete_stream_with_transition_internal(
+        &self,
+        name: &str,
+        transition: TransitionMutation,
+        skip_write_lock: bool,
+    ) -> Result<(), KinesisErrorResponse> {
+        let _write_guard = self
+            .lock_transition_mutation(&transition, skip_write_lock)
+            .await?;
         #[cfg(not(target_arch = "wasm32"))]
         let transition_snapshot = self.capture_transition_state(&transition).await;
         let removed_stream = self.inner.streams.remove(name).map(|(_, entry)| entry);
@@ -1427,16 +1462,9 @@ impl Store {
     where
         F: FnOnce(&mut Stream) -> Result<R, KinesisErrorResponse>,
     {
-        #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() && !skip_write_lock {
-            self.check_persistent_mutation_allowed()?;
-            Some(self.inner.write_lock.lock().await)
-        } else {
-            if self.persistence.is_some() {
-                self.check_persistent_mutation_allowed()?;
-            }
-            None
-        };
+        let _write_guard = self
+            .lock_transition_mutation(&transition, skip_write_lock)
+            .await?;
 
         let entry = self
             .inner
@@ -1684,8 +1712,7 @@ impl Store {
         }; // DashMap Ref dropped here.
 
         // Phase 2: scan and delete under per-shard locks only.
-        let mut total_deleted = 0;
-        let mut bytes_deleted = 0u64;
+        let mut applied = Vec::new();
         for records_arc in shard_arcs {
             let keys_to_delete: Vec<String> = {
                 let records = records_arc.read().await;
@@ -1705,23 +1732,45 @@ impl Store {
 
             if !keys_to_delete.is_empty() {
                 let mut records = records_arc.write().await;
-                let mut removed = 0usize;
                 for key in &keys_to_delete {
                     if let Some(bytes) = records.remove(key) {
-                        bytes_deleted += bytes.len() as u64;
-                        removed += 1;
+                        #[cfg(not(target_arch = "wasm32"))]
+                        applied.push(AppliedDeleteChange {
+                            records_arc: Arc::clone(&records_arc),
+                            key: key.clone(),
+                            deleted_bytes: bytes,
+                        });
+                        #[cfg(target_arch = "wasm32")]
+                        applied.push((bytes.len() as u64, 1usize));
                     }
                 }
-                total_deleted += removed;
             }
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
+        let (bytes_deleted, total_deleted) = applied.iter().fold((0u64, 0u64), |acc, change| {
+            (
+                acc.0 + change.deleted_bytes.len() as u64,
+                acc.1.saturating_add(1),
+            )
+        });
+        #[cfg(target_arch = "wasm32")]
+        let (bytes_deleted, total_deleted) = applied.iter().fold((0u64, 0u64), |acc, change| {
+            (acc.0 + change.0, acc.1.saturating_add(change.1 as u64))
+        });
+
         if total_deleted > 0 {
-            self.metrics
-                .remove_retained(bytes_deleted, total_deleted as u64);
+            self.metrics.remove_retained(bytes_deleted, total_deleted);
+            #[cfg(not(target_arch = "wasm32"))]
+            if let Err(err) = self.persist_current_state_result().await {
+                self.rollback_delete_changes(&applied).await;
+                tracing::warn!("{err}");
+                return 0;
+            }
+            #[cfg(target_arch = "wasm32")]
             self.persist_current_state().await;
         }
-        total_deleted
+        total_deleted as usize
     }
 
     /// Deletes records by their shard keys within a stream.
@@ -1750,17 +1799,45 @@ impl Store {
         }; // DashMap Ref dropped here.
 
         // Phase 2: delete under per-shard write locks only.
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut applied = Vec::new();
+        #[cfg(target_arch = "wasm32")]
         let mut removed_count = 0u64;
+        #[cfg(target_arch = "wasm32")]
         let mut bytes_deleted = 0u64;
         for (records_arc, key) in pending {
             let mut records = records_arc.write().await;
             if let Some(bytes) = records.remove(&key) {
-                bytes_deleted += bytes.len() as u64;
-                removed_count += 1;
+                #[cfg(not(target_arch = "wasm32"))]
+                applied.push(AppliedDeleteChange {
+                    records_arc: Arc::clone(&records_arc),
+                    key,
+                    deleted_bytes: bytes,
+                });
+                #[cfg(target_arch = "wasm32")]
+                {
+                    bytes_deleted += bytes.len() as u64;
+                    removed_count += 1;
+                }
             }
         }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let (bytes_deleted, removed_count) = applied.iter().fold((0u64, 0u64), |acc, change| {
+            (
+                acc.0 + change.deleted_bytes.len() as u64,
+                acc.1.saturating_add(1),
+            )
+        });
         if removed_count > 0 {
             self.metrics.remove_retained(bytes_deleted, removed_count);
+            #[cfg(not(target_arch = "wasm32"))]
+            if let Err(err) = self.persist_current_state_result().await {
+                self.rollback_delete_changes(&applied).await;
+                tracing::warn!("{err}");
+                return;
+            }
+            #[cfg(target_arch = "wasm32")]
             self.persist_current_state().await;
         }
     }
@@ -1865,13 +1942,20 @@ impl Store {
         consumer: Consumer,
         transition: TransitionMutation,
     ) -> Result<(), KinesisErrorResponse> {
-        #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
-            self.check_persistent_mutation_allowed()?;
-            Some(self.inner.write_lock.lock().await)
-        } else {
-            None
-        };
+        self.put_consumer_with_transition_internal(consumer_arn, consumer, transition, false)
+            .await
+    }
+
+    async fn put_consumer_with_transition_internal(
+        &self,
+        consumer_arn: &str,
+        consumer: Consumer,
+        transition: TransitionMutation,
+        skip_write_lock: bool,
+    ) -> Result<(), KinesisErrorResponse> {
+        let _write_guard = self
+            .lock_transition_mutation(&transition, skip_write_lock)
+            .await?;
         let bytes = serde_json::to_vec(&consumer).unwrap();
         let previous = self.inner.consumers.insert(consumer_arn.to_string(), bytes);
         #[cfg(not(target_arch = "wasm32"))]
@@ -1916,13 +2000,19 @@ impl Store {
         consumer_arn: &str,
         transition: TransitionMutation,
     ) -> Result<(), KinesisErrorResponse> {
-        #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
-            self.check_persistent_mutation_allowed()?;
-            Some(self.inner.write_lock.lock().await)
-        } else {
-            None
-        };
+        self.delete_consumer_with_transition_internal(consumer_arn, transition, false)
+            .await
+    }
+
+    async fn delete_consumer_with_transition_internal(
+        &self,
+        consumer_arn: &str,
+        transition: TransitionMutation,
+        skip_write_lock: bool,
+    ) -> Result<(), KinesisErrorResponse> {
+        let _write_guard = self
+            .lock_transition_mutation(&transition, skip_write_lock)
+            .await?;
         let previous = self
             .inner
             .consumers
@@ -2363,6 +2453,16 @@ impl Store {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn rollback_delete_changes(&self, changes: &[AppliedDeleteChange]) {
+        for change in changes.iter().rev() {
+            let mut records = change.records_arc.write().await;
+            records.insert(change.key.clone(), change.deleted_bytes.clone());
+            self.metrics
+                .add_retained(change.deleted_bytes.len() as u64, 1);
+        }
+    }
+
     pub(crate) fn schedule_transition(&self, transition: PendingTransition) {
         let store = self.clone();
         crate::runtime::spawn_background(async move {
@@ -2380,13 +2480,15 @@ impl Store {
 
     async fn finish_transition(&self, transition: PendingTransition) -> Result<(), String> {
         let key = transition.key();
-        let has_transition = self
+        let _write_guard = self.inner.write_lock.lock().await;
+        let current_transition = self
             .inner
             .pending_transitions
             .read()
             .await
-            .contains_key(&key);
-        if !has_transition {
+            .get(&key)
+            .cloned();
+        if current_transition.as_ref() != Some(&transition) {
             return Ok(());
         }
 
@@ -2396,9 +2498,10 @@ impl Store {
                 shards,
                 ..
             } => self
-                .update_stream_with_transition(
+                .update_stream_with_transition_internal(
                     &stream_name,
                     TransitionMutation::Remove(key),
+                    true,
                     move |stream| {
                         if stream.stream_status != StreamStatus::Creating {
                             return Err(KinesisErrorResponse::server_error(
@@ -2424,9 +2527,13 @@ impl Store {
                         stream_name, stream.stream_status
                     ));
                 }
-                self.delete_stream_with_transition(&stream_name, TransitionMutation::Remove(key))
-                    .await
-                    .map_err(|err| err.to_string())?;
+                self.delete_stream_with_transition_internal(
+                    &stream_name,
+                    TransitionMutation::Remove(key),
+                    true,
+                )
+                .await
+                .map_err(|err| err.to_string())?;
                 Ok(())
             }
             PendingTransition::RegisterConsumer { consumer_arn, .. } => {
@@ -2445,10 +2552,11 @@ impl Store {
                     ));
                 }
                 consumer.consumer_status = ConsumerStatus::Active;
-                self.put_consumer_with_transition(
+                self.put_consumer_with_transition_internal(
                     &consumer_arn,
                     consumer,
                     TransitionMutation::Remove(key),
+                    true,
                 )
                 .await
                 .map_err(|err| err.to_string())?;
@@ -2469,9 +2577,10 @@ impl Store {
                         consumer_arn, consumer.consumer_status
                     ));
                 }
-                self.delete_consumer_with_transition(
+                self.delete_consumer_with_transition_internal(
                     &consumer_arn,
                     TransitionMutation::Remove(key),
+                    true,
                 )
                 .await
                 .map_err(|err| err.to_string())?;
@@ -2483,9 +2592,10 @@ impl Store {
                 ..
             } => {
                 let closed_shard_ids = self
-                    .update_stream_with_transition(
+                    .update_stream_with_transition_internal(
                         &stream_name,
                         TransitionMutation::Remove(key),
+                        true,
                         move |stream| {
                             if stream.stream_status != StreamStatus::Updating {
                                 return Err(KinesisErrorResponse::server_error(
@@ -2581,9 +2691,10 @@ impl Store {
                 ..
             } => {
                 let cleared_shard_id = self
-                    .update_stream_with_transition(
+                    .update_stream_with_transition_internal(
                         &stream_name,
                         TransitionMutation::Remove(key),
+                        true,
                         move |stream| {
                             if stream.stream_status != StreamStatus::Updating {
                                 return Err(KinesisErrorResponse::server_error(
@@ -2705,9 +2816,10 @@ impl Store {
                 ..
             } => {
                 let cleared_shard_ids = self
-                    .update_stream_with_transition(
+                    .update_stream_with_transition_internal(
                         &stream_name,
                         TransitionMutation::Remove(key),
+                        true,
                         move |stream| {
                             if stream.stream_status != StreamStatus::Updating {
                                 return Err(KinesisErrorResponse::server_error(
@@ -2794,9 +2906,10 @@ impl Store {
                 Ok(())
             }
             PendingTransition::StartStreamEncryption { stream_name, .. } => self
-                .update_stream_with_transition(
+                .update_stream_with_transition_internal(
                     &stream_name,
                     TransitionMutation::Remove(key),
+                    true,
                     |stream| {
                         if stream.stream_status != StreamStatus::Updating {
                             return Err(KinesisErrorResponse::server_error(
@@ -2812,9 +2925,10 @@ impl Store {
                 .await
                 .map_err(|err| err.to_string()),
             PendingTransition::StopStreamEncryption { stream_name, .. } => self
-                .update_stream_with_transition(
+                .update_stream_with_transition_internal(
                     &stream_name,
                     TransitionMutation::Remove(key),
+                    true,
                     |stream| {
                         if stream.stream_status != StreamStatus::Updating {
                             return Err(KinesisErrorResponse::server_error(

--- a/src/store.rs
+++ b/src/store.rs
@@ -997,11 +997,25 @@ impl Store {
         stream: Stream,
         transition: TransitionMutation,
     ) -> Result<(), KinesisErrorResponse> {
+        self.put_stream_with_transition_internal(name, stream, transition, false)
+            .await
+    }
+
+    async fn put_stream_with_transition_internal(
+        &self,
+        name: &str,
+        stream: Stream,
+        transition: TransitionMutation,
+        skip_write_lock: bool,
+    ) -> Result<(), KinesisErrorResponse> {
         #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
+        let _write_guard = if self.persistence.is_some() && !skip_write_lock {
             self.check_persistent_mutation_allowed()?;
             Some(self.inner.write_lock.lock().await)
         } else {
+            if self.persistence.is_some() {
+                self.check_persistent_mutation_allowed()?;
+            }
             None
         };
 
@@ -1050,6 +1064,92 @@ impl Store {
         self.persist_current_state().await;
 
         Ok(())
+    }
+
+    fn shard_limit_error(
+        &self,
+        current_shards: u32,
+        requested_shards: u32,
+    ) -> KinesisErrorResponse {
+        KinesisErrorResponse::client_error(
+            constants::LIMIT_EXCEEDED,
+            Some(&format!(
+                "This request would exceed the shard limit for the account {} in {}. \
+                 Current shard count for the account: {}. Limit: {}. \
+                 Number of additional shards that would have resulted from this request: {}. \
+                 Refer to the AWS Service Limits page \
+                 (http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) \
+                 for current limits and how to request higher limits.",
+                self.aws_account_id,
+                self.aws_region,
+                current_shards,
+                self.options.shard_limit,
+                requested_shards
+            )),
+        )
+    }
+
+    async fn sum_account_shards_including_pending_creates(&self) -> u32 {
+        let mut total = self.sum_open_shards().await;
+        let pending = self.inner.pending_transitions.read().await;
+        for transition in pending.values() {
+            let PendingTransition::CreateStream {
+                stream_name,
+                shards,
+                ..
+            } = transition
+            else {
+                continue;
+            };
+
+            let mut count_pending = true;
+            if let Some(entry) = self.inner.streams.get(stream_name) {
+                let stream = entry.value().stream.read().await;
+                let open_shards = stream
+                    .shards
+                    .iter()
+                    .filter(|s| s.sequence_number_range.ending_sequence_number.is_none())
+                    .count();
+                if open_shards > 0 {
+                    count_pending = false;
+                }
+            }
+
+            if count_pending {
+                total = total.saturating_add(shards.len() as u32);
+            }
+        }
+        total
+    }
+
+    pub(crate) async fn create_stream_with_reservation(
+        &self,
+        name: &str,
+        shard_count: u32,
+        stream: Stream,
+        transition: PendingTransition,
+    ) -> Result<(), KinesisErrorResponse> {
+        let _write_guard = self.inner.write_lock.lock().await;
+
+        if self.inner.streams.contains_key(name) {
+            return Err(KinesisErrorResponse::stream_in_use(
+                name,
+                &self.aws_account_id,
+            ));
+        }
+
+        let reserved = self.sum_account_shards_including_pending_creates().await;
+        if reserved.saturating_add(shard_count) > self.options.shard_limit {
+            return Err(self.shard_limit_error(reserved, shard_count));
+        }
+
+        self.put_stream_with_transition_internal(
+            name,
+            stream,
+            TransitionMutation::Upsert(transition),
+            true,
+        )
+        .await
     }
 
     /// Deletes a stream and all of its records.

--- a/src/store.rs
+++ b/src/store.rs
@@ -383,6 +383,7 @@ impl Store {
             policies: DashMap::new(),
             resource_tags: DashMap::new(),
             account_settings: RwLock::new(Value::Object(Default::default())),
+            throughput_windows: DashMap::new(),
             pending_transitions: RwLock::new(BTreeMap::new()),
             write_lock: Mutex::new(()),
         });
@@ -1089,35 +1090,53 @@ impl Store {
         )
     }
 
-    async fn sum_account_shards_including_pending_creates(&self) -> u32 {
-        let mut total = self.sum_open_shards().await;
-        let pending = self.inner.pending_transitions.read().await;
-        for transition in pending.values() {
-            let PendingTransition::CreateStream {
+    async fn open_shard_count_for_stream(&self, stream_name: &str) -> u32 {
+        let Some(entry) = self.inner.streams.get(stream_name) else {
+            return 0;
+        };
+        let stream = entry.value().stream.read().await;
+        stream
+            .shards
+            .iter()
+            .filter(|s| s.sequence_number_range.ending_sequence_number.is_none())
+            .count() as u32
+    }
+
+    async fn pending_shard_reservation(&self, transition: &PendingTransition) -> u32 {
+        match transition {
+            PendingTransition::CreateStream {
                 stream_name,
                 shards,
                 ..
-            } = transition
-            else {
-                continue;
-            };
-
-            let mut count_pending = true;
-            if let Some(entry) = self.inner.streams.get(stream_name) {
-                let stream = entry.value().stream.read().await;
-                let open_shards = stream
-                    .shards
-                    .iter()
-                    .filter(|s| s.sequence_number_range.ending_sequence_number.is_none())
-                    .count();
-                if open_shards > 0 {
-                    count_pending = false;
+            } => {
+                let open_shards = self.open_shard_count_for_stream(stream_name).await;
+                if open_shards == 0 {
+                    shards.len() as u32
+                } else {
+                    0
                 }
             }
+            PendingTransition::SplitShard { .. } => 1,
+            PendingTransition::UpdateShardCount {
+                stream_name,
+                target_shard_count,
+                ..
+            } => target_shard_count
+                .saturating_sub(self.open_shard_count_for_stream(stream_name).await),
+            PendingTransition::DeleteStream { .. }
+            | PendingTransition::RegisterConsumer { .. }
+            | PendingTransition::DeregisterConsumer { .. }
+            | PendingTransition::MergeShards { .. }
+            | PendingTransition::StartStreamEncryption { .. }
+            | PendingTransition::StopStreamEncryption { .. } => 0,
+        }
+    }
 
-            if count_pending {
-                total = total.saturating_add(shards.len() as u32);
-            }
+    async fn sum_account_shards_including_pending_expansions(&self) -> u32 {
+        let mut total = self.sum_open_shards().await;
+        let pending = self.inner.pending_transitions.read().await;
+        for transition in pending.values() {
+            total = total.saturating_add(self.pending_shard_reservation(transition).await);
         }
         total
     }
@@ -1138,7 +1157,7 @@ impl Store {
             ));
         }
 
-        let reserved = self.sum_account_shards_including_pending_creates().await;
+        let reserved = self.sum_account_shards_including_pending_expansions().await;
         if reserved.saturating_add(shard_count) > self.options.shard_limit {
             return Err(self.shard_limit_error(reserved, shard_count));
         }
@@ -1148,6 +1167,130 @@ impl Store {
             stream,
             TransitionMutation::Upsert(transition),
             true,
+        )
+        .await
+    }
+
+    pub(crate) async fn split_shard_with_reservation(
+        &self,
+        stream_name: &str,
+        shard_id: &str,
+        shard_ix: i64,
+        new_starting_hash_key: &str,
+        transition: PendingTransition,
+    ) -> Result<(), KinesisErrorResponse> {
+        let _write_guard = self.inner.write_lock.lock().await;
+        let reserved = self.sum_account_shards_including_pending_expansions().await;
+        let shard_id = shard_id.to_string();
+        let new_starting_hash_key = new_starting_hash_key.to_string();
+
+        self.update_stream_with_transition_internal(
+            stream_name,
+            TransitionMutation::Upsert(transition),
+            true,
+            move |stream| {
+                if stream.stream_status != StreamStatus::Active {
+                    return Err(KinesisErrorResponse::client_error(
+                        constants::RESOURCE_IN_USE,
+                        Some(&format!(
+                            "Stream {} under account {} not ACTIVE, instead in state {}",
+                            stream_name, self.aws_account_id, stream.stream_status
+                        )),
+                    ));
+                }
+
+                if shard_ix >= stream.shards.len() as i64 {
+                    return Err(KinesisErrorResponse::client_error(
+                        constants::RESOURCE_NOT_FOUND,
+                        Some(&format!(
+                            "Could not find shard {} in stream {} under account {}.",
+                            shard_id, stream_name, self.aws_account_id
+                        )),
+                    ));
+                }
+
+                if reserved.saturating_add(1) > self.options.shard_limit {
+                    return Err(self.shard_limit_error(reserved, 1));
+                }
+
+                let hash_key: u128 = new_starting_hash_key.parse().unwrap_or(0);
+                let shard = &stream.shards[shard_ix as usize];
+                let shard_start = shard.hash_key_range.start_u128();
+                let shard_end = shard.hash_key_range.end_u128();
+
+                if hash_key <= shard_start + 1 || hash_key >= shard_end {
+                    return Err(KinesisErrorResponse::client_error(
+                        constants::INVALID_ARGUMENT,
+                        Some(&format!(
+                            "NewStartingHashKey {} used in SplitShard() on shard {} in stream {} under account {} \
+                             is not both greater than one plus the shard's StartingHashKey {} and less than the shard's EndingHashKey {}.",
+                            new_starting_hash_key,
+                            shard_id,
+                            stream_name,
+                            self.aws_account_id,
+                            shard.hash_key_range.starting_hash_key,
+                            shard.hash_key_range.ending_hash_key
+                        )),
+                    ));
+                }
+
+                stream.stream_status = StreamStatus::Updating;
+                Ok(())
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn update_shard_count_with_reservation(
+        &self,
+        stream_name: &str,
+        target_shard_count: u32,
+        transition: PendingTransition,
+    ) -> Result<u32, KinesisErrorResponse> {
+        let _write_guard = self.inner.write_lock.lock().await;
+        let reserved = self.sum_account_shards_including_pending_expansions().await;
+
+        self.update_stream_with_transition_internal(
+            stream_name,
+            TransitionMutation::Upsert(transition),
+            true,
+            move |stream| {
+                if stream.stream_status != StreamStatus::Active {
+                    return Err(KinesisErrorResponse::client_error(
+                        constants::RESOURCE_IN_USE,
+                        Some(&format!(
+                            "Stream {} under account {} not ACTIVE, instead in state {}",
+                            stream_name, self.aws_account_id, stream.stream_status
+                        )),
+                    ));
+                }
+
+                let current_count = stream
+                    .shards
+                    .iter()
+                    .filter(|s| s.sequence_number_range.ending_sequence_number.is_none())
+                    .count() as u32;
+
+                if target_shard_count == current_count {
+                    return Err(KinesisErrorResponse::client_error(
+                        constants::INVALID_ARGUMENT,
+                        Some(&format!(
+                            "TargetShardCount {} is the same as the current shard count {}.",
+                            target_shard_count, current_count
+                        )),
+                    ));
+                }
+
+                let additional_shards = target_shard_count.saturating_sub(current_count);
+                if additional_shards > 0
+                    && reserved.saturating_add(additional_shards) > self.options.shard_limit
+                {
+                    return Err(self.shard_limit_error(reserved, additional_shards));
+                }
+
+                stream.stream_status = StreamStatus::Updating;
+                Ok(current_count)
+            },
         )
         .await
     }
@@ -1270,11 +1413,28 @@ impl Store {
     where
         F: FnOnce(&mut Stream) -> Result<R, KinesisErrorResponse>,
     {
+        self.update_stream_with_transition_internal(name, transition, false, f)
+            .await
+    }
+
+    async fn update_stream_with_transition_internal<F, R>(
+        &self,
+        name: &str,
+        transition: TransitionMutation,
+        skip_write_lock: bool,
+        f: F,
+    ) -> Result<R, KinesisErrorResponse>
+    where
+        F: FnOnce(&mut Stream) -> Result<R, KinesisErrorResponse>,
+    {
         #[cfg(not(target_arch = "wasm32"))]
-        let _write_guard = if self.persistence.is_some() {
+        let _write_guard = if self.persistence.is_some() && !skip_write_lock {
             self.check_persistent_mutation_allowed()?;
             Some(self.inner.write_lock.lock().await)
         } else {
+            if self.persistence.is_some() {
+                self.check_persistent_mutation_allowed()?;
+            }
             None
         };
 
@@ -2321,70 +2481,293 @@ impl Store {
                 stream_name,
                 target_shard_count,
                 ..
-            } => self
-                .update_stream_with_transition(
-                    &stream_name,
-                    TransitionMutation::Remove(key),
-                    move |stream| {
-                        if stream.stream_status != StreamStatus::Updating {
-                            return Err(KinesisErrorResponse::server_error(
-                                None,
-                                Some("recovered UpdateShardCount transition found stream in unexpected state"),
-                            ));
-                        }
+            } => {
+                let closed_shard_ids = self
+                    .update_stream_with_transition(
+                        &stream_name,
+                        TransitionMutation::Remove(key),
+                        move |stream| {
+                            if stream.stream_status != StreamStatus::Updating {
+                                return Err(KinesisErrorResponse::server_error(
+                                    None,
+                                    Some("recovered UpdateShardCount transition found stream in unexpected state"),
+                                ));
+                            }
 
-                        let now = current_time_ms();
-                        let open_indices: Vec<usize> = stream
-                            .shards
-                            .iter()
-                            .enumerate()
-                            .filter(|(_, s)| s.sequence_number_range.ending_sequence_number.is_none())
-                            .map(|(i, _)| i)
-                            .collect();
+                            let now = current_time_ms();
+                            let open_indices: Vec<usize> = stream
+                                .shards
+                                .iter()
+                                .enumerate()
+                                .filter(|(_, s)| {
+                                    s.sequence_number_range.ending_sequence_number.is_none()
+                                })
+                                .map(|(i, _)| i)
+                                .collect();
+                            let closed_shard_ids = open_indices
+                                .iter()
+                                .map(|&ix| stream.shards[ix].shard_id.clone())
+                                .collect::<Vec<_>>();
 
-                        for &ix in &open_indices {
+                            for &ix in &open_indices {
+                                let create_time = sequence::parse_sequence(
+                                    &stream.shards[ix].sequence_number_range.starting_sequence_number,
+                                )
+                                .map(|s| s.shard_create_time)
+                                .unwrap_or(0);
+
+                                stream.shards[ix].sequence_number_range.ending_sequence_number =
+                                    Some(sequence::stringify_sequence(&sequence::SeqObj {
+                                        shard_create_time: create_time,
+                                        shard_ix: ix as i64,
+                                        seq_ix: Some(sequence::MAX_SEQ_IX),
+                                        seq_time: Some(now),
+                                        byte1: None,
+                                        seq_rand: None,
+                                        version: 2,
+                                    }));
+                            }
+
+                            let pow_128 = BigUint::one() << 128;
+                            let shard_hash = &pow_128 / BigUint::from(target_shard_count);
+
+                            for i in 0..target_shard_count {
+                                let new_ix = stream.shards.len() as i64;
+                                let start: BigUint = &shard_hash * BigUint::from(i);
+                                let end: BigUint = if i < target_shard_count - 1 {
+                                    &shard_hash * BigUint::from(i + 1) - BigUint::one()
+                                } else {
+                                    &pow_128 - BigUint::one()
+                                };
+
+                                stream.shards.push(Shard {
+                                    shard_id: sequence::shard_id_name(new_ix),
+                                    parent_shard_id: None,
+                                    adjacent_parent_shard_id: None,
+                                    hash_key_range: HashKeyRange::new(
+                                        start.to_string(),
+                                        end.to_string(),
+                                    ),
+                                    sequence_number_range: SequenceNumberRange {
+                                        starting_sequence_number: sequence::stringify_sequence(
+                                            &sequence::SeqObj {
+                                                shard_create_time: now + 1000,
+                                                shard_ix: new_ix,
+                                                seq_ix: None,
+                                                seq_time: None,
+                                                byte1: None,
+                                                seq_rand: None,
+                                                version: 2,
+                                            },
+                                        ),
+                                        ending_sequence_number: None,
+                                    },
+                                });
+                            }
+
+                            stream.stream_status = StreamStatus::Active;
+                            Ok(closed_shard_ids)
+                        },
+                    )
+                    .await
+                    .map_err(|err| err.to_string())?;
+                self.clear_throughput_windows_for_shards(&stream_name, &closed_shard_ids);
+                Ok(())
+            }
+            PendingTransition::SplitShard {
+                stream_name,
+                shard_to_split,
+                new_starting_hash_key,
+                ..
+            } => {
+                let cleared_shard_id = self
+                    .update_stream_with_transition(
+                        &stream_name,
+                        TransitionMutation::Remove(key),
+                        move |stream| {
+                            if stream.stream_status != StreamStatus::Updating {
+                                return Err(KinesisErrorResponse::server_error(
+                                    None,
+                                    Some("recovered SplitShard transition found stream in unexpected state"),
+                                ));
+                            }
+
+                            let (shard_id, shard_ix) = sequence::resolve_shard_id(&shard_to_split)
+                                .map_err(|_| {
+                                    KinesisErrorResponse::server_error(
+                                        None,
+                                        Some("recovered SplitShard transition has invalid shard id"),
+                                    )
+                                })?;
+                            if shard_ix >= stream.shards.len() as i64 {
+                                return Err(KinesisErrorResponse::server_error(
+                                    None,
+                                    Some("recovered SplitShard transition points to missing shard"),
+                                ));
+                            }
+
+                            let hash_key = new_starting_hash_key.parse::<u128>().map_err(|_| {
+                                KinesisErrorResponse::server_error(
+                                    None,
+                                    Some("recovered SplitShard transition has invalid hash key"),
+                                )
+                            })?;
+                            let shard_start = stream.shards[shard_ix as usize]
+                                .hash_key_range
+                                .start_u128();
+                            let shard_end = stream.shards[shard_ix as usize]
+                                .hash_key_range
+                                .end_u128();
+
+                            let now = current_time_ms();
+                            stream.stream_status = StreamStatus::Active;
+
+                            let shard = &mut stream.shards[shard_ix as usize];
                             let create_time = sequence::parse_sequence(
-                                &stream.shards[ix]
-                                    .sequence_number_range
-                                    .starting_sequence_number,
+                                &shard.sequence_number_range.starting_sequence_number,
                             )
                             .map(|s| s.shard_create_time)
                             .unwrap_or(0);
 
-                            stream.shards[ix]
-                                .sequence_number_range
-                                .ending_sequence_number =
+                            shard.sequence_number_range.ending_sequence_number =
                                 Some(sequence::stringify_sequence(&sequence::SeqObj {
                                     shard_create_time: create_time,
-                                    shard_ix: ix as i64,
+                                    shard_ix,
                                     seq_ix: Some(sequence::MAX_SEQ_IX),
                                     seq_time: Some(now),
                                     byte1: None,
                                     seq_rand: None,
                                     version: 2,
                                 }));
-                        }
 
-                        let pow_128 = BigUint::one() << 128;
-                        let shard_hash = &pow_128 / BigUint::from(target_shard_count);
-
-                        for i in 0..target_shard_count {
-                            let new_ix = stream.shards.len() as i64;
-                            let start: BigUint = &shard_hash * BigUint::from(i);
-                            let end: BigUint = if i < target_shard_count - 1 {
-                                &shard_hash * BigUint::from(i + 1) - BigUint::one()
-                            } else {
-                                &pow_128 - BigUint::one()
-                            };
-
+                            let new_ix1 = stream.shards.len() as i64;
                             stream.shards.push(Shard {
-                                shard_id: sequence::shard_id_name(new_ix),
-                                parent_shard_id: None,
+                                parent_shard_id: Some(shard_id.clone()),
                                 adjacent_parent_shard_id: None,
                                 hash_key_range: HashKeyRange::new(
-                                    start.to_string(),
-                                    end.to_string(),
+                                    shard_start.to_string(),
+                                    (hash_key - 1).to_string(),
                                 ),
+                                sequence_number_range: SequenceNumberRange {
+                                    starting_sequence_number: sequence::stringify_sequence(
+                                        &sequence::SeqObj {
+                                            shard_create_time: now + 1000,
+                                            shard_ix: new_ix1,
+                                            seq_ix: None,
+                                            seq_time: None,
+                                            byte1: None,
+                                            seq_rand: None,
+                                            version: 2,
+                                        },
+                                    ),
+                                    ending_sequence_number: None,
+                                },
+                                shard_id: sequence::shard_id_name(new_ix1),
+                            });
+
+                            let new_ix2 = stream.shards.len() as i64;
+                            stream.shards.push(Shard {
+                                parent_shard_id: Some(shard_id),
+                                adjacent_parent_shard_id: None,
+                                hash_key_range: HashKeyRange::new(
+                                    hash_key.to_string(),
+                                    shard_end.to_string(),
+                                ),
+                                sequence_number_range: SequenceNumberRange {
+                                    starting_sequence_number: sequence::stringify_sequence(
+                                        &sequence::SeqObj {
+                                            shard_create_time: now + 1000,
+                                            shard_ix: new_ix2,
+                                            seq_ix: None,
+                                            seq_time: None,
+                                            byte1: None,
+                                            seq_rand: None,
+                                            version: 2,
+                                        },
+                                    ),
+                                    ending_sequence_number: None,
+                                },
+                                shard_id: sequence::shard_id_name(new_ix2),
+                            });
+
+                            Ok(shard_to_split)
+                        },
+                    )
+                    .await
+                    .map_err(|err| err.to_string())?;
+                self.clear_throughput_windows_for_shards(&stream_name, [cleared_shard_id.as_str()]);
+                Ok(())
+            }
+            PendingTransition::MergeShards {
+                stream_name,
+                shard_to_merge,
+                adjacent_shard_to_merge,
+                ..
+            } => {
+                let cleared_shard_ids = self
+                    .update_stream_with_transition(
+                        &stream_name,
+                        TransitionMutation::Remove(key),
+                        move |stream| {
+                            if stream.stream_status != StreamStatus::Updating {
+                                return Err(KinesisErrorResponse::server_error(
+                                    None,
+                                    Some("recovered MergeShards transition found stream in unexpected state"),
+                                ));
+                            }
+
+                            let (shard_id0, shard_ix0) =
+                                sequence::resolve_shard_id(&shard_to_merge).map_err(|_| {
+                                    KinesisErrorResponse::server_error(
+                                        None,
+                                        Some("recovered MergeShards transition has invalid shard id"),
+                                    )
+                                })?;
+                            let (shard_id1, shard_ix1) =
+                                sequence::resolve_shard_id(&adjacent_shard_to_merge).map_err(|_| {
+                                    KinesisErrorResponse::server_error(
+                                        None,
+                                        Some("recovered MergeShards transition has invalid adjacent shard id"),
+                                    )
+                                })?;
+
+                            let now = current_time_ms();
+                            stream.stream_status = StreamStatus::Active;
+
+                            for &ix in &[shard_ix0, shard_ix1] {
+                                let shard = &mut stream.shards[ix as usize];
+                                let create_time = sequence::parse_sequence(
+                                    &shard.sequence_number_range.starting_sequence_number,
+                                )
+                                .map(|s| s.shard_create_time)
+                                .unwrap_or(0);
+
+                                shard.sequence_number_range.ending_sequence_number =
+                                    Some(sequence::stringify_sequence(&sequence::SeqObj {
+                                        shard_create_time: create_time,
+                                        shard_ix: ix,
+                                        seq_ix: Some(sequence::MAX_SEQ_IX),
+                                        seq_time: Some(now),
+                                        byte1: None,
+                                        seq_rand: None,
+                                        version: 2,
+                                    }));
+                            }
+
+                            let new_ix = stream.shards.len() as i64;
+                            let starting_hash = stream.shards[shard_ix0 as usize]
+                                .hash_key_range
+                                .starting_hash_key
+                                .clone();
+                            let ending_hash = stream.shards[shard_ix1 as usize]
+                                .hash_key_range
+                                .ending_hash_key
+                                .clone();
+
+                            stream.shards.push(Shard {
+                                parent_shard_id: Some(shard_id0),
+                                adjacent_parent_shard_id: Some(shard_id1),
+                                hash_key_range: HashKeyRange::new(starting_hash, ending_hash),
                                 sequence_number_range: SequenceNumberRange {
                                     starting_sequence_number: sequence::stringify_sequence(
                                         &sequence::SeqObj {
@@ -2399,226 +2782,17 @@ impl Store {
                                     ),
                                     ending_sequence_number: None,
                                 },
+                                shard_id: sequence::shard_id_name(new_ix),
                             });
-                        }
 
-                        stream.stream_status = StreamStatus::Active;
-                        Ok(())
-                    },
-                )
-                .await
-                .map_err(|err| err.to_string()),
-            PendingTransition::SplitShard {
-                stream_name,
-                shard_to_split,
-                new_starting_hash_key,
-                ..
-            } => self
-                .update_stream_with_transition(
-                    &stream_name,
-                    TransitionMutation::Remove(key),
-                    move |stream| {
-                        if stream.stream_status != StreamStatus::Updating {
-                            return Err(KinesisErrorResponse::server_error(
-                                None,
-                                Some("recovered SplitShard transition found stream in unexpected state"),
-                            ));
-                        }
-
-                        let (shard_id, shard_ix) = sequence::resolve_shard_id(&shard_to_split)
-                            .map_err(|_| {
-                                KinesisErrorResponse::server_error(
-                                    None,
-                                    Some("recovered SplitShard transition has invalid shard id"),
-                                )
-                            })?;
-                        if shard_ix >= stream.shards.len() as i64 {
-                            return Err(KinesisErrorResponse::server_error(
-                                None,
-                                Some("recovered SplitShard transition points to missing shard"),
-                            ));
-                        }
-
-                        let hash_key = new_starting_hash_key.parse::<u128>().map_err(|_| {
-                            KinesisErrorResponse::server_error(
-                                None,
-                                Some("recovered SplitShard transition has invalid hash key"),
-                            )
-                        })?;
-                        let shard_start = stream.shards[shard_ix as usize]
-                            .hash_key_range
-                            .start_u128();
-                        let shard_end = stream.shards[shard_ix as usize]
-                            .hash_key_range
-                            .end_u128();
-
-                        let now = current_time_ms();
-                        stream.stream_status = StreamStatus::Active;
-
-                        let shard = &mut stream.shards[shard_ix as usize];
-                        let create_time = sequence::parse_sequence(
-                            &shard.sequence_number_range.starting_sequence_number,
-                        )
-                        .map(|s| s.shard_create_time)
-                        .unwrap_or(0);
-
-                        shard.sequence_number_range.ending_sequence_number =
-                            Some(sequence::stringify_sequence(&sequence::SeqObj {
-                                shard_create_time: create_time,
-                                shard_ix,
-                                seq_ix: Some(sequence::MAX_SEQ_IX),
-                                seq_time: Some(now),
-                                byte1: None,
-                                seq_rand: None,
-                                version: 2,
-                            }));
-
-                        let new_ix1 = stream.shards.len() as i64;
-                        stream.shards.push(Shard {
-                            parent_shard_id: Some(shard_id.clone()),
-                            adjacent_parent_shard_id: None,
-                            hash_key_range: HashKeyRange::new(
-                                shard_start.to_string(),
-                                (hash_key - 1).to_string(),
-                            ),
-                            sequence_number_range: SequenceNumberRange {
-                                starting_sequence_number: sequence::stringify_sequence(
-                                    &sequence::SeqObj {
-                                        shard_create_time: now + 1000,
-                                        shard_ix: new_ix1,
-                                        seq_ix: None,
-                                        seq_time: None,
-                                        byte1: None,
-                                        seq_rand: None,
-                                        version: 2,
-                                    },
-                                ),
-                                ending_sequence_number: None,
-                            },
-                            shard_id: sequence::shard_id_name(new_ix1),
-                        });
-
-                        let new_ix2 = stream.shards.len() as i64;
-                        stream.shards.push(Shard {
-                            parent_shard_id: Some(shard_id),
-                            adjacent_parent_shard_id: None,
-                            hash_key_range: HashKeyRange::new(
-                                hash_key.to_string(),
-                                shard_end.to_string(),
-                            ),
-                            sequence_number_range: SequenceNumberRange {
-                                starting_sequence_number: sequence::stringify_sequence(
-                                    &sequence::SeqObj {
-                                        shard_create_time: now + 1000,
-                                        shard_ix: new_ix2,
-                                        seq_ix: None,
-                                        seq_time: None,
-                                        byte1: None,
-                                        seq_rand: None,
-                                        version: 2,
-                                    },
-                                ),
-                                ending_sequence_number: None,
-                            },
-                            shard_id: sequence::shard_id_name(new_ix2),
-                        });
-
-                        Ok(())
-                    },
-                )
-                .await
-                .map_err(|err| err.to_string()),
-            PendingTransition::MergeShards {
-                stream_name,
-                shard_to_merge,
-                adjacent_shard_to_merge,
-                ..
-            } => self
-                .update_stream_with_transition(
-                    &stream_name,
-                    TransitionMutation::Remove(key),
-                    move |stream| {
-                        if stream.stream_status != StreamStatus::Updating {
-                            return Err(KinesisErrorResponse::server_error(
-                                None,
-                                Some("recovered MergeShards transition found stream in unexpected state"),
-                            ));
-                        }
-
-                        let (shard_id0, shard_ix0) =
-                            sequence::resolve_shard_id(&shard_to_merge).map_err(|_| {
-                                KinesisErrorResponse::server_error(
-                                    None,
-                                    Some("recovered MergeShards transition has invalid shard id"),
-                                )
-                            })?;
-                        let (shard_id1, shard_ix1) =
-                            sequence::resolve_shard_id(&adjacent_shard_to_merge).map_err(|_| {
-                                KinesisErrorResponse::server_error(
-                                    None,
-                                    Some("recovered MergeShards transition has invalid adjacent shard id"),
-                                )
-                            })?;
-
-                        let now = current_time_ms();
-                        stream.stream_status = StreamStatus::Active;
-
-                        for &ix in &[shard_ix0, shard_ix1] {
-                            let shard = &mut stream.shards[ix as usize];
-                            let create_time = sequence::parse_sequence(
-                                &shard.sequence_number_range.starting_sequence_number,
-                            )
-                            .map(|s| s.shard_create_time)
-                            .unwrap_or(0);
-
-                            shard.sequence_number_range.ending_sequence_number =
-                                Some(sequence::stringify_sequence(&sequence::SeqObj {
-                                    shard_create_time: create_time,
-                                    shard_ix: ix,
-                                    seq_ix: Some(sequence::MAX_SEQ_IX),
-                                    seq_time: Some(now),
-                                    byte1: None,
-                                    seq_rand: None,
-                                    version: 2,
-                                }));
-                        }
-
-                        let new_ix = stream.shards.len() as i64;
-                        let starting_hash = stream.shards[shard_ix0 as usize]
-                            .hash_key_range
-                            .starting_hash_key
-                            .clone();
-                        let ending_hash = stream.shards[shard_ix1 as usize]
-                            .hash_key_range
-                            .ending_hash_key
-                            .clone();
-
-                        stream.shards.push(Shard {
-                            parent_shard_id: Some(shard_id0),
-                            adjacent_parent_shard_id: Some(shard_id1),
-                            hash_key_range: HashKeyRange::new(starting_hash, ending_hash),
-                            sequence_number_range: SequenceNumberRange {
-                                starting_sequence_number: sequence::stringify_sequence(
-                                    &sequence::SeqObj {
-                                        shard_create_time: now + 1000,
-                                        shard_ix: new_ix,
-                                        seq_ix: None,
-                                        seq_time: None,
-                                        byte1: None,
-                                        seq_rand: None,
-                                        version: 2,
-                                    },
-                                ),
-                                ending_sequence_number: None,
-                            },
-                            shard_id: sequence::shard_id_name(new_ix),
-                        });
-
-                        Ok(())
-                    },
-                )
-                .await
-                .map_err(|err| err.to_string()),
+                            Ok([shard_to_merge, adjacent_shard_to_merge])
+                        },
+                    )
+                    .await
+                    .map_err(|err| err.to_string())?;
+                self.clear_throughput_windows_for_shards(&stream_name, cleared_shard_ids);
+                Ok(())
+            }
             PendingTransition::StartStreamEncryption { stream_name, .. } => self
                 .update_stream_with_transition(
                     &stream_name,

--- a/src/store.rs
+++ b/src/store.rs
@@ -250,6 +250,24 @@ pub struct SequenceAllocation {
     pub now: u64,
 }
 
+/// A charged shard-throughput reservation that may be refunded on rollback.
+#[derive(Debug, Clone)]
+pub struct ThroughputReservation {
+    key: Option<String>,
+    window_start_ms: u64,
+    bytes: u64,
+}
+
+impl ThroughputReservation {
+    fn disabled() -> Self {
+        Self {
+            key: None,
+            window_start_ms: 0,
+            bytes: 0,
+        }
+    }
+}
+
 /// Per-shard record map: shard_hex → sorted records.
 type ShardRecords = DashMap<String, Arc<RwLock<BTreeMap<String, Vec<u8>>>>>;
 
@@ -272,6 +290,77 @@ struct AppliedDeleteChange {
     records_arc: Arc<RwLock<BTreeMap<String, Vec<u8>>>>,
     key: String,
     deleted_bytes: Vec<u8>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct RestoredState {
+    streams: Vec<(String, Stream, Vec<u64>)>,
+    records: Vec<(String, Vec<(String, BTreeMap<String, Vec<u8>>)>)>,
+    consumers: Vec<(String, Vec<u8>)>,
+    policies: Vec<(String, String)>,
+    resource_tags: Vec<(String, BTreeMap<String, String>)>,
+    account_settings: Value,
+    pending_transitions: BTreeMap<String, PendingTransition>,
+    retained_bytes: u64,
+    retained_records: u64,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl RestoredState {
+    fn from_snapshot(snapshot: PersistentSnapshot) -> Result<Self, String> {
+        let PersistentSnapshot {
+            streams,
+            records,
+            consumers,
+            policies,
+            resource_tags,
+            account_settings_json,
+            pending_transitions,
+            retained_bytes,
+            retained_records,
+            ..
+        } = snapshot;
+
+        let account_settings = if account_settings_json.is_empty() {
+            Value::Object(Default::default())
+        } else {
+            serde_json::from_slice(&account_settings_json)
+                .map_err(|err| format!("failed to decode persisted account settings: {err}"))?
+        };
+
+        Ok(Self {
+            streams: streams
+                .into_iter()
+                .map(|stream| {
+                    let (name, stream_value, shard_counters) = stream.into_parts();
+                    (name, stream_value, shard_counters)
+                })
+                .collect(),
+            records: records
+                .into_iter()
+                .fold(BTreeMap::new(), |mut acc, shard_records| {
+                    acc.entry(shard_records.stream_name)
+                        .or_insert_with(Vec::new)
+                        .push((
+                            shard_records.shard_hex,
+                            shard_records.records.into_iter().collect(),
+                        ));
+                    acc
+                })
+                .into_iter()
+                .collect(),
+            consumers,
+            policies,
+            resource_tags,
+            account_settings,
+            pending_transitions: pending_transitions
+                .into_iter()
+                .map(|transition| (transition.key(), transition))
+                .collect(),
+            retained_bytes,
+            retained_records,
+        })
+    }
 }
 
 /// Shared inner state behind an [`Arc`] for cheap [`Store`] clones.
@@ -450,66 +539,46 @@ impl Store {
             return Ok(());
         };
 
-        persistence
-            .last_snapshot_ms
-            .store(snapshot.created_at_ms, Ordering::Relaxed);
-        self.metrics.set_last_snapshot_ms(snapshot.created_at_ms);
-        self.restore_snapshot(snapshot)?;
         self.metrics.set_replay_complete(false);
         self.health.replay_complete.store(false, Ordering::Relaxed);
 
+        let mut restored_snapshot = snapshot;
         for entry in entries {
-            self.apply_wal_entry(entry)?;
+            Self::apply_wal_entry(&mut restored_snapshot, entry)?;
         }
 
+        let created_at_ms = restored_snapshot.created_at_ms;
+        let restored_state = RestoredState::from_snapshot(restored_snapshot)?;
+        self.install_restored_state(restored_state);
+        persistence
+            .last_snapshot_ms
+            .store(created_at_ms, Ordering::Relaxed);
+        self.metrics.set_last_snapshot_ms(created_at_ms);
         self.metrics.set_replay_complete(true);
         self.health.replay_complete.store(true, Ordering::Relaxed);
         Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn apply_wal_entry(&self, entry: WalEntry) -> Result<(), String> {
+    fn apply_wal_entry(snapshot: &mut PersistentSnapshot, entry: WalEntry) -> Result<(), String> {
         match entry {
-            WalEntry::Snapshot(snapshot) => self.restore_snapshot(snapshot),
+            WalEntry::Snapshot(next_snapshot) => {
+                *snapshot = next_snapshot;
+                Ok(())
+            }
         }
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn restore_snapshot(&self, snapshot: PersistentSnapshot) -> Result<(), String> {
-        let PersistentSnapshot {
-            streams,
-            records,
-            consumers,
-            policies,
-            resource_tags,
-            account_settings_json,
-            pending_transitions,
-            retained_bytes,
-            retained_records,
-            ..
-        } = snapshot;
+    fn install_restored_state(&self, restored_state: RestoredState) {
         self.inner.streams.clear();
         self.inner.stream_records.clear();
         self.inner.consumers.clear();
         self.inner.policies.clear();
         self.inner.resource_tags.clear();
-        if let Ok(mut transitions) = self.inner.pending_transitions.try_write() {
-            transitions.clear();
-            for transition in pending_transitions {
-                transitions.insert(transition.key(), transition);
-            }
-        }
-        if let Ok(mut settings) = self.inner.account_settings.try_write() {
-            *settings = if account_settings_json.is_empty() {
-                Value::Object(Default::default())
-            } else {
-                serde_json::from_slice(&account_settings_json)
-                    .map_err(|err| format!("failed to decode persisted account settings: {err}"))?
-            };
-        }
+        self.inner.throughput_windows.clear();
 
-        for stream in streams {
-            let (name, stream_value, shard_counters) = stream.into_parts();
+        for (name, stream_value, shard_counters) in restored_state.streams {
             let entry = Arc::new(StreamEntry {
                 stream: RwLock::new(stream_value),
                 shard_seq: RwLock::new(
@@ -524,29 +593,34 @@ impl Store {
             self.inner.streams.insert(name, entry);
         }
 
-        for shard_records in records {
-            let shard_map = self
-                .inner
-                .stream_records
-                .entry(shard_records.stream_name)
-                .or_default();
-            let records = shard_records.records.into_iter().collect();
-            shard_map.insert(shard_records.shard_hex, Arc::new(RwLock::new(records)));
+        for (stream_name, shards) in restored_state.records {
+            let shard_map = self.inner.stream_records.entry(stream_name).or_default();
+            for (shard_hex, records) in shards {
+                shard_map.insert(shard_hex, Arc::new(RwLock::new(records)));
+            }
         }
 
-        for (consumer_arn, bytes) in consumers {
+        for (consumer_arn, bytes) in restored_state.consumers {
             self.inner.consumers.insert(consumer_arn, bytes);
         }
-        for (resource_arn, policy) in policies {
+        for (resource_arn, policy) in restored_state.policies {
             self.inner.policies.insert(resource_arn, policy);
         }
-        for (resource_arn, tags) in resource_tags {
+        for (resource_arn, tags) in restored_state.resource_tags {
             self.inner.resource_tags.insert(resource_arn, tags);
         }
+        if let Ok(mut transitions) = self.inner.pending_transitions.try_write() {
+            *transitions = restored_state.pending_transitions;
+        }
+        if let Ok(mut settings) = self.inner.account_settings.try_write() {
+            *settings = restored_state.account_settings;
+        }
 
-        self.metrics.set_retained(retained_bytes, retained_records);
+        self.metrics.set_retained(
+            restored_state.retained_bytes,
+            restored_state.retained_records,
+        );
         self.refresh_topology_metrics_sync();
-        Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -871,17 +945,25 @@ impl Store {
             .unwrap_or_else(|| "durable state is not ready".to_string())
     }
 
-    pub(crate) fn check_writable(&self) -> Result<(), KinesisErrorResponse> {
+    fn availability_block_reason(&self) -> Option<String> {
         if !self.health.durable_ok.load(Ordering::Relaxed) {
-            let detail = self.durable_state_error_detail();
-            return Err(KinesisErrorResponse::server_error(None, Some(&detail)));
+            return Some(self.durable_state_error_detail());
         }
         if !self.health.replay_complete.load(Ordering::Relaxed) {
-            return Err(KinesisErrorResponse::server_error(
-                None,
-                Some("durable replay is not complete"),
-            ));
+            return Some("durable replay is not complete".to_string());
         }
+        None
+    }
+
+    pub(crate) fn check_available(&self) -> Result<(), KinesisErrorResponse> {
+        if let Some(detail) = self.availability_block_reason() {
+            return Err(KinesisErrorResponse::server_error(None, Some(&detail)));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn check_writable(&self) -> Result<(), KinesisErrorResponse> {
+        self.check_available()?;
         if self.retained_capacity_exceeded() {
             return Err(self.retained_limit_error(self.metrics.retained_bytes(), 0));
         }
@@ -893,11 +975,8 @@ impl Store {
         if !self.durable_state_requested() {
             return None;
         }
-        if !self.health.durable_ok.load(Ordering::Relaxed) {
-            return Some(self.durable_state_error_detail());
-        }
-        if !self.health.replay_complete.load(Ordering::Relaxed) {
-            return Some("durable replay is not complete".to_string());
+        if let Some(detail) = self.availability_block_reason() {
+            return Some(detail);
         }
         if self.persistence.is_none() {
             return Some("durable state backend is unavailable".to_string());
@@ -2291,28 +2370,8 @@ impl Store {
     /// in-memory implementation this never happens, but the signature is kept
     /// for API compatibility.
     pub fn check_ready(&self) -> Result<(), StoreHealthError> {
-        if !self.health.durable_ok.load(Ordering::Relaxed) {
-            let detail = self
-                .health
-                .last_error
-                .read()
-                .ok()
-                .and_then(|guard| guard.clone())
-                .unwrap_or_else(|| "durable state is not ready".to_string());
+        if let Some(detail) = self.availability_block_reason() {
             return Err(StoreHealthError::ReadFailed(detail));
-        }
-        if !self.health.replay_complete.load(Ordering::Relaxed) {
-            return Err(StoreHealthError::ReadFailed(
-                "durable replay is not complete".to_string(),
-            ));
-        }
-        if self.retained_capacity_exceeded() {
-            let limit = self.options.max_retained_bytes.unwrap();
-            return Err(StoreHealthError::ReadFailed(format!(
-                "retained bytes limit exceeded: {} > {}",
-                self.metrics.retained_bytes(),
-                limit
-            )));
         }
         Ok(())
     }
@@ -2986,16 +3045,16 @@ impl Store {
         shard_id: &str,
         bytes: u64,
         now_ms: u64,
-    ) -> Result<(), KinesisErrorResponse> {
+    ) -> Result<ThroughputReservation, KinesisErrorResponse> {
         if !self.options.enforce_limits {
-            return Ok(());
+            return Ok(ThroughputReservation::disabled());
         }
 
         let key = throughput_window_key(stream_name, shard_id);
         let window = self
             .inner
             .throughput_windows
-            .entry(key)
+            .entry(key.clone())
             .or_insert_with(|| {
                 Arc::new(Mutex::new(ShardThroughputWindow {
                     window_start_ms: now_ms,
@@ -3008,7 +3067,38 @@ impl Store {
         let mut window = window.lock().await;
         roll_throughput_window(&mut window, now_ms);
         reserve_throughput_window(&mut window, bytes)?;
-        Ok(())
+        Ok(ThroughputReservation {
+            key: Some(key),
+            window_start_ms: window.window_start_ms,
+            bytes,
+        })
+    }
+
+    /// Refunds a previously charged shard-throughput reservation.
+    ///
+    /// Refunds are applied only if the original throughput window is still
+    /// current, preventing a rollback from mutating a newer second's quota.
+    pub async fn refund_shard_throughput(&self, reservation: ThroughputReservation) {
+        let Some(key) = reservation.key else {
+            return;
+        };
+
+        let Some(window) = self
+            .inner
+            .throughput_windows
+            .get(&key)
+            .map(|entry| Arc::clone(entry.value()))
+        else {
+            return;
+        };
+
+        let mut window = window.lock().await;
+        if window.window_start_ms != reservation.window_start_ms {
+            return;
+        }
+
+        window.bytes = window.bytes.saturating_sub(reservation.bytes);
+        window.records = window.records.saturating_sub(1);
     }
 
     fn clear_throughput_windows_for_stream(&self, stream_name: &str) {

--- a/tests/create_stream.rs
+++ b/tests/create_stream.rs
@@ -231,3 +231,97 @@ async fn create_stream_creating_then_active() {
         1
     );
 }
+
+#[tokio::test]
+async fn create_stream_pending_reserves_shard_capacity() {
+    let server = TestServer::with_options(ferrokinesis::store::StoreOptions {
+        create_stream_ms: 200,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 1,
+        ..Default::default()
+    })
+    .await;
+
+    let res = server
+        .request(
+            "CreateStream",
+            &json!({"StreamName": "pending-limit-1", "ShardCount": 1}),
+        )
+        .await;
+    assert_eq!(res.status(), 200);
+
+    let res = server
+        .request(
+            "CreateStream",
+            &json!({"StreamName": "pending-limit-2", "ShardCount": 1}),
+        )
+        .await;
+    assert_eq!(res.status(), 400);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["__type"], "LimitExceededException");
+}
+
+#[tokio::test]
+async fn create_stream_pending_reserves_mixed_counts() {
+    let server = TestServer::with_options(ferrokinesis::store::StoreOptions {
+        create_stream_ms: 200,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 3,
+        ..Default::default()
+    })
+    .await;
+
+    let res = server
+        .request(
+            "CreateStream",
+            &json!({"StreamName": "pending-mixed-a", "ShardCount": 2}),
+        )
+        .await;
+    assert_eq!(res.status(), 200);
+
+    let res = server
+        .request(
+            "CreateStream",
+            &json!({"StreamName": "pending-mixed-b", "ShardCount": 2}),
+        )
+        .await;
+    assert_eq!(res.status(), 400);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["__type"], "LimitExceededException");
+
+    let res = server
+        .request(
+            "CreateStream",
+            &json!({"StreamName": "pending-mixed-c", "ShardCount": 1}),
+        )
+        .await;
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn create_stream_concurrent_admission_respects_limit() {
+    let server = TestServer::with_options(ferrokinesis::store::StoreOptions {
+        create_stream_ms: 200,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 1,
+        ..Default::default()
+    })
+    .await;
+
+    let req_a = json!({"StreamName": "pending-concurrent-a", "ShardCount": 1});
+    let req_b = json!({"StreamName": "pending-concurrent-b", "ShardCount": 1});
+
+    let (res_a, res_b) = tokio::join!(
+        server.request("CreateStream", &req_a),
+        server.request("CreateStream", &req_b),
+    );
+
+    let codes = [res_a.status().as_u16(), res_b.status().as_u16()];
+    let success = codes.iter().filter(|&&code| code == 200).count();
+    let limit = codes.iter().filter(|&&code| code == 400).count();
+    assert_eq!(success, 1, "expected exactly one success: {codes:?}");
+    assert_eq!(limit, 1, "expected exactly one limit failure: {codes:?}");
+}

--- a/tests/durable_state.rs
+++ b/tests/durable_state.rs
@@ -1,8 +1,8 @@
 use ferrokinesis::actions::{Operation, dispatch};
-use ferrokinesis::persistence::Persistence;
+use ferrokinesis::persistence::{Persistence, WalEntry};
 use ferrokinesis::store::{Store, StoreOptions};
-use ferrokinesis::types::StreamStatus;
-use serde_json::json;
+use ferrokinesis::types::{ConsumerStatus, EncryptionType, StreamStatus};
+use serde_json::{Value, json};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::Path;
@@ -11,9 +11,9 @@ use tempfile::tempdir;
 
 fn durable_options(state_dir: &Path, snapshot_interval_secs: u64) -> StoreOptions {
     StoreOptions {
-        create_stream_ms: 0,
-        delete_stream_ms: 0,
-        update_stream_ms: 0,
+        create_stream_ms: 50,
+        delete_stream_ms: 50,
+        update_stream_ms: 50,
         shard_limit: 50,
         state_dir: Some(state_dir.to_path_buf()),
         snapshot_interval_secs,
@@ -21,7 +21,7 @@ fn durable_options(state_dir: &Path, snapshot_interval_secs: u64) -> StoreOption
     }
 }
 
-async fn create_active_stream(store: &Store, name: &str) {
+async fn create_active_stream(store: &Store, name: &str) -> String {
     dispatch(
         store,
         Operation::CreateStream,
@@ -32,17 +32,88 @@ async fn create_active_stream(store: &Store, name: &str) {
     )
     .await
     .unwrap();
-    for _ in 0..50 {
+    for _ in 0..80 {
         let stream = store.get_stream(name).await.unwrap();
         if stream.stream_status == StreamStatus::Active && !stream.shards.is_empty() {
-            return;
+            return stream.stream_arn;
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
     panic!("stream {name} did not become ACTIVE");
 }
 
-async fn put_record(store: &Store, name: &str, data: &str, partition_key: &str) {
+async fn wait_for_stream_active(store: &Store, name: &str, min_open_shards: usize) {
+    for _ in 0..80 {
+        let stream = store.get_stream(name).await.unwrap();
+        let open_shards = stream
+            .shards
+            .iter()
+            .filter(|shard| shard.sequence_number_range.ending_sequence_number.is_none())
+            .count();
+        if stream.stream_status == StreamStatus::Active && open_shards >= min_open_shards {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("stream {name} did not become ACTIVE with {min_open_shards} open shards");
+}
+
+async fn wait_for_stream_deleted(store: &Store, name: &str) {
+    for _ in 0..80 {
+        if !store.contains_stream(name).await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("stream {name} was not deleted");
+}
+
+async fn register_consumer(store: &Store, stream_arn: &str, consumer_name: &str) -> String {
+    let body = dispatch(
+        store,
+        Operation::RegisterStreamConsumer,
+        json!({
+            "StreamARN": stream_arn,
+            "ConsumerName": consumer_name,
+        }),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    body["Consumer"]["ConsumerARN"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn wait_for_consumer_status(store: &Store, consumer_arn: &str, expected: ConsumerStatus) {
+    for _ in 0..80 {
+        if let Some(consumer) = store.get_consumer(consumer_arn).await
+            && consumer.consumer_status == expected
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("consumer {consumer_arn} did not reach {expected}");
+}
+
+async fn wait_for_consumer_deleted(store: &Store, consumer_arn: &str) {
+    for _ in 0..80 {
+        if store.get_consumer(consumer_arn).await.is_none() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("consumer {consumer_arn} was not deleted");
+}
+
+async fn put_record(
+    store: &Store,
+    name: &str,
+    data: &str,
+    partition_key: &str,
+) -> Result<Option<Value>, ferrokinesis::error::KinesisErrorResponse> {
     dispatch(
         store,
         Operation::PutRecord,
@@ -53,7 +124,54 @@ async fn put_record(store: &Store, name: &str, data: &str, partition_key: &str) 
         }),
     )
     .await
+}
+
+async fn put_records(
+    store: &Store,
+    name: &str,
+    records: &[(&str, &str)],
+) -> Result<Option<Value>, ferrokinesis::error::KinesisErrorResponse> {
+    dispatch(
+        store,
+        Operation::PutRecords,
+        json!({
+            "StreamName": name,
+            "Records": records
+                .iter()
+                .map(|(data, partition_key)| json!({"Data": data, "PartitionKey": partition_key}))
+                .collect::<Vec<_>>(),
+        }),
+    )
+    .await
+}
+
+fn latest_snapshot_from_wal(state_dir: &Path) -> Value {
+    let (_, entries) = Persistence::new(state_dir.to_path_buf())
+        .unwrap()
+        .load()
+        .unwrap()
+        .unwrap();
+    let snapshot = entries
+        .into_iter()
+        .rev()
+        .find_map(|entry| match entry {
+            WalEntry::Snapshot(snapshot) => Some(snapshot),
+        })
+        .expect("wal snapshot");
+    serde_json::to_value(snapshot).unwrap()
+}
+
+fn write_legacy_snapshot(state_dir: &Path, mut snapshot: Value) {
+    snapshot
+        .as_object_mut()
+        .unwrap()
+        .remove("pending_transitions");
+    fs::write(
+        state_dir.join("snapshot.bin"),
+        serde_json::to_vec(&snapshot).unwrap(),
+    )
     .unwrap();
+    fs::write(state_dir.join("wal.log"), []).unwrap();
 }
 
 #[tokio::test]
@@ -64,7 +182,7 @@ async fn durable_store_replays_wal_after_restart() {
 
     let store = Store::new(options.clone());
     create_active_stream(&store, stream_name).await;
-    put_record(&store, stream_name, "AAAA", "pk").await;
+    put_record(&store, stream_name, "AAAA", "pk").await.unwrap();
     drop(store);
 
     let persisted = Persistence::new(dir.path().to_path_buf()).unwrap().load();
@@ -95,7 +213,7 @@ async fn durable_store_restores_from_snapshot_after_restart() {
     let store = Store::new(options.clone());
     create_active_stream(&store, stream_name).await;
     tokio::time::sleep(Duration::from_millis(1_100)).await;
-    put_record(&store, stream_name, "AAAA", "pk").await;
+    put_record(&store, stream_name, "AAAA", "pk").await.unwrap();
     drop(store);
 
     let persisted = Persistence::new(dir.path().to_path_buf()).unwrap().load();
@@ -117,7 +235,7 @@ async fn durable_store_marks_itself_unready_when_wal_is_corrupted() {
 
     let store = Store::new(options.clone());
     create_active_stream(&store, stream_name).await;
-    put_record(&store, stream_name, "AAAA", "pk").await;
+    put_record(&store, stream_name, "AAAA", "pk").await.unwrap();
     drop(store);
 
     let mut wal = OpenOptions::new()
@@ -161,4 +279,361 @@ async fn durable_store_preserves_internal_stream_fields() {
     );
     assert_eq!(stream.warm_throughput_mibps, 7);
     assert_eq!(stream.max_record_size_kib, 4096);
+}
+
+#[tokio::test]
+async fn durable_store_resumes_create_stream_transition_after_restart() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+
+    dispatch(
+        &store,
+        Operation::CreateStream,
+        json!({"StreamName": "restart-create", "ShardCount": 1}),
+    )
+    .await
+    .unwrap();
+    drop(store);
+
+    let recovered = Store::new(options);
+    wait_for_stream_active(&recovered, "restart-create", 1).await;
+}
+
+#[tokio::test]
+async fn durable_store_resumes_delete_stream_transition_after_restart() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+    create_active_stream(&store, "restart-delete").await;
+
+    dispatch(
+        &store,
+        Operation::DeleteStream,
+        json!({"StreamName": "restart-delete"}),
+    )
+    .await
+    .unwrap();
+    drop(store);
+
+    let recovered = Store::new(options);
+    wait_for_stream_deleted(&recovered, "restart-delete").await;
+}
+
+#[tokio::test]
+async fn durable_store_resumes_register_consumer_transition_after_restart() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+    let stream_arn = create_active_stream(&store, "restart-register-consumer").await;
+    let consumer_arn = register_consumer(&store, &stream_arn, "consumer-a").await;
+    drop(store);
+
+    let recovered = Store::new(options);
+    wait_for_consumer_status(&recovered, &consumer_arn, ConsumerStatus::Active).await;
+}
+
+#[tokio::test]
+async fn durable_store_resumes_deregister_consumer_transition_after_restart() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+    let stream_arn = create_active_stream(&store, "restart-deregister-consumer").await;
+    let consumer_arn = register_consumer(&store, &stream_arn, "consumer-a").await;
+    wait_for_consumer_status(&store, &consumer_arn, ConsumerStatus::Active).await;
+
+    dispatch(
+        &store,
+        Operation::DeregisterStreamConsumer,
+        json!({"ConsumerARN": consumer_arn}),
+    )
+    .await
+    .unwrap();
+    drop(store);
+
+    let recovered = Store::new(options);
+    wait_for_consumer_deleted(&recovered, &consumer_arn).await;
+}
+
+#[tokio::test]
+async fn durable_store_resumes_update_shard_count_transition_after_restart() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+    create_active_stream(&store, "restart-reshard").await;
+
+    dispatch(
+        &store,
+        Operation::UpdateShardCount,
+        json!({"StreamName": "restart-reshard", "TargetShardCount": 2}),
+    )
+    .await
+    .unwrap();
+    drop(store);
+
+    let recovered = Store::new(options);
+    wait_for_stream_active(&recovered, "restart-reshard", 2).await;
+}
+
+#[tokio::test]
+async fn durable_store_resumes_start_encryption_transition_after_restart() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+    create_active_stream(&store, "restart-start-encryption").await;
+
+    dispatch(
+        &store,
+        Operation::StartStreamEncryption,
+        json!({
+            "StreamName": "restart-start-encryption",
+            "EncryptionType": "KMS",
+            "KeyId": "key-123",
+        }),
+    )
+    .await
+    .unwrap();
+    drop(store);
+
+    let recovered = Store::new(options);
+    wait_for_stream_active(&recovered, "restart-start-encryption", 1).await;
+    let stream = recovered
+        .get_stream("restart-start-encryption")
+        .await
+        .unwrap();
+    assert_eq!(stream.encryption_type, EncryptionType::Kms);
+}
+
+#[tokio::test]
+async fn durable_store_resumes_stop_encryption_transition_after_restart() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+    create_active_stream(&store, "restart-stop-encryption").await;
+
+    dispatch(
+        &store,
+        Operation::StartStreamEncryption,
+        json!({
+            "StreamName": "restart-stop-encryption",
+            "EncryptionType": "KMS",
+            "KeyId": "key-123",
+        }),
+    )
+    .await
+    .unwrap();
+    wait_for_stream_active(&store, "restart-stop-encryption", 1).await;
+
+    dispatch(
+        &store,
+        Operation::StopStreamEncryption,
+        json!({
+            "StreamName": "restart-stop-encryption",
+            "EncryptionType": "KMS",
+        }),
+    )
+    .await
+    .unwrap();
+    drop(store);
+
+    let recovered = Store::new(options);
+    wait_for_stream_active(&recovered, "restart-stop-encryption", 1).await;
+    let stream = recovered
+        .get_stream("restart-stop-encryption")
+        .await
+        .unwrap();
+    assert_eq!(stream.encryption_type, EncryptionType::None);
+    assert!(stream.key_id.is_none());
+}
+
+#[tokio::test]
+async fn legacy_snapshot_recovers_consumer_creating_without_transition_metadata() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+    let stream_arn = create_active_stream(&store, "legacy-consumer-creating").await;
+    let consumer_arn = register_consumer(&store, &stream_arn, "consumer-a").await;
+    drop(store);
+
+    let snapshot = latest_snapshot_from_wal(dir.path());
+    write_legacy_snapshot(dir.path(), snapshot);
+
+    let recovered = Store::new(options);
+    wait_for_consumer_status(&recovered, &consumer_arn, ConsumerStatus::Active).await;
+}
+
+#[tokio::test]
+async fn legacy_snapshot_recovers_stream_deleting_without_transition_metadata() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+    create_active_stream(&store, "legacy-stream-deleting").await;
+
+    dispatch(
+        &store,
+        Operation::DeleteStream,
+        json!({"StreamName": "legacy-stream-deleting"}),
+    )
+    .await
+    .unwrap();
+    drop(store);
+
+    let snapshot = latest_snapshot_from_wal(dir.path());
+    write_legacy_snapshot(dir.path(), snapshot);
+
+    let recovered = Store::new(options);
+    wait_for_stream_deleted(&recovered, "legacy-stream-deleting").await;
+}
+
+#[tokio::test]
+async fn legacy_snapshot_marks_store_unhealthy_for_ambiguous_stream_transition() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+
+    dispatch(
+        &store,
+        Operation::CreateStream,
+        json!({"StreamName": "legacy-stream-creating", "ShardCount": 1}),
+    )
+    .await
+    .unwrap();
+    drop(store);
+
+    let snapshot = latest_snapshot_from_wal(dir.path());
+    write_legacy_snapshot(dir.path(), snapshot);
+
+    let recovered = Store::new(options);
+    let err = recovered.check_ready().unwrap_err().to_string();
+    assert!(err.contains("ambiguous persisted stream transition"));
+}
+
+#[tokio::test]
+async fn durable_store_rejects_put_record_after_wal_failure_and_rolls_back_state() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options);
+    create_active_stream(&store, "wal-failure").await;
+
+    fs::remove_file(dir.path().join("wal.log")).unwrap();
+    fs::create_dir(dir.path().join("wal.log")).unwrap();
+
+    let err = put_record(&store, "wal-failure", "AAAA", "pk")
+        .await
+        .unwrap_err();
+    assert_eq!(err.status_code, 500);
+    let batch_err = put_records(&store, "wal-failure", &[("QUFBQQ==", "pk-a")])
+        .await
+        .unwrap_err();
+    assert_eq!(batch_err.status_code, 500);
+    assert!(store.check_ready().is_err());
+    assert!(store.get_record_store("wal-failure").await.is_empty());
+}
+
+#[tokio::test]
+async fn durable_store_rejects_subsequent_writes_after_snapshot_failure() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 1);
+    let store = Store::new(options);
+    create_active_stream(&store, "snapshot-failure").await;
+
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    fs::create_dir(dir.path().join("snapshot.bin.tmp")).unwrap();
+
+    put_record(&store, "snapshot-failure", "AAAA", "pk-1")
+        .await
+        .unwrap();
+    assert!(store.check_ready().is_err());
+
+    let err = put_record(&store, "snapshot-failure", "BBBB", "pk-2")
+        .await
+        .unwrap_err();
+    assert_eq!(err.status_code, 500);
+    let batch_err = put_records(&store, "snapshot-failure", &[("QkJCQg==", "pk-a")])
+        .await
+        .unwrap_err();
+    assert_eq!(batch_err.status_code, 500);
+}
+
+#[tokio::test]
+async fn recovered_store_rejects_writes_when_replay_failed() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options.clone());
+    create_active_stream(&store, "replay-failure").await;
+    put_record(&store, "replay-failure", "AAAA", "pk")
+        .await
+        .unwrap();
+    drop(store);
+
+    let mut wal = OpenOptions::new()
+        .append(true)
+        .open(dir.path().join("wal.log"))
+        .unwrap();
+    wal.write_all(&[0xde, 0xad, 0xbe]).unwrap();
+    wal.sync_all().unwrap();
+
+    let recovered = Store::new(options);
+    let err = put_record(&recovered, "replay-failure", "BBBB", "pk-2")
+        .await
+        .unwrap_err();
+    assert_eq!(err.status_code, 500);
+    let batch_err = put_records(&recovered, "replay-failure", &[("QkJCQg==", "pk-a")])
+        .await
+        .unwrap_err();
+    assert_eq!(batch_err.status_code, 500);
+}
+
+#[tokio::test]
+async fn retained_bytes_cap_rejects_put_record_and_put_records_without_growth() {
+    let dir = tempdir().unwrap();
+    let mut options = durable_options(dir.path(), 0);
+    options.max_retained_bytes = Some(10);
+    let store = Store::new(options);
+    create_active_stream(&store, "retained-cap").await;
+
+    let err = put_record(&store, "retained-cap", "QUFBQQ==", "pk")
+        .await
+        .unwrap_err();
+    assert_eq!(err.body.error_type, "LimitExceededException");
+    assert_eq!(store.metrics().retained_bytes(), 0);
+    assert_eq!(store.metrics().retained_records(), 0);
+
+    let err = put_records(
+        &store,
+        "retained-cap",
+        &[("QUFBQQ==", "pk-a"), ("QkJCQg==", "pk-b")],
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.body.error_type, "LimitExceededException");
+    assert_eq!(store.metrics().retained_bytes(), 0);
+    assert_eq!(store.metrics().retained_records(), 0);
+}
+
+#[tokio::test]
+async fn delete_record_keys_uses_actual_deletions_for_metrics() {
+    let store = Store::new(StoreOptions::default());
+    store
+        .put_record(
+            "metrics-delete",
+            "aabbccdd/seq001",
+            &ferrokinesis::types::StoredRecord {
+                partition_key: "pk".to_string(),
+                data: "AAAA".to_string(),
+                approximate_arrival_timestamp: 1.0,
+            },
+        )
+        .await
+        .unwrap();
+
+    store
+        .delete_record_keys(
+            "metrics-delete",
+            &["aabbccdd/seq001".to_string(), "aabbccdd/seq001".to_string()],
+        )
+        .await;
+
+    assert_eq!(store.metrics().retained_records(), 0);
+    assert_eq!(store.metrics().retained_bytes(), 0);
 }

--- a/tests/durable_state.rs
+++ b/tests/durable_state.rs
@@ -42,6 +42,41 @@ async fn create_active_stream(store: &Store, name: &str) -> String {
     panic!("stream {name} did not become ACTIVE");
 }
 
+async fn split_stream(store: &Store, name: &str, shard_id: &str) {
+    let stream = store.get_stream(name).await.unwrap();
+    let shard = stream
+        .shards
+        .iter()
+        .find(|candidate| candidate.shard_id == shard_id)
+        .unwrap();
+    let mid = (shard.hash_key_range.start_u128() + shard.hash_key_range.end_u128()) / 2;
+
+    dispatch(
+        store,
+        Operation::SplitShard,
+        json!({
+            "StreamName": name,
+            "ShardToSplit": shard_id,
+            "NewStartingHashKey": mid.to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+}
+
+async fn request_update_shard_count(store: &Store, name: &str, target_shard_count: u32) {
+    dispatch(
+        store,
+        Operation::UpdateShardCount,
+        json!({
+            "StreamName": name,
+            "TargetShardCount": target_shard_count,
+        }),
+    )
+    .await
+    .unwrap();
+}
+
 async fn wait_for_stream_active(store: &Store, name: &str, min_open_shards: usize) {
     for _ in 0..80 {
         let stream = store.get_stream(name).await.unwrap();
@@ -584,6 +619,58 @@ async fn durable_store_reserves_pending_create_shards_after_restart() {
         Operation::CreateStream,
         json!({
             "StreamName": "pending-second",
+            "ShardCount": 1,
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.body.error_type, "LimitExceededException");
+}
+
+#[tokio::test]
+async fn durable_store_reserves_pending_split_shards_after_restart() {
+    let dir = tempdir().unwrap();
+    let mut options = durable_options(dir.path(), 0);
+    options.update_stream_ms = 500;
+    options.shard_limit = 2;
+
+    let store = Store::new(options.clone());
+    create_active_stream(&store, "pending-split-reserved").await;
+    split_stream(&store, "pending-split-reserved", "shardId-000000000000").await;
+    drop(store);
+
+    let recovered = Store::new(options);
+    let err = dispatch(
+        &recovered,
+        Operation::CreateStream,
+        json!({
+            "StreamName": "blocked-after-split-restart",
+            "ShardCount": 1,
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.body.error_type, "LimitExceededException");
+}
+
+#[tokio::test]
+async fn durable_store_reserves_pending_update_shard_count_after_restart() {
+    let dir = tempdir().unwrap();
+    let mut options = durable_options(dir.path(), 0);
+    options.update_stream_ms = 500;
+    options.shard_limit = 2;
+
+    let store = Store::new(options.clone());
+    create_active_stream(&store, "pending-reshard-reserved").await;
+    request_update_shard_count(&store, "pending-reshard-reserved", 2).await;
+    drop(store);
+
+    let recovered = Store::new(options);
+    let err = dispatch(
+        &recovered,
+        Operation::CreateStream,
+        json!({
+            "StreamName": "blocked-after-reshard-restart",
             "ShardCount": 1,
         }),
     )

--- a/tests/durable_state.rs
+++ b/tests/durable_state.rs
@@ -559,6 +559,40 @@ async fn durable_store_rolls_back_create_stream_when_persistence_fails() {
 }
 
 #[tokio::test]
+async fn durable_store_reserves_pending_create_shards_after_restart() {
+    let dir = tempdir().unwrap();
+    let mut options = durable_options(dir.path(), 0);
+    options.create_stream_ms = 500;
+    options.shard_limit = 1;
+
+    let store = Store::new(options.clone());
+    dispatch(
+        &store,
+        Operation::CreateStream,
+        json!({
+            "StreamName": "pending-reserved",
+            "ShardCount": 1,
+        }),
+    )
+    .await
+    .unwrap();
+    drop(store);
+
+    let recovered = Store::new(options);
+    let err = dispatch(
+        &recovered,
+        Operation::CreateStream,
+        json!({
+            "StreamName": "pending-second",
+            "ShardCount": 1,
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.body.error_type, "LimitExceededException");
+}
+
+#[tokio::test]
 async fn durable_store_rolls_back_delete_stream_when_persistence_fails() {
     let dir = tempdir().unwrap();
     let options = durable_options(dir.path(), 0);

--- a/tests/durable_state.rs
+++ b/tests/durable_state.rs
@@ -1,7 +1,7 @@
 use ferrokinesis::actions::{Operation, dispatch};
 use ferrokinesis::persistence::{Persistence, WalEntry};
 use ferrokinesis::sequence;
-use ferrokinesis::store::{Store, StoreOptions};
+use ferrokinesis::store::{DurableStateOptions, Store, StoreOptions};
 use ferrokinesis::types::{ConsumerStatus, EncryptionType, StoredRecord, StreamStatus};
 use ferrokinesis::util::current_time_ms;
 use serde_json::{Value, json};
@@ -17,8 +17,11 @@ fn durable_options(state_dir: &Path, snapshot_interval_secs: u64) -> StoreOption
         delete_stream_ms: 50,
         update_stream_ms: 50,
         shard_limit: 50,
-        state_dir: Some(state_dir.to_path_buf()),
-        snapshot_interval_secs,
+        durable: Some(DurableStateOptions {
+            state_dir: state_dir.to_path_buf(),
+            snapshot_interval_secs,
+            max_retained_bytes: None,
+        }),
         ..Default::default()
     }
 }
@@ -191,9 +194,10 @@ fn latest_snapshot_from_wal(state_dir: &Path) -> Value {
     let snapshot = entries
         .into_iter()
         .rev()
-        .find_map(|entry| match entry {
-            WalEntry::Snapshot(snapshot) => Some(snapshot),
+        .map(|entry| match entry {
+            WalEntry::Snapshot(snapshot) => snapshot,
         })
+        .next()
         .expect("wal snapshot");
     serde_json::to_value(snapshot).unwrap()
 }
@@ -215,6 +219,16 @@ fn break_wal(state_dir: &Path) {
     let wal_path = state_dir.join("wal.log");
     let _ = fs::remove_file(&wal_path);
     fs::create_dir(&wal_path).unwrap();
+}
+
+fn append_malformed_wal_entry(state_dir: &Path) {
+    let mut wal = OpenOptions::new()
+        .append(true)
+        .open(state_dir.join("wal.log"))
+        .unwrap();
+    wal.write_all(&(3_u64).to_le_bytes()).unwrap();
+    wal.write_all(&[0xde, 0xad, 0xbe]).unwrap();
+    wal.sync_all().unwrap();
 }
 
 async fn insert_backdated_record(store: &Store, stream_name: &str, seq_ix: u64, seq_time: u64) {
@@ -302,6 +316,52 @@ async fn durable_store_restores_from_snapshot_after_restart() {
 }
 
 #[tokio::test]
+async fn durable_store_ignores_truncated_final_wal_entry_after_restart() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let stream_name = "durable-truncated-tail";
+
+    let store = Store::new(options.clone());
+    create_active_stream(&store, stream_name).await;
+    put_record(&store, stream_name, "AAAA", "pk").await.unwrap();
+    store
+        .put_account_settings(&json!({"status": "still-recoverable"}))
+        .await
+        .unwrap();
+    drop(store);
+
+    let wal_path = dir.path().join("wal.log");
+    let wal_bytes = fs::read(&wal_path).unwrap();
+    fs::write(&wal_path, &wal_bytes[..wal_bytes.len() - 3]).unwrap();
+
+    let recovered = Store::new(options);
+    let ready = recovered.check_ready();
+    assert!(ready.is_ok(), "{ready:?}");
+    assert_eq!(recovered.get_record_store(stream_name).await.len(), 1);
+}
+
+#[tokio::test]
+async fn durable_store_recovers_from_empty_wal_after_snapshot_compaction() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 1);
+    let stream_name = "durable-empty-wal-after-snapshot";
+
+    let store = Store::new(options.clone());
+    create_active_stream(&store, stream_name).await;
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    put_record(&store, stream_name, "AAAA", "pk").await.unwrap();
+    drop(store);
+
+    assert!(dir.path().join("snapshot.bin").exists());
+    fs::write(dir.path().join("wal.log"), []).unwrap();
+
+    let recovered = Store::new(options);
+    let ready = recovered.check_ready();
+    assert!(ready.is_ok(), "{ready:?}");
+    assert_eq!(recovered.get_record_store(stream_name).await.len(), 1);
+}
+
+#[tokio::test]
 async fn durable_store_marks_itself_unready_when_wal_is_corrupted() {
     let dir = tempdir().unwrap();
     let options = durable_options(dir.path(), 0);
@@ -312,12 +372,7 @@ async fn durable_store_marks_itself_unready_when_wal_is_corrupted() {
     put_record(&store, stream_name, "AAAA", "pk").await.unwrap();
     drop(store);
 
-    let mut wal = OpenOptions::new()
-        .append(true)
-        .open(dir.path().join("wal.log"))
-        .unwrap();
-    wal.write_all(&[0xde, 0xad, 0xbe]).unwrap();
-    wal.sync_all().unwrap();
+    append_malformed_wal_entry(dir.path());
 
     let recovered = Store::new(options);
     let err = recovered.check_ready().unwrap_err().to_string();
@@ -1045,12 +1100,7 @@ async fn recovered_store_rejects_writes_when_replay_failed() {
         .unwrap();
     drop(store);
 
-    let mut wal = OpenOptions::new()
-        .append(true)
-        .open(dir.path().join("wal.log"))
-        .unwrap();
-    wal.write_all(&[0xde, 0xad, 0xbe]).unwrap();
-    wal.sync_all().unwrap();
+    append_malformed_wal_entry(dir.path());
 
     let recovered = Store::new(options);
     assert!(!recovered.contains_stream("replay-failure").await);

--- a/tests/durable_state.rs
+++ b/tests/durable_state.rs
@@ -1,0 +1,164 @@
+use ferrokinesis::actions::{Operation, dispatch};
+use ferrokinesis::persistence::Persistence;
+use ferrokinesis::store::{Store, StoreOptions};
+use ferrokinesis::types::StreamStatus;
+use serde_json::json;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::time::Duration;
+use tempfile::tempdir;
+
+fn durable_options(state_dir: &Path, snapshot_interval_secs: u64) -> StoreOptions {
+    StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 50,
+        state_dir: Some(state_dir.to_path_buf()),
+        snapshot_interval_secs,
+        ..Default::default()
+    }
+}
+
+async fn create_active_stream(store: &Store, name: &str) {
+    dispatch(
+        store,
+        Operation::CreateStream,
+        json!({
+            "StreamName": name,
+            "ShardCount": 1,
+        }),
+    )
+    .await
+    .unwrap();
+    for _ in 0..50 {
+        let stream = store.get_stream(name).await.unwrap();
+        if stream.stream_status == StreamStatus::Active && !stream.shards.is_empty() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("stream {name} did not become ACTIVE");
+}
+
+async fn put_record(store: &Store, name: &str, data: &str, partition_key: &str) {
+    dispatch(
+        store,
+        Operation::PutRecord,
+        json!({
+            "StreamName": name,
+            "Data": data,
+            "PartitionKey": partition_key,
+        }),
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn durable_store_replays_wal_after_restart() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let stream_name = "durable-wal-replay";
+
+    let store = Store::new(options.clone());
+    create_active_stream(&store, stream_name).await;
+    put_record(&store, stream_name, "AAAA", "pk").await;
+    drop(store);
+
+    let persisted = Persistence::new(dir.path().to_path_buf()).unwrap().load();
+    assert!(persisted.is_ok(), "{persisted:?}");
+
+    let recovered = Store::new(options);
+    let ready = recovered.check_ready();
+    assert!(ready.is_ok(), "{ready:?}");
+
+    let stream = recovered.get_stream(stream_name).await.unwrap();
+    assert_eq!(stream.stream_status, StreamStatus::Active);
+
+    let records = recovered.get_record_store(stream_name).await;
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records.values().next().unwrap().partition_key,
+        "pk",
+        "recovered record should preserve payload metadata"
+    );
+}
+
+#[tokio::test]
+async fn durable_store_restores_from_snapshot_after_restart() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 1);
+    let stream_name = "durable-snapshot-restore";
+
+    let store = Store::new(options.clone());
+    create_active_stream(&store, stream_name).await;
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    put_record(&store, stream_name, "AAAA", "pk").await;
+    drop(store);
+
+    let persisted = Persistence::new(dir.path().to_path_buf()).unwrap().load();
+    assert!(persisted.is_ok(), "{persisted:?}");
+    assert!(dir.path().join("snapshot.bin").exists());
+    assert_eq!(fs::metadata(dir.path().join("wal.log")).unwrap().len(), 0);
+
+    let recovered = Store::new(options);
+    let ready = recovered.check_ready();
+    assert!(ready.is_ok(), "{ready:?}");
+    assert_eq!(recovered.get_record_store(stream_name).await.len(), 1);
+}
+
+#[tokio::test]
+async fn durable_store_marks_itself_unready_when_wal_is_corrupted() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let stream_name = "durable-corrupt-wal";
+
+    let store = Store::new(options.clone());
+    create_active_stream(&store, stream_name).await;
+    put_record(&store, stream_name, "AAAA", "pk").await;
+    drop(store);
+
+    let mut wal = OpenOptions::new()
+        .append(true)
+        .open(dir.path().join("wal.log"))
+        .unwrap();
+    wal.write_all(&[0xde, 0xad, 0xbe]).unwrap();
+    wal.sync_all().unwrap();
+
+    let recovered = Store::new(options);
+    let err = recovered.check_ready().unwrap_err().to_string();
+    assert!(err.contains("wal"));
+}
+
+#[tokio::test]
+async fn durable_store_preserves_internal_stream_fields() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let stream_name = "durable-hidden-fields";
+
+    let store = Store::new(options.clone());
+    create_active_stream(&store, stream_name).await;
+    store
+        .update_stream(stream_name, |stream| {
+            stream.tags.insert("env".to_string(), "prod".to_string());
+            stream.key_id = Some("arn:aws:kms:eu-west-1:123456789012:key/abc".to_string());
+            stream.warm_throughput_mibps = 7;
+            stream.max_record_size_kib = 4096;
+            Ok(())
+        })
+        .await
+        .unwrap();
+    drop(store);
+
+    let recovered = Store::new(options);
+    let stream = recovered.get_stream(stream_name).await.unwrap();
+    assert_eq!(stream.tags.get("env").map(String::as_str), Some("prod"));
+    assert_eq!(
+        stream.key_id.as_deref(),
+        Some("arn:aws:kms:eu-west-1:123456789012:key/abc")
+    );
+    assert_eq!(stream.warm_throughput_mibps, 7);
+    assert_eq!(stream.max_record_size_kib, 4096);
+}

--- a/tests/durable_state.rs
+++ b/tests/durable_state.rs
@@ -174,6 +174,12 @@ fn write_legacy_snapshot(state_dir: &Path, mut snapshot: Value) {
     fs::write(state_dir.join("wal.log"), []).unwrap();
 }
 
+fn break_wal(state_dir: &Path) {
+    let wal_path = state_dir.join("wal.log");
+    let _ = fs::remove_file(&wal_path);
+    fs::create_dir(&wal_path).unwrap();
+}
+
 #[tokio::test]
 async fn durable_store_replays_wal_after_restart() {
     let dir = tempdir().unwrap();
@@ -528,6 +534,104 @@ async fn durable_store_rejects_put_record_after_wal_failure_and_rolls_back_state
     assert_eq!(batch_err.status_code, 500);
     assert!(store.check_ready().is_err());
     assert!(store.get_record_store("wal-failure").await.is_empty());
+}
+
+#[tokio::test]
+async fn durable_store_rolls_back_create_stream_when_persistence_fails() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options);
+
+    break_wal(dir.path());
+
+    let err = dispatch(
+        &store,
+        Operation::CreateStream,
+        json!({
+            "StreamName": "create-rollback",
+            "ShardCount": 1,
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.status_code, 500);
+    assert!(!store.contains_stream("create-rollback").await);
+}
+
+#[tokio::test]
+async fn durable_store_rolls_back_delete_stream_when_persistence_fails() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options);
+    create_active_stream(&store, "delete-rollback").await;
+
+    break_wal(dir.path());
+
+    let err = dispatch(
+        &store,
+        Operation::DeleteStream,
+        json!({
+            "StreamName": "delete-rollback",
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.status_code, 500);
+
+    let stream = store.get_stream("delete-rollback").await.unwrap();
+    assert_eq!(stream.stream_status, StreamStatus::Active);
+}
+
+#[tokio::test]
+async fn durable_store_rolls_back_register_consumer_when_persistence_fails() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options);
+    let stream_arn = create_active_stream(&store, "consumer-rollback").await;
+
+    break_wal(dir.path());
+
+    let err = dispatch(
+        &store,
+        Operation::RegisterStreamConsumer,
+        json!({
+            "StreamARN": stream_arn,
+            "ConsumerName": "consumer-a",
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.status_code, 500);
+    assert!(
+        store
+            .list_consumers_for_stream(&stream_arn)
+            .await
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn durable_store_rolls_back_account_settings_when_persistence_fails() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options);
+
+    break_wal(dir.path());
+
+    let err = dispatch(
+        &store,
+        Operation::UpdateAccountSettings,
+        json!({
+            "MinimumThroughputBillingCommitment": {
+                "Status": "ACTIVE",
+                "CommitmentDuration": "P30D"
+            }
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.status_code, 500);
+    assert_eq!(store.get_account_settings().await, json!({}));
 }
 
 #[tokio::test]

--- a/tests/durable_state.rs
+++ b/tests/durable_state.rs
@@ -208,7 +208,7 @@ fn write_legacy_snapshot(state_dir: &Path, mut snapshot: Value) {
         serde_json::to_vec(&snapshot).unwrap(),
     )
     .unwrap();
-    fs::write(state_dir.join("wal.log"), []).unwrap();
+    fs::write(state_dir.join("wal.log"), b"FKWALv2\n").unwrap();
 }
 
 fn break_wal(state_dir: &Path) {
@@ -293,7 +293,7 @@ async fn durable_store_restores_from_snapshot_after_restart() {
     let persisted = Persistence::new(dir.path().to_path_buf()).unwrap().load();
     assert!(persisted.is_ok(), "{persisted:?}");
     assert!(dir.path().join("snapshot.bin").exists());
-    assert_eq!(fs::metadata(dir.path().join("wal.log")).unwrap().len(), 0);
+    assert_eq!(fs::metadata(dir.path().join("wal.log")).unwrap().len(), 8);
 
     let recovered = Store::new(options);
     let ready = recovered.check_ready();
@@ -1053,6 +1053,13 @@ async fn recovered_store_rejects_writes_when_replay_failed() {
     wal.sync_all().unwrap();
 
     let recovered = Store::new(options);
+    assert!(!recovered.contains_stream("replay-failure").await);
+
+    let read_err = dispatch(&recovered, Operation::ListStreams, json!({}))
+        .await
+        .unwrap_err();
+    assert_eq!(read_err.status_code, 500);
+
     let err = put_record(&recovered, "replay-failure", "BBBB", "pk-2")
         .await
         .unwrap_err();
@@ -1088,6 +1095,97 @@ async fn retained_bytes_cap_rejects_put_record_and_put_records_without_growth() 
     assert_eq!(err.body.error_type, "LimitExceededException");
     assert_eq!(store.metrics().retained_bytes(), 0);
     assert_eq!(store.metrics().retained_records(), 0);
+}
+
+#[tokio::test]
+async fn put_record_refunds_throughput_when_retained_cap_rejects_write() {
+    let store = Store::new(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 50,
+        enforce_limits: true,
+        max_retained_bytes: Some(0),
+        ..StoreOptions::default()
+    });
+    create_active_stream(&store, "throughput-refund-retained").await;
+
+    let anchor_ms = current_time_ms();
+    let err = put_record(&store, "throughput-refund-retained", "QUFBQQ==", "pk")
+        .await
+        .unwrap_err();
+    assert_eq!(err.body.error_type, "LimitExceededException");
+
+    store
+        .try_reserve_shard_throughput(
+            "throughput-refund-retained",
+            "shardId-000000000000",
+            1_048_576,
+            anchor_ms,
+        )
+        .await
+        .expect("failed PutRecord should refund shard throughput");
+}
+
+#[tokio::test]
+async fn put_record_refunds_throughput_when_persistence_fails() {
+    let dir = tempdir().unwrap();
+    let mut options = durable_options(dir.path(), 0);
+    options.enforce_limits = true;
+    let store = Store::new(options);
+    create_active_stream(&store, "throughput-refund-persistence").await;
+
+    break_wal(dir.path());
+
+    let anchor_ms = current_time_ms();
+    let err = put_record(&store, "throughput-refund-persistence", "QUFBQQ==", "pk")
+        .await
+        .unwrap_err();
+    assert_eq!(err.status_code, 500);
+
+    store
+        .try_reserve_shard_throughput(
+            "throughput-refund-persistence",
+            "shardId-000000000000",
+            1_048_576,
+            anchor_ms,
+        )
+        .await
+        .expect("persistence rollback should refund shard throughput");
+}
+
+#[tokio::test]
+async fn put_records_refunds_throughput_when_batch_rolls_back() {
+    let store = Store::new(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 50,
+        enforce_limits: true,
+        max_retained_bytes: Some(0),
+        ..StoreOptions::default()
+    });
+    create_active_stream(&store, "throughput-refund-batch").await;
+
+    let anchor_ms = current_time_ms();
+    let err = put_records(
+        &store,
+        "throughput-refund-batch",
+        &[("QUFBQQ==", "pk-a"), ("QkJCQg==", "pk-b")],
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.body.error_type, "LimitExceededException");
+
+    store
+        .try_reserve_shard_throughput(
+            "throughput-refund-batch",
+            "shardId-000000000000",
+            1_048_576,
+            anchor_ms,
+        )
+        .await
+        .expect("failed PutRecords batch should refund shard throughput");
 }
 
 #[tokio::test]

--- a/tests/durable_state.rs
+++ b/tests/durable_state.rs
@@ -931,6 +931,110 @@ async fn durable_store_rejects_subsequent_writes_after_snapshot_failure() {
 }
 
 #[tokio::test]
+async fn durable_store_skips_delete_record_keys_after_snapshot_failure() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 1);
+    let store = Store::new(options.clone());
+
+    store
+        .put_record(
+            "delete-keys-snapshot-failure",
+            "aabbccdd/seq001",
+            &StoredRecord {
+                partition_key: "pk-1".to_string(),
+                data: "AAAA".to_string(),
+                approximate_arrival_timestamp: 1.0,
+            },
+        )
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    fs::create_dir(dir.path().join("snapshot.bin.tmp")).unwrap();
+
+    store
+        .put_record(
+            "delete-keys-snapshot-failure",
+            "aabbccdd/seq002",
+            &StoredRecord {
+                partition_key: "pk-2".to_string(),
+                data: "BBBB".to_string(),
+                approximate_arrival_timestamp: 2.0,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(store.check_ready().is_err());
+
+    store
+        .delete_record_keys(
+            "delete-keys-snapshot-failure",
+            &["aabbccdd/seq001".to_string()],
+        )
+        .await;
+
+    assert_eq!(
+        store
+            .get_record_store("delete-keys-snapshot-failure")
+            .await
+            .len(),
+        2
+    );
+    drop(store);
+
+    let recovered = Store::new(options);
+    assert_eq!(
+        recovered
+            .get_record_store("delete-keys-snapshot-failure")
+            .await
+            .len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn durable_store_skips_delete_expired_records_after_snapshot_failure() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 1);
+    let store = Store::new(options.clone());
+    create_active_stream(&store, "expired-snapshot-failure").await;
+
+    let expired_time = current_time_ms() - 25 * 60 * 60 * 1000;
+    insert_backdated_record(&store, "expired-snapshot-failure", 1, expired_time).await;
+
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    fs::create_dir(dir.path().join("snapshot.bin.tmp")).unwrap();
+
+    put_record(&store, "expired-snapshot-failure", "AAAA", "pk-current")
+        .await
+        .unwrap();
+    assert!(store.check_ready().is_err());
+
+    let deleted = store
+        .delete_expired_records("expired-snapshot-failure", 24)
+        .await;
+
+    assert_eq!(deleted, 0);
+    assert_eq!(
+        store
+            .get_record_store("expired-snapshot-failure")
+            .await
+            .len(),
+        2
+    );
+    drop(store);
+
+    let recovered = Store::new(options);
+    assert_eq!(
+        recovered
+            .get_record_store("expired-snapshot-failure")
+            .await
+            .len(),
+        2
+    );
+}
+
+#[tokio::test]
 async fn recovered_store_rejects_writes_when_replay_failed() {
     let dir = tempdir().unwrap();
     let options = durable_options(dir.path(), 0);

--- a/tests/durable_state.rs
+++ b/tests/durable_state.rs
@@ -1,7 +1,9 @@
 use ferrokinesis::actions::{Operation, dispatch};
 use ferrokinesis::persistence::{Persistence, WalEntry};
+use ferrokinesis::sequence;
 use ferrokinesis::store::{Store, StoreOptions};
-use ferrokinesis::types::{ConsumerStatus, EncryptionType, StreamStatus};
+use ferrokinesis::types::{ConsumerStatus, EncryptionType, StoredRecord, StreamStatus};
+use ferrokinesis::util::current_time_ms;
 use serde_json::{Value, json};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
@@ -213,6 +215,37 @@ fn break_wal(state_dir: &Path) {
     let wal_path = state_dir.join("wal.log");
     let _ = fs::remove_file(&wal_path);
     fs::create_dir(&wal_path).unwrap();
+}
+
+async fn insert_backdated_record(store: &Store, stream_name: &str, seq_ix: u64, seq_time: u64) {
+    let stream = store.get_stream(stream_name).await.unwrap();
+    let shard = &stream.shards[0];
+    let shard_create_time =
+        sequence::parse_sequence(&shard.sequence_number_range.starting_sequence_number)
+            .unwrap()
+            .shard_create_time;
+    let seq = sequence::stringify_sequence(&sequence::SeqObj {
+        shard_create_time,
+        seq_ix: Some(seq_ix),
+        seq_time: Some(seq_time),
+        shard_ix: 0,
+        byte1: None,
+        seq_rand: None,
+        version: 2,
+    });
+    let key = format!("{}/{}", sequence::shard_ix_to_hex(0), seq);
+    store
+        .put_record(
+            stream_name,
+            &key,
+            &StoredRecord {
+                partition_key: format!("pk-{seq_ix}"),
+                data: "AAAA".to_string(),
+                approximate_arrival_timestamp: (seq_time / 1000) as f64,
+            },
+        )
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -488,6 +521,65 @@ async fn durable_store_resumes_stop_encryption_transition_after_restart() {
 }
 
 #[tokio::test]
+async fn superseded_create_stream_transition_does_not_poison_store() {
+    let dir = tempdir().unwrap();
+    let mut options = durable_options(dir.path(), 0);
+    options.create_stream_ms = 100;
+    options.delete_stream_ms = 100;
+    let store = Store::new(options);
+
+    create_active_stream(&store, "steady-stream").await;
+
+    dispatch(
+        &store,
+        Operation::CreateStream,
+        json!({
+            "StreamName": "race-delete",
+            "ShardCount": 1,
+        }),
+    )
+    .await
+    .unwrap();
+    dispatch(
+        &store,
+        Operation::DeleteStream,
+        json!({
+            "StreamName": "race-delete",
+        }),
+    )
+    .await
+    .unwrap();
+
+    wait_for_stream_deleted(&store, "race-delete").await;
+    assert!(store.check_ready().is_ok());
+    put_record(&store, "steady-stream", "AAAA", "pk")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn superseded_register_consumer_transition_does_not_poison_store() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options);
+    let stream_arn = create_active_stream(&store, "consumer-race").await;
+
+    let consumer_arn = register_consumer(&store, &stream_arn, "consumer-a").await;
+    dispatch(
+        &store,
+        Operation::DeregisterStreamConsumer,
+        json!({
+            "ConsumerARN": consumer_arn,
+        }),
+    )
+    .await
+    .unwrap();
+
+    wait_for_consumer_deleted(&store, &consumer_arn).await;
+    assert!(store.check_ready().is_ok());
+}
+
+#[tokio::test]
 async fn legacy_snapshot_recovers_consumer_creating_without_transition_metadata() {
     let dir = tempdir().unwrap();
     let options = durable_options(dir.path(), 0);
@@ -753,6 +845,64 @@ async fn durable_store_rolls_back_account_settings_when_persistence_fails() {
     .unwrap_err();
     assert_eq!(err.status_code, 500);
     assert_eq!(store.get_account_settings().await, json!({}));
+}
+
+#[tokio::test]
+async fn durable_store_rolls_back_delete_record_keys_when_persistence_fails() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options);
+    store
+        .put_record(
+            "delete-keys-rollback",
+            "aabbccdd/seq001",
+            &StoredRecord {
+                partition_key: "pk".to_string(),
+                data: "AAAA".to_string(),
+                approximate_arrival_timestamp: 1.0,
+            },
+        )
+        .await
+        .unwrap();
+
+    let expected_bytes = store.metrics().retained_bytes();
+    let expected_records = store.metrics().retained_records();
+    break_wal(dir.path());
+
+    store
+        .delete_record_keys("delete-keys-rollback", &["aabbccdd/seq001".to_string()])
+        .await;
+
+    assert_eq!(
+        store.get_record_store("delete-keys-rollback").await.len(),
+        1
+    );
+    assert_eq!(store.metrics().retained_bytes(), expected_bytes);
+    assert_eq!(store.metrics().retained_records(), expected_records);
+    assert!(store.check_ready().is_err());
+}
+
+#[tokio::test]
+async fn durable_store_rolls_back_delete_expired_records_when_persistence_fails() {
+    let dir = tempdir().unwrap();
+    let options = durable_options(dir.path(), 0);
+    let store = Store::new(options);
+    create_active_stream(&store, "expired-rollback").await;
+
+    let expired_time = current_time_ms() - 25 * 60 * 60 * 1000;
+    insert_backdated_record(&store, "expired-rollback", 1, expired_time).await;
+
+    let expected_bytes = store.metrics().retained_bytes();
+    let expected_records = store.metrics().retained_records();
+    break_wal(dir.path());
+
+    let deleted = store.delete_expired_records("expired-rollback", 24).await;
+
+    assert_eq!(deleted, 0);
+    assert_eq!(store.get_record_store("expired-rollback").await.len(), 1);
+    assert_eq!(store.metrics().retained_bytes(), expected_bytes);
+    assert_eq!(store.metrics().retained_records(), expected_records);
+    assert!(store.check_ready().is_err());
 }
 
 #[tokio::test]

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::*;
-use ferrokinesis::store::StoreOptions;
+use ferrokinesis::store::{DurableStateOptions, StoreOptions};
 use reqwest::Method;
 use reqwest::header::HeaderMap;
 use serde_json::{Value, json};
@@ -110,7 +110,11 @@ async fn health_ready_returns_503_when_durable_state_fails_to_initialize() {
         delete_stream_ms: 0,
         update_stream_ms: 0,
         shard_limit: 50,
-        state_dir: Some(state_file.path().to_path_buf()),
+        durable: Some(DurableStateOptions {
+            state_dir: state_file.path().to_path_buf(),
+            snapshot_interval_secs: 0,
+            max_retained_bytes: None,
+        }),
         ..Default::default()
     })
     .await;
@@ -160,6 +164,36 @@ async fn health_ready_returns_503_when_durable_state_fails_to_initialize() {
             .contains_stream("blocked-during-durable-init-failure")
             .await
     );
+
+    let mut headers = HeaderMap::new();
+    headers.insert("Content-Type", AMZ_JSON.parse().unwrap());
+    headers.insert(
+        "X-Amz-Target",
+        format!("{VERSION}.CreateStream").parse().unwrap(),
+    );
+    let (status, body) = decode_body(
+        server
+            .raw_request(
+                Method::POST,
+                "/",
+                headers,
+                serde_json::to_vec(&json!({
+                    "StreamName": "blocked-before-auth-check",
+                    "ShardCount": 1,
+                }))
+                .unwrap(),
+            )
+            .await,
+    )
+    .await;
+    assert_eq!(status, 500);
+    assert_eq!(body["__type"], "InternalFailure");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap()
+            .contains("failed to initialize durable state")
+    );
 }
 
 #[tokio::test]
@@ -201,6 +235,100 @@ async fn metrics_count_known_operation_failures_before_dispatch() {
         .unwrap();
     assert!(
         body.contains("ferrokinesis_requests_total{operation=\"CreateStream\",result=\"error\"} 1")
+    );
+}
+
+#[tokio::test]
+async fn metrics_count_known_operation_auth_and_signature_failures() {
+    let server = TestServer::new().await;
+
+    let mut missing_auth_headers = HeaderMap::new();
+    missing_auth_headers.insert("Content-Type", AMZ_JSON.parse().unwrap());
+    missing_auth_headers.insert(
+        "X-Amz-Target",
+        format!("{VERSION}.CreateStream").parse().unwrap(),
+    );
+
+    let mut invalid_signature_headers = missing_auth_headers.clone();
+    invalid_signature_headers.insert(
+        "Authorization",
+        "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=abcd1234"
+            .parse()
+            .unwrap(),
+    );
+    invalid_signature_headers.insert("X-Amz-Date", "20150101T000000Z".parse().unwrap());
+
+    let mut incomplete_signature_headers = missing_auth_headers.clone();
+    incomplete_signature_headers.insert(
+        "Authorization",
+        "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target"
+            .parse()
+            .unwrap(),
+    );
+    incomplete_signature_headers.insert("X-Amz-Date", "20150101T000000Z".parse().unwrap());
+
+    assert_eq!(
+        server
+            .raw_request(
+                Method::POST,
+                "/",
+                missing_auth_headers,
+                serde_json::to_vec(&json!({
+                    "StreamName": "metrics-missing-auth",
+                    "ShardCount": 1,
+                }))
+                .unwrap(),
+            )
+            .await
+            .status(),
+        400
+    );
+    assert_eq!(
+        server
+            .raw_request(
+                Method::POST,
+                "/?X-Amz-Algorithm=AWS4-HMAC-SHA256",
+                invalid_signature_headers,
+                serde_json::to_vec(&json!({
+                    "StreamName": "metrics-invalid-signature",
+                    "ShardCount": 1,
+                }))
+                .unwrap(),
+            )
+            .await
+            .status(),
+        400
+    );
+    assert_eq!(
+        server
+            .raw_request(
+                Method::POST,
+                "/",
+                incomplete_signature_headers,
+                serde_json::to_vec(&json!({
+                    "StreamName": "metrics-incomplete-signature",
+                    "ShardCount": 1,
+                }))
+                .unwrap(),
+            )
+            .await
+            .status(),
+        403
+    );
+
+    let body = server
+        .raw_request(Method::GET, "/metrics", HeaderMap::new(), vec![])
+        .await
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        body.contains("ferrokinesis_requests_total{operation=\"CreateStream\",result=\"error\"} 3")
+    );
+    assert!(body.contains("ferrokinesis_request_failures_total{reason=\"missing_auth_token\"} 1"));
+    assert!(body.contains("ferrokinesis_request_failures_total{reason=\"invalid_signature\"} 1"));
+    assert!(
+        body.contains("ferrokinesis_request_failures_total{reason=\"incomplete_signature\"} 1")
     );
 }
 

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -133,4 +133,31 @@ async fn health_ready_returns_503_when_durable_state_fails_to_initialize() {
             .unwrap()
             .contains("failed to initialize durable state")
     );
+
+    let (status, body) = decode_body(
+        server
+            .request(
+                "CreateStream",
+                &serde_json::json!({
+                    "StreamName": "blocked-during-durable-init-failure",
+                    "ShardCount": 1,
+                }),
+            )
+            .await,
+    )
+    .await;
+    assert_eq!(status, 500);
+    assert_eq!(body["__type"], "InternalFailure");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap()
+            .contains("failed to initialize durable state")
+    );
+    assert!(
+        !server
+            .store
+            .contains_stream("blocked-during-durable-init-failure")
+            .await
+    );
 }

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -1,9 +1,11 @@
 mod common;
 
 use common::*;
+use ferrokinesis::store::StoreOptions;
 use reqwest::Method;
 use reqwest::header::HeaderMap;
 use serde_json::Value;
+use tempfile::NamedTempFile;
 
 #[tokio::test]
 async fn health_returns_200_with_json() {
@@ -59,4 +61,76 @@ async fn post_health_returns_method_not_allowed() {
         .raw_request(Method::POST, "/_health", HeaderMap::new(), vec![])
         .await;
     assert_eq!(res.status(), 405);
+}
+
+#[tokio::test]
+async fn metrics_returns_prometheus_text_with_runtime_counters() {
+    let server = TestServer::new().await;
+    let name = "metrics-runtime";
+    server.create_stream(name, 1).await;
+    server.put_record(name, "AAAA", "pk").await;
+
+    let desc = server.describe_stream(name).await;
+    let shard_id = desc["StreamDescription"]["Shards"][0]["ShardId"]
+        .as_str()
+        .unwrap();
+    let _ = server.get_shard_iterator(name, shard_id, "LATEST").await;
+
+    let res = server
+        .raw_request(Method::GET, "/metrics", HeaderMap::new(), vec![])
+        .await;
+    assert_eq!(res.status(), 200);
+    assert_eq!(
+        res.headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("text/plain; version=0.0.4; charset=utf-8")
+    );
+
+    let body = res.text().await.unwrap();
+    assert!(body.contains("ferrokinesis_retained_records 1"));
+    assert!(body.contains("ferrokinesis_streams 1"));
+    assert!(body.contains("ferrokinesis_active_iterators 1"));
+    assert!(
+        body.contains("ferrokinesis_requests_total{operation=\"CreateStream\",result=\"ok\"} 1")
+    );
+    assert!(body.contains("ferrokinesis_requests_total{operation=\"PutRecord\",result=\"ok\"} 1"));
+    assert!(
+        body.contains(
+            "ferrokinesis_requests_total{operation=\"GetShardIterator\",result=\"ok\"} 1"
+        )
+    );
+}
+
+#[tokio::test]
+async fn health_ready_returns_503_when_durable_state_fails_to_initialize() {
+    let state_file = NamedTempFile::new().unwrap();
+    let server = TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 50,
+        state_dir: Some(state_file.path().to_path_buf()),
+        ..Default::default()
+    })
+    .await;
+
+    let ready = server
+        .raw_request(Method::GET, "/_health/ready", HeaderMap::new(), vec![])
+        .await;
+    assert_eq!(ready.status(), 503);
+    assert_eq!(ready.text().await.unwrap(), "Service Unavailable");
+
+    let health = server
+        .raw_request(Method::GET, "/_health", HeaderMap::new(), vec![])
+        .await;
+    assert_eq!(health.status(), 503);
+    let body: Value = health.json().await.unwrap();
+    assert_eq!(body["status"], "DOWN");
+    assert!(
+        body["components"]["store"]["detail"]
+            .as_str()
+            .unwrap()
+            .contains("failed to initialize durable state")
+    );
 }

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -4,7 +4,7 @@ use common::*;
 use ferrokinesis::store::StoreOptions;
 use reqwest::Method;
 use reqwest::header::HeaderMap;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tempfile::NamedTempFile;
 
 #[tokio::test]
@@ -160,4 +160,120 @@ async fn health_ready_returns_503_when_durable_state_fails_to_initialize() {
             .contains_stream("blocked-during-durable-init-failure")
             .await
     );
+}
+
+#[tokio::test]
+async fn metrics_count_known_operation_failures_before_dispatch() {
+    let server = TestServer::new().await;
+    let mut headers = HeaderMap::new();
+    headers.insert("Content-Type", AMZ_JSON.parse().unwrap());
+    headers.insert(
+        "X-Amz-Target",
+        format!("{VERSION}.CreateStream").parse().unwrap(),
+    );
+    headers.insert(
+        "Authorization",
+        "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=abcd1234"
+            .parse()
+            .unwrap(),
+    );
+    headers.insert("X-Amz-Date", "20150101T000000Z".parse().unwrap());
+
+    let res = server
+        .raw_request(
+            Method::POST,
+            "/",
+            headers,
+            serde_json::to_vec(&json!({
+                "StreamName": "metrics-invalid-create",
+                "ShardCount": "not-a-number",
+            }))
+            .unwrap(),
+        )
+        .await;
+    assert_eq!(res.status(), 400);
+
+    let body = server
+        .raw_request(Method::GET, "/metrics", HeaderMap::new(), vec![])
+        .await
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        body.contains("ferrokinesis_requests_total{operation=\"CreateStream\",result=\"error\"} 1")
+    );
+}
+
+#[tokio::test]
+async fn metrics_count_failures_without_parsed_operation_separately() {
+    let server = TestServer::new().await;
+    let mut headers = HeaderMap::new();
+    headers.insert("Content-Type", AMZ_JSON.parse().unwrap());
+    headers.insert(
+        "X-Amz-Target",
+        format!("{VERSION}.NoSuchOperation").parse().unwrap(),
+    );
+    headers.insert(
+        "Authorization",
+        "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=abcd1234"
+            .parse()
+            .unwrap(),
+    );
+    headers.insert("X-Amz-Date", "20150101T000000Z".parse().unwrap());
+
+    let res = server
+        .raw_request(Method::POST, "/", headers, b"{}".to_vec())
+        .await;
+    assert_eq!(res.status(), 400);
+
+    let body = server
+        .raw_request(Method::GET, "/metrics", HeaderMap::new(), vec![])
+        .await
+        .text()
+        .await
+        .unwrap();
+    assert!(body.contains("ferrokinesis_request_failures_total{reason=\"unknown_operation\"} 1"));
+}
+
+#[tokio::test]
+async fn readiness_stays_up_when_retained_byte_backpressure_is_hit() {
+    let server = TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 50,
+        max_retained_bytes: Some(1),
+        ..Default::default()
+    })
+    .await;
+    let name = "retained-ready";
+    server.create_stream(name, 1).await;
+    server.store.metrics().set_retained(2, 1);
+
+    let ready = server
+        .raw_request(Method::GET, "/_health/ready", HeaderMap::new(), vec![])
+        .await;
+    assert_eq!(ready.status(), 200);
+    assert_eq!(ready.text().await.unwrap(), "OK");
+
+    let health = server
+        .raw_request(Method::GET, "/_health", HeaderMap::new(), vec![])
+        .await;
+    assert_eq!(health.status(), 200);
+
+    let (status, body) = decode_body(
+        server
+            .request(
+                "PutRecord",
+                &json!({
+                    "StreamName": name,
+                    "Data": "AAAA",
+                    "PartitionKey": "pk",
+                }),
+            )
+            .await,
+    )
+    .await;
+    assert_eq!(status, 400);
+    assert_eq!(body["__type"], "LimitExceededException");
 }

--- a/tests/split_merge_shards.rs
+++ b/tests/split_merge_shards.rs
@@ -4,6 +4,21 @@ use common::*;
 use ferrokinesis::store::StoreOptions;
 use serde_json::{Value, json};
 
+fn shard_midpoint(desc: &Value, shard_index: usize) -> String {
+    let shard = &desc["StreamDescription"]["Shards"][shard_index];
+    let start: u128 = shard["HashKeyRange"]["StartingHashKey"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    let end: u128 = shard["HashKeyRange"]["EndingHashKey"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    ((start + end) / 2).to_string()
+}
+
 // -- SplitShard --
 
 #[tokio::test]
@@ -187,6 +202,87 @@ async fn split_shard_limit_exceeded() {
     assert_eq!(res.status(), 400);
     let body: Value = res.json().await.unwrap();
     assert_eq!(body["__type"], "LimitExceededException");
+}
+
+#[tokio::test]
+async fn pending_split_reservation_blocks_create_stream() {
+    let server = TestServer::with_options(StoreOptions {
+        create_stream_ms: 200,
+        delete_stream_ms: 0,
+        update_stream_ms: 200,
+        shard_limit: 2,
+        ..Default::default()
+    })
+    .await;
+
+    let name = "split-pending-blocks-create";
+    server.create_stream(name, 1).await;
+
+    let desc = server.describe_stream(name).await;
+    let mid = shard_midpoint(&desc, 0);
+
+    let split = server
+        .request(
+            "SplitShard",
+            &json!({
+                "StreamName": name,
+                "ShardToSplit": "shardId-000000000000",
+                "NewStartingHashKey": mid,
+            }),
+        )
+        .await;
+    assert_eq!(split.status(), 200);
+
+    let create = server
+        .request(
+            "CreateStream",
+            &json!({
+                "StreamName": "blocked-by-pending-split",
+                "ShardCount": 1,
+            }),
+        )
+        .await;
+    assert_eq!(create.status(), 400);
+    let body: Value = create.json().await.unwrap();
+    assert_eq!(body["__type"], "LimitExceededException");
+}
+
+#[tokio::test]
+async fn concurrent_split_and_create_do_not_oversubscribe_shard_limit() {
+    let server = TestServer::with_options(StoreOptions {
+        create_stream_ms: 200,
+        delete_stream_ms: 0,
+        update_stream_ms: 200,
+        shard_limit: 2,
+        ..Default::default()
+    })
+    .await;
+
+    let name = "split-create-concurrent-limit";
+    server.create_stream(name, 1).await;
+
+    let desc = server.describe_stream(name).await;
+    let mid = shard_midpoint(&desc, 0);
+    let split_body = json!({
+        "StreamName": name,
+        "ShardToSplit": "shardId-000000000000",
+        "NewStartingHashKey": mid,
+    });
+    let create_body = json!({
+        "StreamName": "concurrent-created-stream",
+        "ShardCount": 1,
+    });
+
+    let (split_res, create_res) = tokio::join!(
+        server.request("SplitShard", &split_body),
+        server.request("CreateStream", &create_body),
+    );
+
+    let codes = [split_res.status().as_u16(), create_res.status().as_u16()];
+    let success = codes.iter().filter(|&&code| code == 200).count();
+    let limit = codes.iter().filter(|&&code| code == 400).count();
+    assert_eq!(success, 1, "expected exactly one success: {codes:?}");
+    assert_eq!(limit, 1, "expected exactly one limit failure: {codes:?}");
 }
 
 // -- MergeShards --

--- a/tests/stream_updates.rs
+++ b/tests/stream_updates.rs
@@ -470,6 +470,92 @@ async fn update_shard_count_clears_closed_shard_throughput_windows() {
 }
 
 #[tokio::test]
+async fn update_shard_count_scale_up_respects_pending_expansion_reservation() {
+    let server = TestServer::with_options(StoreOptions {
+        create_stream_ms: 200,
+        delete_stream_ms: 0,
+        update_stream_ms: 200,
+        shard_limit: 4,
+        ..Default::default()
+    })
+    .await;
+    let name = "usc-scale-up-pending-cap";
+    server.create_stream(name, 2).await;
+
+    let create = server
+        .request(
+            "CreateStream",
+            &json!({
+                "StreamName": "pending-create-cap",
+                "ShardCount": 2,
+            }),
+        )
+        .await;
+    assert_eq!(create.status(), 200);
+
+    let res = server
+        .request(
+            "UpdateShardCount",
+            &json!({
+                "StreamName": name,
+                "TargetShardCount": 3,
+                "ScalingType": "UNIFORM_SCALING",
+            }),
+        )
+        .await;
+    assert_eq!(res.status(), 400);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["__type"], "LimitExceededException");
+}
+
+#[tokio::test]
+async fn update_shard_count_scale_down_ignores_pending_expansion_reservation() {
+    let server = TestServer::with_options(StoreOptions {
+        create_stream_ms: 200,
+        delete_stream_ms: 0,
+        update_stream_ms: 200,
+        shard_limit: 4,
+        ..Default::default()
+    })
+    .await;
+    let name = "usc-scale-down-pending-cap";
+    server.create_stream(name, 2).await;
+
+    let create = server
+        .request(
+            "CreateStream",
+            &json!({
+                "StreamName": "pending-create-allows-scale-down",
+                "ShardCount": 2,
+            }),
+        )
+        .await;
+    assert_eq!(create.status(), 200);
+
+    let res = server
+        .request(
+            "UpdateShardCount",
+            &json!({
+                "StreamName": name,
+                "TargetShardCount": 1,
+                "ScalingType": "UNIFORM_SCALING",
+            }),
+        )
+        .await;
+    assert_eq!(res.status(), 200);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+
+    let desc = server.describe_stream(name).await;
+    let shards = desc["StreamDescription"]["Shards"].as_array().unwrap();
+    let open_count = shards
+        .iter()
+        .filter(|s| s["SequenceNumberRange"]["EndingSequenceNumber"].is_null())
+        .count();
+    assert_eq!(open_count, 1);
+}
+
+#[tokio::test]
 async fn update_shard_count_same_count_is_error() {
     let server = TestServer::new().await;
     let name = "usc-same";

--- a/tests/subscribe_to_shard.rs
+++ b/tests/subscribe_to_shard.rs
@@ -287,7 +287,8 @@ async fn subscribe_stream_not_found_from_consumer_arn() {
                 consumer_creation_timestamp: EpochSeconds(1.0),
             },
         )
-        .await;
+        .await
+        .unwrap();
 
     let result = ferrokinesis::actions::subscribe_to_shard::execute_streaming(
         &store,
@@ -321,7 +322,8 @@ async fn subscribe_consumer_arn_missing_consumer_segment() {
                 consumer_creation_timestamp: EpochSeconds(1.0),
             },
         )
-        .await;
+        .await
+        .unwrap();
 
     let result = ferrokinesis::actions::subscribe_to_shard::execute_streaming(
         &store,
@@ -355,7 +357,8 @@ async fn subscribe_consumer_arn_unresolvable_stream_name() {
                 consumer_creation_timestamp: EpochSeconds(1.0),
             },
         )
-        .await;
+        .await
+        .unwrap();
 
     let result = ferrokinesis::actions::subscribe_to_shard::execute_streaming(
         &store,
@@ -494,7 +497,8 @@ async fn subscribe_unknown_position_type_direct() {
                 consumer_creation_timestamp: EpochSeconds(1.0),
             },
         )
-        .await;
+        .await
+        .unwrap();
 
     let result = ferrokinesis::actions::subscribe_to_shard::execute_streaming(
         &store,

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -100,7 +100,7 @@ async fn deleting_stream_clears_throughput_windows() {
         .await
         .expect("initial write should consume throughput");
 
-    store.delete_stream("stream").await;
+    let _ = store.delete_stream("stream").await;
 
     store
         .try_reserve_shard_throughput("stream", "shardId-000000000000", 600_000, 5_000)


### PR DESCRIPTION
## Summary
- add `state_dir`, `snapshot_interval_secs`, and `max_retained_bytes` runtime/config support for durable single-node mode
- persist full internal stream state, records, policies, consumers, tags, and account settings with WAL replay and snapshots
- expose `/metrics` and readiness failures for durable-state initialization and replay problems
- add restart/recovery coverage for WAL replay, snapshot restore, corrupted WAL handling, and internal stream field preservation

## Notes
- this is the core runtime slice for #196 and stays single-node by design
- throughput simulation and `PutRecords` partial failures remain in their own stacked PRs

## Testing
- cargo fmt --all --check
- cargo test --test durable_state --test health
- cargo test --workspace

Closes #196