### PR TITLE
ci: run workflows for stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
   schedule:
     - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- allow CI and conformance workflows to run for pull requests targeting non-`main` base branches
- keep `push` filtering to `main`
- unblock status checks for stacked PRs like `#200` and `#203`

## Testing
- ruby -e "require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/conformance.yml")"
- git diff --check

Closes #204