### PR TITLE
feat(checkpoint): same-port DynamoDB routing with CreateTable/DescribeTable foundation

### DIFF
--- a/src/checkpoint/mod.rs
+++ b/src/checkpoint/mod.rs
@@ -25,25 +25,39 @@ impl CheckpointStore {
         }
     }
 
-    fn dispatch(&self, operation: &str, payload: Value) -> Result<Value, DdbError> {
-        match operation {
-            "CreateTable" => {
-                let input: CreateTableRequest = serde_json::from_value(payload)
-                    .map_err(|_| DdbError::serialization("Invalid CreateTable request body"))?;
-                let table = self.create_table(input)?;
-                Ok(json!({ "TableDescription": table }))
-            }
-            "DescribeTable" => {
-                let input: DescribeTableRequest = serde_json::from_value(payload)
-                    .map_err(|_| DdbError::serialization("Invalid DescribeTable request body"))?;
-                let table = self.describe_table(input)?;
-                Ok(json!({ "Table": table }))
-            }
-            _ => Err(DdbError::unknown_operation(operation)),
-        }
+    pub(crate) fn export_snapshot_json(&self) -> Result<Vec<u8>, String> {
+        let tables = self
+            .tables
+            .read()
+            .map_err(|_| "checkpoint table store lock poisoned".to_string())?;
+        let mut snapshot: Vec<TableMeta> = tables.values().cloned().collect();
+        snapshot.sort_by(|left, right| left.table_name.cmp(&right.table_name));
+        serde_json::to_vec(&snapshot)
+            .map_err(|err| format!("failed to encode persisted checkpoint tables: {err}"))
     }
 
-    fn create_table(&self, input: CreateTableRequest) -> Result<TableDescription, DdbError> {
+    pub(crate) fn restore_snapshot_json(&self, bytes: &[u8]) -> Result<(), String> {
+        let restored: Vec<TableMeta> = if bytes.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_slice(bytes)
+                .map_err(|err| format!("failed to decode persisted checkpoint tables: {err}"))?
+        };
+        let mut tables = self
+            .tables
+            .write()
+            .map_err(|_| "checkpoint table store lock poisoned".to_string())?;
+        tables.clear();
+        for table in restored {
+            tables.insert(table.table_name.clone(), table);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn create_table(
+        &self,
+        input: CreateTableRequest,
+    ) -> Result<TableDescription, DdbError> {
         if input.table_name.trim().is_empty() {
             return Err(DdbError::validation(
                 "Value null at 'tableName' failed to satisfy constraint: Member must not be null",
@@ -72,6 +86,11 @@ impl CheckpointStore {
             table_name: input.table_name.clone(),
             attribute_definitions: input.attribute_definitions,
             key_schema: input.key_schema,
+            global_secondary_indexes: input
+                .global_secondary_indexes
+                .into_iter()
+                .map(GlobalSecondaryIndexMeta::from_request)
+                .collect(),
             table_id: uuid::Uuid::new_v4().to_string(),
             created_at_seconds,
         };
@@ -80,7 +99,10 @@ impl CheckpointStore {
         Ok(table_description)
     }
 
-    fn describe_table(&self, input: DescribeTableRequest) -> Result<TableDescription, DdbError> {
+    pub(crate) fn describe_table(
+        &self,
+        input: DescribeTableRequest,
+    ) -> Result<TableDescription, DdbError> {
         let tables = self
             .tables
             .read()
@@ -93,13 +115,22 @@ impl CheckpointStore {
         };
         Ok(table_meta.as_description(&self.aws_account_id, &self.aws_region))
     }
+
+    pub(crate) fn remove_table(&self, table_name: &str) -> Result<(), DdbError> {
+        let mut tables = self
+            .tables
+            .write()
+            .map_err(|_| DdbError::internal("table store lock poisoned"))?;
+        tables.remove(table_name);
+        Ok(())
+    }
 }
 
-pub(crate) fn handle_request(
+pub(crate) async fn handle_request(
     uri: &Uri,
     headers: &HeaderMap,
     response_headers: &HeaderMap,
-    checkpoint_store: &CheckpointStore,
+    store: &crate::store::Store,
     operation: &str,
     body: &Bytes,
 ) -> Response {
@@ -140,7 +171,32 @@ pub(crate) fn handle_request(
         }
     };
 
-    match checkpoint_store.dispatch(operation, payload) {
+    let result = match operation {
+        "CreateTable" => {
+            let input = serde_json::from_value(payload)
+                .map_err(|_| DdbError::serialization("Invalid CreateTable request body"));
+            match input {
+                Ok(input) => store
+                    .checkpoint_create_table(input)
+                    .await
+                    .map(|table| json!({ "TableDescription": table })),
+                Err(err) => Err(err),
+            }
+        }
+        "DescribeTable" => {
+            let input = serde_json::from_value(payload)
+                .map_err(|_| DdbError::serialization("Invalid DescribeTable request body"));
+            match input {
+                Ok(input) => store
+                    .checkpoint_describe_table(input)
+                    .map(|table| json!({ "Table": table })),
+                Err(err) => Err(err),
+            }
+        }
+        _ => Err(DdbError::unknown_operation(operation)),
+    };
+
+    match result {
         Ok(result) => send_json_response(response_headers, StatusCode::OK, &result),
         Err(error) => send_error(response_headers, error),
     }
@@ -250,7 +306,7 @@ fn send_json_response(extra_headers: &HeaderMap, status: StatusCode, body: &Valu
 }
 
 #[derive(Debug)]
-struct DdbError {
+pub(crate) struct DdbError {
     status_code: u16,
     error_type: &'static str,
     message: String,
@@ -301,16 +357,18 @@ impl DdbError {
         Self::new(400, "ResourceNotFoundException", message)
     }
 
-    fn internal(message: impl Into<String>) -> Self {
+    pub(crate) fn internal(message: impl Into<String>) -> Self {
         Self::new(500, "InternalServerError", message)
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct TableMeta {
     table_name: String,
     attribute_definitions: Vec<AttributeDefinition>,
     key_schema: Vec<KeySchemaElement>,
+    #[serde(default)]
+    global_secondary_indexes: Vec<GlobalSecondaryIndexMeta>,
     table_id: String,
     created_at_seconds: f64,
 }
@@ -328,24 +386,31 @@ impl TableMeta {
                 self.table_name
             ),
             table_id: self.table_id.clone(),
+            global_secondary_indexes: self
+                .global_secondary_indexes
+                .iter()
+                .map(|index| index.as_description(&self.table_name, aws_account_id, aws_region))
+                .collect(),
         }
     }
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct CreateTableRequest {
-    table_name: String,
+pub(crate) struct CreateTableRequest {
+    pub(crate) table_name: String,
     #[serde(default)]
     attribute_definitions: Vec<AttributeDefinition>,
     #[serde(default)]
     key_schema: Vec<KeySchemaElement>,
+    #[serde(default)]
+    global_secondary_indexes: Vec<GlobalSecondaryIndexRequest>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct DescribeTableRequest {
-    table_name: String,
+pub(crate) struct DescribeTableRequest {
+    pub(crate) table_name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -362,9 +427,71 @@ struct KeySchemaElement {
     key_type: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct Projection {
+    projection_type: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    non_key_attributes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct GlobalSecondaryIndexRequest {
+    index_name: String,
+    #[serde(default)]
+    key_schema: Vec<KeySchemaElement>,
+    projection: Projection,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GlobalSecondaryIndexMeta {
+    index_name: String,
+    key_schema: Vec<KeySchemaElement>,
+    projection: Projection,
+}
+
+impl GlobalSecondaryIndexMeta {
+    fn from_request(request: GlobalSecondaryIndexRequest) -> Self {
+        Self {
+            index_name: request.index_name,
+            key_schema: request.key_schema,
+            projection: request.projection,
+        }
+    }
+
+    fn as_description(
+        &self,
+        table_name: &str,
+        aws_account_id: &str,
+        aws_region: &str,
+    ) -> GlobalSecondaryIndexDescription {
+        GlobalSecondaryIndexDescription {
+            index_name: self.index_name.clone(),
+            key_schema: self.key_schema.clone(),
+            projection: self.projection.clone(),
+            index_status: "ACTIVE".to_string(),
+            index_arn: format!(
+                "arn:aws:dynamodb:{aws_region}:{aws_account_id}:table/{table_name}/index/{}",
+                self.index_name
+            ),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "PascalCase")]
-struct TableDescription {
+struct GlobalSecondaryIndexDescription {
+    index_name: String,
+    key_schema: Vec<KeySchemaElement>,
+    projection: Projection,
+    index_status: String,
+    index_arn: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct TableDescription {
     attribute_definitions: Vec<AttributeDefinition>,
     key_schema: Vec<KeySchemaElement>,
     table_name: String,
@@ -372,4 +499,6 @@ struct TableDescription {
     creation_date_time: f64,
     table_arn: String,
     table_id: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    global_secondary_indexes: Vec<GlobalSecondaryIndexDescription>,
 }

--- a/src/checkpoint/mod.rs
+++ b/src/checkpoint/mod.rs
@@ -1,0 +1,375 @@
+use axum::body::Bytes;
+use axum::http::{HeaderMap, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+pub(crate) const DYNAMODB_API: &str = "DynamoDB_20120810";
+const DDB_CONTENT_TYPE_JSON: &str = "application/x-amz-json-1.0";
+
+#[derive(Clone)]
+pub(crate) struct CheckpointStore {
+    aws_account_id: String,
+    aws_region: String,
+    tables: Arc<RwLock<HashMap<String, TableMeta>>>,
+}
+
+impl CheckpointStore {
+    pub(crate) fn new(aws_account_id: String, aws_region: String) -> Self {
+        Self {
+            aws_account_id,
+            aws_region,
+            tables: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    fn dispatch(&self, operation: &str, payload: Value) -> Result<Value, DdbError> {
+        match operation {
+            "CreateTable" => {
+                let input: CreateTableRequest = serde_json::from_value(payload)
+                    .map_err(|_| DdbError::serialization("Invalid CreateTable request body"))?;
+                let table = self.create_table(input)?;
+                Ok(json!({ "TableDescription": table }))
+            }
+            "DescribeTable" => {
+                let input: DescribeTableRequest = serde_json::from_value(payload)
+                    .map_err(|_| DdbError::serialization("Invalid DescribeTable request body"))?;
+                let table = self.describe_table(input)?;
+                Ok(json!({ "Table": table }))
+            }
+            _ => Err(DdbError::unknown_operation(operation)),
+        }
+    }
+
+    fn create_table(&self, input: CreateTableRequest) -> Result<TableDescription, DdbError> {
+        if input.table_name.trim().is_empty() {
+            return Err(DdbError::validation(
+                "Value null at 'tableName' failed to satisfy constraint: Member must not be null",
+            ));
+        }
+        if input.key_schema.is_empty() {
+            return Err(DdbError::validation(
+                "One or more parameter values were invalid: KeySchema is required",
+            ));
+        }
+
+        let mut tables = self
+            .tables
+            .write()
+            .map_err(|_| DdbError::internal("table store lock poisoned"))?;
+
+        if tables.contains_key(&input.table_name) {
+            return Err(DdbError::resource_in_use(format!(
+                "Table already exists: {}",
+                input.table_name
+            )));
+        }
+
+        let created_at_seconds = crate::util::current_time_ms() as f64 / 1000.0;
+        let table_meta = TableMeta {
+            table_name: input.table_name.clone(),
+            attribute_definitions: input.attribute_definitions,
+            key_schema: input.key_schema,
+            table_id: uuid::Uuid::new_v4().to_string(),
+            created_at_seconds,
+        };
+        let table_description = table_meta.as_description(&self.aws_account_id, &self.aws_region);
+        tables.insert(input.table_name, table_meta);
+        Ok(table_description)
+    }
+
+    fn describe_table(&self, input: DescribeTableRequest) -> Result<TableDescription, DdbError> {
+        let tables = self
+            .tables
+            .read()
+            .map_err(|_| DdbError::internal("table store lock poisoned"))?;
+        let Some(table_meta) = tables.get(&input.table_name) else {
+            return Err(DdbError::resource_not_found(format!(
+                "Requested resource not found: Table: {} not found",
+                input.table_name
+            )));
+        };
+        Ok(table_meta.as_description(&self.aws_account_id, &self.aws_region))
+    }
+}
+
+pub(crate) fn handle_request(
+    uri: &Uri,
+    headers: &HeaderMap,
+    response_headers: &HeaderMap,
+    checkpoint_store: &CheckpointStore,
+    operation: &str,
+    body: &Bytes,
+) -> Response {
+    let content_type = headers
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim();
+
+    if content_type != DDB_CONTENT_TYPE_JSON {
+        return send_error(
+            response_headers,
+            DdbError::serialization("Unsupported content type for DynamoDB target"),
+        );
+    }
+
+    if body.is_empty() {
+        return send_error(
+            response_headers,
+            DdbError::serialization("Request body is empty"),
+        );
+    }
+
+    if let Err(error) = validate_auth(headers, uri) {
+        return send_error(response_headers, error);
+    }
+
+    let payload: Value = match serde_json::from_slice(body) {
+        Ok(Value::Object(map)) => Value::Object(map),
+        Ok(_) | Err(_) => {
+            return send_error(
+                response_headers,
+                DdbError::serialization("Could not parse request body as JSON object"),
+            );
+        }
+    };
+
+    match checkpoint_store.dispatch(operation, payload) {
+        Ok(result) => send_json_response(response_headers, StatusCode::OK, &result),
+        Err(error) => send_error(response_headers, error),
+    }
+}
+
+fn validate_auth(headers: &HeaderMap, uri: &Uri) -> Result<(), DdbError> {
+    let auth_header = headers.get("authorization").and_then(|v| v.to_str().ok());
+    let query_string = uri.query().unwrap_or("");
+    let auth_query = query_string.contains("X-Amz-Algorithm");
+
+    if auth_header.is_some() && auth_query {
+        return Err(DdbError::invalid_signature(
+            "Found both 'X-Amz-Algorithm' as a query-string param and 'Authorization' as HTTP header.",
+        ));
+    }
+
+    if auth_header.is_none() && !auth_query {
+        return Err(DdbError::missing_auth_token("Missing Authentication Token"));
+    }
+
+    if let Some(auth) = auth_header {
+        let mut msg = String::new();
+        let auth_params: HashMap<String, String> = auth
+            .split([',', ' '])
+            .skip(1)
+            .filter(|s| !s.is_empty())
+            .filter_map(|s| {
+                let kv: Vec<&str> = s.trim().splitn(2, '=').collect();
+                if kv.len() == 2 {
+                    Some((kv[0].to_string(), kv[1].to_string()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for param in ["Credential", "Signature", "SignedHeaders"] {
+            if !auth_params.contains_key(param) {
+                msg += &format!("Authorization header requires '{param}' parameter. ");
+            }
+        }
+        if !headers.contains_key("x-amz-date") && !headers.contains_key("date") {
+            msg += "Authorization header requires existence of either a 'X-Amz-Date' or a 'Date' header. ";
+        }
+        if !msg.is_empty() {
+            msg += &format!("Authorization={auth}");
+            return Err(DdbError::incomplete_signature(msg));
+        }
+        return Ok(());
+    }
+
+    let query_params: HashMap<String, String> = query_string
+        .split('&')
+        .filter_map(|s| {
+            let kv: Vec<&str> = s.splitn(2, '=').collect();
+            if kv.len() == 2 {
+                Some((kv[0].to_string(), kv[1].to_string()))
+            } else if !kv[0].is_empty() {
+                Some((kv[0].to_string(), String::new()))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut msg = String::new();
+    for param in [
+        "X-Amz-Algorithm",
+        "X-Amz-Credential",
+        "X-Amz-Signature",
+        "X-Amz-SignedHeaders",
+        "X-Amz-Date",
+    ] {
+        if !query_params.contains_key(param) || query_params[param].is_empty() {
+            msg += &format!("AWS query-string parameters must include '{param}'. ");
+        }
+    }
+    if !msg.is_empty() {
+        msg += "Re-examine the query-string parameters.";
+        return Err(DdbError::incomplete_signature(msg));
+    }
+
+    Ok(())
+}
+
+fn send_error(extra_headers: &HeaderMap, error: DdbError) -> Response {
+    let body = json!({
+        "__type": format!("com.amazonaws.dynamodb.v20120810#{}", error.error_type),
+        "message": error.message,
+    });
+    send_json_response(
+        extra_headers,
+        StatusCode::from_u16(error.status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+        &body,
+    )
+}
+
+fn send_json_response(extra_headers: &HeaderMap, status: StatusCode, body: &Value) -> Response {
+    let mut headers = extra_headers.clone();
+    let body_bytes = serde_json::to_vec(body).unwrap_or_default();
+    headers.insert("Content-Type", DDB_CONTENT_TYPE_JSON.parse().unwrap());
+    headers.insert(
+        "Content-Length",
+        body_bytes.len().to_string().parse().unwrap(),
+    );
+    (status, headers, body_bytes).into_response()
+}
+
+#[derive(Debug)]
+struct DdbError {
+    status_code: u16,
+    error_type: &'static str,
+    message: String,
+}
+
+impl DdbError {
+    fn new(status_code: u16, error_type: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status_code,
+            error_type,
+            message: message.into(),
+        }
+    }
+
+    fn serialization(message: impl Into<String>) -> Self {
+        Self::new(400, "SerializationException", message)
+    }
+
+    fn unknown_operation(operation: &str) -> Self {
+        Self::new(
+            400,
+            "UnknownOperationException",
+            format!("Unknown operation: {operation}"),
+        )
+    }
+
+    fn missing_auth_token(message: impl Into<String>) -> Self {
+        Self::new(400, "MissingAuthenticationTokenException", message)
+    }
+
+    fn invalid_signature(message: impl Into<String>) -> Self {
+        Self::new(400, "InvalidSignatureException", message)
+    }
+
+    fn incomplete_signature(message: impl Into<String>) -> Self {
+        Self::new(403, "IncompleteSignatureException", message)
+    }
+
+    fn validation(message: impl Into<String>) -> Self {
+        Self::new(400, "ValidationException", message)
+    }
+
+    fn resource_in_use(message: impl Into<String>) -> Self {
+        Self::new(400, "ResourceInUseException", message)
+    }
+
+    fn resource_not_found(message: impl Into<String>) -> Self {
+        Self::new(400, "ResourceNotFoundException", message)
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self::new(500, "InternalServerError", message)
+    }
+}
+
+#[derive(Clone)]
+struct TableMeta {
+    table_name: String,
+    attribute_definitions: Vec<AttributeDefinition>,
+    key_schema: Vec<KeySchemaElement>,
+    table_id: String,
+    created_at_seconds: f64,
+}
+
+impl TableMeta {
+    fn as_description(&self, aws_account_id: &str, aws_region: &str) -> TableDescription {
+        TableDescription {
+            attribute_definitions: self.attribute_definitions.clone(),
+            key_schema: self.key_schema.clone(),
+            table_name: self.table_name.clone(),
+            table_status: "ACTIVE".to_string(),
+            creation_date_time: self.created_at_seconds,
+            table_arn: format!(
+                "arn:aws:dynamodb:{aws_region}:{aws_account_id}:table/{}",
+                self.table_name
+            ),
+            table_id: self.table_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct CreateTableRequest {
+    table_name: String,
+    #[serde(default)]
+    attribute_definitions: Vec<AttributeDefinition>,
+    #[serde(default)]
+    key_schema: Vec<KeySchemaElement>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct DescribeTableRequest {
+    table_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct AttributeDefinition {
+    attribute_name: String,
+    attribute_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct KeySchemaElement {
+    attribute_name: String,
+    key_type: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct TableDescription {
+    attribute_definitions: Vec<AttributeDefinition>,
+    key_schema: Vec<KeySchemaElement>,
+    table_name: String,
+    table_status: String,
+    creation_date_time: f64,
+    table_arn: String,
+    table_id: String,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 pub mod actions;
 #[cfg(feature = "server")]
 pub mod capture;
+mod checkpoint;
 #[cfg(feature = "server")]
 pub mod config;
 #[doc(hidden)]

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -26,6 +26,8 @@ pub struct PersistentSnapshot {
     pub resource_tags: Vec<(String, BTreeMap<String, String>)>,
     pub account_settings_json: Vec<u8>,
     #[serde(default)]
+    pub checkpoint_tables_json: Vec<u8>,
+    #[serde(default)]
     pub(crate) pending_transitions: Vec<PendingTransition>,
     pub retained_bytes: u64,
     pub retained_records: u64,
@@ -335,6 +337,7 @@ mod tests {
             policies: vec![],
             resource_tags: vec![],
             account_settings_json: vec![],
+            checkpoint_tables_json: vec![],
             pending_transitions: vec![],
             retained_bytes: 0,
             retained_records: 0,

--- a/src/server.rs
+++ b/src/server.rs
@@ -192,10 +192,11 @@ pub async fn handler(
                 &uri,
                 &headers,
                 &response_headers,
-                store.checkpoint(),
+                &store,
                 operation_str,
                 &body,
-            );
+            )
+            .await;
         }
 
         let service_valid = service == constants::KINESIS_API;

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,6 +10,7 @@
 //! layer and rewraps them as Kinesis-shaped `SerializationException` errors.
 
 use crate::actions::{self, Operation};
+use crate::checkpoint;
 use crate::constants;
 use crate::error::KinesisErrorResponse;
 use crate::metrics::PreOperationFailureReason;
@@ -185,6 +186,17 @@ pub async fn handler(
         let parts: Vec<&str> = target.splitn(2, '.').collect();
         let service = parts.first().copied().unwrap_or("");
         let operation_str = if parts.len() > 1 { parts[1] } else { "" };
+
+        if service == checkpoint::DYNAMODB_API {
+            return checkpoint::handle_request(
+                &uri,
+                &headers,
+                &response_headers,
+                store.checkpoint(),
+                operation_str,
+                &body,
+            );
+        }
 
         let service_valid = service == constants::KINESIS_API;
         let operation = operation_str.parse::<Operation>().ok();

--- a/src/store.rs
+++ b/src/store.rs
@@ -342,6 +342,12 @@ type RestoredShardRecords = Vec<(String, BTreeMap<String, Vec<u8>>)>;
 #[cfg(not(target_arch = "wasm32"))]
 type RestoredStreamRecords = Vec<(String, RestoredShardRecords)>;
 
+#[cfg(not(target_arch = "wasm32"))]
+type RestoredShardRecords = Vec<(String, BTreeMap<String, Vec<u8>>)>;
+
+#[cfg(not(target_arch = "wasm32"))]
+type RestoredStreamRecords = Vec<(String, RestoredShardRecords)>;
+
 struct ShardThroughputWindow {
     window_start_ms: u64,
     bytes: u64,

--- a/src/store.rs
+++ b/src/store.rs
@@ -371,6 +371,7 @@ struct RestoredState {
     policies: Vec<(String, String)>,
     resource_tags: Vec<(String, BTreeMap<String, String>)>,
     account_settings: Value,
+    checkpoint_tables_json: Vec<u8>,
     pending_transitions: BTreeMap<String, PendingTransition>,
     retained_bytes: u64,
     retained_records: u64,
@@ -386,6 +387,7 @@ impl RestoredState {
             policies,
             resource_tags,
             account_settings_json,
+            checkpoint_tables_json,
             pending_transitions,
             retained_bytes,
             retained_records,
@@ -424,6 +426,7 @@ impl RestoredState {
             policies,
             resource_tags,
             account_settings,
+            checkpoint_tables_json,
             pending_transitions: pending_transitions
                 .into_iter()
                 .map(|transition| (transition.key(), transition))
@@ -607,8 +610,52 @@ impl Store {
         Arc::clone(&self.metrics)
     }
 
-    pub(crate) fn checkpoint(&self) -> &crate::checkpoint::CheckpointStore {
-        &self.checkpoint
+    pub(crate) async fn checkpoint_create_table(
+        &self,
+        input: crate::checkpoint::CreateTableRequest,
+    ) -> Result<crate::checkpoint::TableDescription, crate::checkpoint::DdbError> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _write_guard = if self.persistence.is_some() {
+            if !self.health.durable_ok.load(Ordering::Relaxed) {
+                let detail = self
+                    .health
+                    .last_error
+                    .read()
+                    .ok()
+                    .and_then(|guard| guard.clone())
+                    .unwrap_or_else(|| "durable state is not ready".to_string());
+                return Err(crate::checkpoint::DdbError::internal(detail));
+            }
+            if !self.health.replay_complete.load(Ordering::Relaxed) {
+                return Err(crate::checkpoint::DdbError::internal(
+                    "durable replay is not complete",
+                ));
+            }
+            Some(self.inner.write_lock.lock().await)
+        } else {
+            None
+        };
+
+        let table_name = input.table_name.clone();
+        let table = self.checkpoint.create_table(input)?;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(err) = self.persist_current_state_result().await {
+            let _ = self.checkpoint.remove_table(&table_name);
+            return Err(crate::checkpoint::DdbError::internal(err));
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        self.persist_current_state().await;
+
+        Ok(table)
+    }
+
+    pub(crate) fn checkpoint_describe_table(
+        &self,
+        input: crate::checkpoint::DescribeTableRequest,
+    ) -> Result<crate::checkpoint::TableDescription, crate::checkpoint::DdbError> {
+        self.checkpoint.describe_table(input)
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -629,7 +676,7 @@ impl Store {
 
         let created_at_ms = restored_snapshot.created_at_ms;
         let restored_state = RestoredState::from_snapshot(restored_snapshot)?;
-        self.install_restored_state(restored_state);
+        self.install_restored_state(restored_state)?;
         persistence
             .last_snapshot_ms
             .store(created_at_ms, Ordering::Relaxed);
@@ -650,7 +697,7 @@ impl Store {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn install_restored_state(&self, restored_state: RestoredState) {
+    fn install_restored_state(&self, restored_state: RestoredState) -> Result<(), String> {
         self.inner.streams.clear();
         self.inner.stream_records.clear();
         self.inner.consumers.clear();
@@ -695,12 +742,15 @@ impl Store {
         if let Ok(mut settings) = self.inner.account_settings.try_write() {
             *settings = restored_state.account_settings;
         }
+        self.checkpoint
+            .restore_snapshot_json(&restored_state.checkpoint_tables_json)?;
 
         self.metrics.set_retained(
             restored_state.retained_bytes,
             restored_state.retained_records,
         );
         self.refresh_topology_metrics_sync();
+        Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -848,6 +898,7 @@ impl Store {
                 serde_json::to_vec(&account_settings)
                     .map_err(|err| format!("failed to encode snapshot account settings: {err}"))?
             },
+            checkpoint_tables_json: self.checkpoint.export_snapshot_json()?,
             pending_transitions: self
                 .inner
                 .pending_transitions

--- a/src/store.rs
+++ b/src/store.rs
@@ -342,12 +342,6 @@ type RestoredShardRecords = Vec<(String, BTreeMap<String, Vec<u8>>)>;
 #[cfg(not(target_arch = "wasm32"))]
 type RestoredStreamRecords = Vec<(String, RestoredShardRecords)>;
 
-#[cfg(not(target_arch = "wasm32"))]
-type RestoredShardRecords = Vec<(String, BTreeMap<String, Vec<u8>>)>;
-
-#[cfg(not(target_arch = "wasm32"))]
-type RestoredStreamRecords = Vec<(String, RestoredShardRecords)>;
-
 struct ShardThroughputWindow {
     window_start_ms: u64,
     bytes: u64,

--- a/src/store.rs
+++ b/src/store.rs
@@ -462,6 +462,7 @@ pub struct Store {
     pub aws_account_id: String,
     /// The simulated AWS region.
     pub aws_region: String,
+    checkpoint: crate::checkpoint::CheckpointStore,
     inner: Arc<StoreInner>,
     metrics: Arc<AppMetrics>,
     health: Arc<StoreHealthState>,
@@ -557,6 +558,10 @@ impl Store {
 
         let store = Self {
             options,
+            checkpoint: crate::checkpoint::CheckpointStore::new(
+                aws_account_id.clone(),
+                aws_region.clone(),
+            ),
             aws_account_id,
             aws_region,
             inner,
@@ -600,6 +605,10 @@ impl Store {
     /// Returns the shared application metrics registry.
     pub fn metrics(&self) -> Arc<AppMetrics> {
         Arc::clone(&self.metrics)
+    }
+
+    pub(crate) fn checkpoint(&self) -> &crate::checkpoint::CheckpointStore {
+        &self.checkpoint
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/tests/checkpoint.rs
+++ b/tests/checkpoint.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::TestServer;
-use ferrokinesis::store::StoreOptions;
+use ferrokinesis::store::{DurableStateOptions, StoreOptions};
 use reqwest::Client;
 use reqwest::Method;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -106,8 +106,11 @@ fn checkpoint_store_options(state_dir: &std::path::Path) -> StoreOptions {
         delete_stream_ms: 0,
         update_stream_ms: 0,
         shard_limit: 50,
-        state_dir: Some(state_dir.to_path_buf()),
-        snapshot_interval_secs: 30,
+        durable: Some(DurableStateOptions {
+            state_dir: state_dir.to_path_buf(),
+            snapshot_interval_secs: 30,
+            max_retained_bytes: None,
+        }),
         ..Default::default()
     }
 }

--- a/tests/checkpoint.rs
+++ b/tests/checkpoint.rs
@@ -1,0 +1,127 @@
+mod common;
+
+use common::TestServer;
+use reqwest::Method;
+use reqwest::header::{HeaderMap, HeaderValue};
+use serde_json::{Value, json};
+
+const DDB_JSON: &str = "application/x-amz-json-1.0";
+const DDB_VERSION: &str = "DynamoDB_20120810";
+
+async fn ddb_request(server: &TestServer, operation: &str, payload: &Value) -> reqwest::Response {
+    let mut headers = HeaderMap::new();
+    headers.insert("Content-Type", HeaderValue::from_static(DDB_JSON));
+    headers.insert(
+        "X-Amz-Target",
+        HeaderValue::from_str(&format!("{DDB_VERSION}.{operation}")).unwrap(),
+    );
+    headers.insert(
+        "Authorization",
+        HeaderValue::from_static(
+            "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/dynamodb/aws4_request, \
+             SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=abcd1234",
+        ),
+    );
+    headers.insert("X-Amz-Date", HeaderValue::from_static("20150101T000000Z"));
+
+    server
+        .raw_request(
+            Method::POST,
+            "/",
+            headers,
+            serde_json::to_vec(payload).unwrap(),
+        )
+        .await
+}
+
+#[tokio::test]
+async fn dynamodb_create_and_describe_table() {
+    let server = TestServer::new().await;
+
+    let create_res = ddb_request(
+        &server,
+        "CreateTable",
+        &json!({
+            "TableName": "kcl-lease-table",
+            "AttributeDefinitions": [
+                {"AttributeName": "leaseKey", "AttributeType": "S"}
+            ],
+            "KeySchema": [
+                {"AttributeName": "leaseKey", "KeyType": "HASH"}
+            ],
+            "BillingMode": "PAY_PER_REQUEST"
+        }),
+    )
+    .await;
+    assert_eq!(create_res.status(), 200);
+    let create_body: Value = create_res.json().await.unwrap();
+    assert_eq!(
+        create_body["TableDescription"]["TableName"],
+        "kcl-lease-table"
+    );
+    assert_eq!(create_body["TableDescription"]["TableStatus"], "ACTIVE");
+    assert!(
+        create_body["TableDescription"]["TableArn"]
+            .as_str()
+            .unwrap()
+            .contains("table/kcl-lease-table")
+    );
+
+    let describe_res = ddb_request(
+        &server,
+        "DescribeTable",
+        &json!({
+            "TableName": "kcl-lease-table"
+        }),
+    )
+    .await;
+    assert_eq!(describe_res.status(), 200);
+    let describe_body: Value = describe_res.json().await.unwrap();
+    assert_eq!(describe_body["Table"]["TableName"], "kcl-lease-table");
+    assert_eq!(describe_body["Table"]["TableStatus"], "ACTIVE");
+
+    // Same listener still serves Kinesis traffic.
+    let list_streams = server.request("ListStreams", &json!({})).await;
+    assert_eq!(list_streams.status(), 200);
+}
+
+#[tokio::test]
+async fn dynamodb_unknown_operation_returns_dynamodb_error_shape() {
+    let server = TestServer::new().await;
+    let res = ddb_request(&server, "NotAnOperation", &json!({})).await;
+    assert_eq!(res.status(), 400);
+    assert_eq!(
+        res.headers().get("content-type").unwrap().to_str().unwrap(),
+        DDB_JSON
+    );
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(
+        body["__type"],
+        "com.amazonaws.dynamodb.v20120810#UnknownOperationException"
+    );
+}
+
+#[tokio::test]
+async fn dynamodb_create_table_twice_returns_resource_in_use() {
+    let server = TestServer::new().await;
+    let payload = json!({
+        "TableName": "kcl-lease-table-dup",
+        "AttributeDefinitions": [
+            {"AttributeName": "leaseKey", "AttributeType": "S"}
+        ],
+        "KeySchema": [
+            {"AttributeName": "leaseKey", "KeyType": "HASH"}
+        ]
+    });
+
+    let first = ddb_request(&server, "CreateTable", &payload).await;
+    assert_eq!(first.status(), 200);
+
+    let second = ddb_request(&server, "CreateTable", &payload).await;
+    assert_eq!(second.status(), 400);
+    let body: Value = second.json().await.unwrap();
+    assert_eq!(
+        body["__type"],
+        "com.amazonaws.dynamodb.v20120810#ResourceInUseException"
+    );
+}

--- a/tests/checkpoint.rs
+++ b/tests/checkpoint.rs
@@ -1,14 +1,25 @@
 mod common;
 
 use common::TestServer;
+use ferrokinesis::store::StoreOptions;
+use reqwest::Client;
 use reqwest::Method;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::{Value, json};
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
 
 const DDB_JSON: &str = "application/x-amz-json-1.0";
 const DDB_VERSION: &str = "DynamoDB_20120810";
 
-async fn ddb_request(server: &TestServer, operation: &str, payload: &Value) -> reqwest::Response {
+async fn ddb_request_to(
+    client: &Client,
+    url: &str,
+    operation: &str,
+    payload: &Value,
+) -> reqwest::Response {
     let mut headers = HeaderMap::new();
     headers.insert("Content-Type", HeaderValue::from_static(DDB_JSON));
     headers.insert(
@@ -24,14 +35,127 @@ async fn ddb_request(server: &TestServer, operation: &str, payload: &Value) -> r
     );
     headers.insert("X-Amz-Date", HeaderValue::from_static("20150101T000000Z"));
 
-    server
-        .raw_request(
-            Method::POST,
-            "/",
-            headers,
-            serde_json::to_vec(payload).unwrap(),
-        )
+    client
+        .request(Method::POST, url)
+        .headers(headers)
+        .body(serde_json::to_vec(payload).unwrap())
+        .send()
         .await
+        .unwrap()
+}
+
+async fn ddb_request(server: &TestServer, operation: &str, payload: &Value) -> reqwest::Response {
+    ddb_request_to(&server.client, &server.url(), operation, payload).await
+}
+
+struct RestartableServer {
+    url: String,
+    client: Client,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    task: tokio::task::JoinHandle<std::io::Result<()>>,
+}
+
+impl RestartableServer {
+    async fn start(options: StoreOptions) -> Self {
+        let (app, _store) = ferrokinesis::create_app(options);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            ferrokinesis::serve_plain_http(listener, app, async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+        });
+
+        Self {
+            url: format!("http://{addr}"),
+            client: Client::new(),
+            shutdown_tx: Some(shutdown_tx),
+            task,
+        }
+    }
+
+    async fn wait_ready(&self) {
+        for _ in 0..40 {
+            if let Ok(response) = self
+                .client
+                .get(format!("{}/_health/ready", self.url))
+                .send()
+                .await
+                && response.status().is_success()
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("server did not become ready");
+    }
+
+    async fn shutdown(mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        self.task.await.unwrap().unwrap();
+    }
+}
+
+fn checkpoint_store_options(state_dir: &std::path::Path) -> StoreOptions {
+    StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 50,
+        state_dir: Some(state_dir.to_path_buf()),
+        snapshot_interval_secs: 30,
+        ..Default::default()
+    }
+}
+
+fn gsi_create_table_payload(table_name: &str) -> Value {
+    json!({
+        "TableName": table_name,
+        "AttributeDefinitions": [
+            {"AttributeName": "leaseKey", "AttributeType": "S"},
+            {"AttributeName": "leaseOwner", "AttributeType": "S"}
+        ],
+        "KeySchema": [
+            {"AttributeName": "leaseKey", "KeyType": "HASH"}
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [
+            {
+                "IndexName": "leaseOwner-index",
+                "KeySchema": [
+                    {"AttributeName": "leaseOwner", "KeyType": "HASH"}
+                ],
+                "Projection": {
+                    "ProjectionType": "ALL"
+                }
+            }
+        ]
+    })
+}
+
+fn assert_table_has_gsi(table: &Value, table_name: &str) {
+    assert_eq!(table["TableName"], table_name);
+    assert_eq!(table["TableStatus"], "ACTIVE");
+    assert_eq!(table["GlobalSecondaryIndexes"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        table["GlobalSecondaryIndexes"][0]["IndexName"],
+        "leaseOwner-index"
+    );
+    assert_eq!(table["GlobalSecondaryIndexes"][0]["IndexStatus"], "ACTIVE");
+    assert_eq!(
+        table["GlobalSecondaryIndexes"][0]["Projection"]["ProjectionType"],
+        "ALL"
+    );
+    assert!(
+        table["GlobalSecondaryIndexes"][0]["IndexArn"]
+            .as_str()
+            .unwrap()
+            .contains(&format!("table/{table_name}/index/leaseOwner-index"))
+    );
 }
 
 #[tokio::test]
@@ -83,6 +207,67 @@ async fn dynamodb_create_and_describe_table() {
     // Same listener still serves Kinesis traffic.
     let list_streams = server.request("ListStreams", &json!({})).await;
     assert_eq!(list_streams.status(), 200);
+}
+
+#[tokio::test]
+async fn dynamodb_create_and_describe_table_with_gsi_metadata() {
+    let server = TestServer::new().await;
+    let payload = gsi_create_table_payload("kcl-lease-table-with-gsi");
+
+    let create_res = ddb_request(&server, "CreateTable", &payload).await;
+    assert_eq!(create_res.status(), 200);
+    let create_body: Value = create_res.json().await.unwrap();
+    assert_table_has_gsi(&create_body["TableDescription"], "kcl-lease-table-with-gsi");
+
+    let describe_res = ddb_request(
+        &server,
+        "DescribeTable",
+        &json!({
+            "TableName": "kcl-lease-table-with-gsi"
+        }),
+    )
+    .await;
+    assert_eq!(describe_res.status(), 200);
+    let describe_body: Value = describe_res.json().await.unwrap();
+    assert_table_has_gsi(&describe_body["Table"], "kcl-lease-table-with-gsi");
+}
+
+#[tokio::test]
+async fn checkpoint_tables_survive_durable_restart() {
+    let state_dir = tempdir().unwrap();
+    let payload = gsi_create_table_payload("kcl-lease-table-durable");
+
+    let server = RestartableServer::start(checkpoint_store_options(state_dir.path())).await;
+    server.wait_ready().await;
+    let create_res = ddb_request_to(&server.client, &server.url, "CreateTable", &payload).await;
+    assert_eq!(create_res.status(), 200);
+    server.shutdown().await;
+
+    let restarted = RestartableServer::start(checkpoint_store_options(state_dir.path())).await;
+    restarted.wait_ready().await;
+
+    let ready_res = restarted
+        .client
+        .get(format!("{}/_health/ready", restarted.url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ready_res.status(), 200);
+
+    let describe_res = ddb_request_to(
+        &restarted.client,
+        &restarted.url,
+        "DescribeTable",
+        &json!({
+            "TableName": "kcl-lease-table-durable"
+        }),
+    )
+    .await;
+    assert_eq!(describe_res.status(), 200);
+    let describe_body: Value = describe_res.json().await.unwrap();
+    assert_table_has_gsi(&describe_body["Table"], "kcl-lease-table-durable");
+
+    restarted.shutdown().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- route `DynamoDB_20120810.*` requests through the existing `POST /` handler on the same listener
- add an internal checkpoint store scaffold with DynamoDB JSON 1.0 protocol handling
- implement the first two checkpoint operations: `CreateTable` and `DescribeTable`
- return DynamoDB-style JSON error envelopes for unknown ops/auth/content-type failures in the checkpoint path
- add focused integration tests for same-port routing and create/describe behavior

## Scope Notes
This is the smallest coherent first slice for #142. It intentionally does **not** implement full KCL lease semantics yet (`PutItem`/`UpdateItem`/`DeleteItem`/`Scan`/`Query`/`UpdateTable` and durable persistence are follow-ups).

## Validation
- `cargo test --test checkpoint`
- `cargo test --test connection json_unknown_operation_if_no_target`
