### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - add durable single-node state mode ([#203](https://github.com/mandrean/ferrokinesis/pull/203))
+- add PutRecords partial failure responses ([#200](https://github.com/mandrean/ferrokinesis/pull/200))
+- add optional shard write throttling ([#199](https://github.com/mandrean/ferrokinesis/pull/199))
+- add h2c support for plain listeners ([#197](https://github.com/mandrean/ferrokinesis/pull/197))
 
 ### Other
 
 - parallelize check workflow ([#225](https://github.com/mandrean/ferrokinesis/pull/225))
 - clarify mirror credential feature flags ([#214](https://github.com/mandrean/ferrokinesis/pull/214))
-- clarify mirror credential feature flags
+- update rand for security audit ([#202](https://github.com/mandrean/ferrokinesis/pull/202))
+- run workflows for stacked pull requests ([#205](https://github.com/mandrean/ferrokinesis/pull/205))
 
 ## [0.6.0](https://github.com/mandrean/ferrokinesis/compare/v0.5.0...v0.6.0) - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/mandrean/ferrokinesis/compare/v0.6.0...v0.7.0) - 2026-04-11
+
+### Added
+
+- add durable single-node state mode ([#203](https://github.com/mandrean/ferrokinesis/pull/203))
+
+### Other
+
+- parallelize check workflow ([#225](https://github.com/mandrean/ferrokinesis/pull/225))
+- clarify mirror credential feature flags ([#214](https://github.com/mandrean/ferrokinesis/pull/214))
+- clarify mirror credential feature flags
+
 ## [0.6.0](https://github.com/mandrean/ferrokinesis/compare/v0.5.0...v0.6.0) - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrokinesis"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes",
  "async-stream",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "ferrokinesis-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes",
  "base64",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "ferrokinesis-wasm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "axum",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "crates/ferrokinesis-core", "crates/ferrokinesis-wasm"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"
@@ -76,7 +76,7 @@ replay = ["server", "dep:reqwest"]
 tls = ["server", "dep:axum-server", "dep:rcgen", "dep:rustls"]
 
 [dependencies]
-ferrokinesis-core = { path = "crates/ferrokinesis-core", version = "0.6.0" }
+ferrokinesis-core = { path = "crates/ferrokinesis-core", version = "0.7.0" }
 backon = { version = "1.6", default-features = false, features = ["tokio-sleep"], optional = true }
 aws-config = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "credentials-process"] }
 aws-credential-types = { version = "1", optional = true }


### PR DESCRIPTION
## 🤖 New release

* `ferrokinesis-core`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `ferrokinesis`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)

### ⚠ `ferrokinesis` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FileConfig.enforce_limits in /tmp/.tmpsbpXbA/ferrokinesis/src/config.rs:76
  field FileConfig.state_dir in /tmp/.tmpsbpXbA/ferrokinesis/src/config.rs:78
  field FileConfig.snapshot_interval_secs in /tmp/.tmpsbpXbA/ferrokinesis/src/config.rs:80
  field FileConfig.max_retained_bytes in /tmp/.tmpsbpXbA/ferrokinesis/src/config.rs:82
  field StoreOptions.enforce_limits in /tmp/.tmpsbpXbA/ferrokinesis/src/store.rs:244
  field StoreOptions.durable in /tmp/.tmpsbpXbA/ferrokinesis/src/store.rs:246
  field StoreOptions.max_retained_bytes in /tmp/.tmpsbpXbA/ferrokinesis/src/store.rs:248
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `ferrokinesis`

<blockquote>

## [0.7.0](https://github.com/mandrean/ferrokinesis/compare/v0.6.0...v0.7.0) - 2026-04-11

### Added

- add durable single-node state mode ([#203](https://github.com/mandrean/ferrokinesis/pull/203))
- add PutRecords partial failure responses ([#200](https://github.com/mandrean/ferrokinesis/pull/200))
- add optional shard write throttling ([#199](https://github.com/mandrean/ferrokinesis/pull/199))
- add h2c support for plain listeners ([#197](https://github.com/mandrean/ferrokinesis/pull/197))

### Other

- parallelize check workflow ([#225](https://github.com/mandrean/ferrokinesis/pull/225))
- clarify mirror credential feature flags ([#214](https://github.com/mandrean/ferrokinesis/pull/214))
- update rand for security audit ([#202](https://github.com/mandrean/ferrokinesis/pull/202))
- run workflows for stacked pull requests ([#205](https://github.com/mandrean/ferrokinesis/pull/205))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
