### PR TITLE
feat(ci): add report-only memory smoke/soak harness jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,71 @@ jobs:
             bench-comparison.txt
           retention-days: 90
 
+  memory-smoke:
+    name: Memory Smoke (report-only)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-rust-toolchain
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check
+          save-if: false
+      - name: Prepare harness scripts
+        run: |
+          git show ${{ github.event.pull_request.head.sha }}:scripts/ci/memory-harness.sh > /tmp/memory-harness.sh
+          git show ${{ github.event.pull_request.head.sha }}:scripts/ci/compare-memory-smoke.py > /tmp/compare-memory-smoke.py
+          chmod +x /tmp/memory-harness.sh /tmp/compare-memory-smoke.py
+      - name: Run base memory smoke
+        id: memory_base
+        continue-on-error: true
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          /tmp/memory-harness.sh \
+            --repo-root "$PWD" \
+            --profile base \
+            --duration-secs 300 \
+            --sample-interval-secs 5 \
+            --output-dir artifacts/memory-smoke/base
+      - name: Run head memory smoke
+        id: memory_head
+        if: always()
+        continue-on-error: true
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          /tmp/memory-harness.sh \
+            --repo-root "$PWD" \
+            --profile head \
+            --duration-secs 300 \
+            --sample-interval-secs 5 \
+            --output-dir artifacts/memory-smoke/head
+      - name: Compare base/head summaries
+        if: always()
+        continue-on-error: true
+        run: |
+          mkdir -p artifacts/memory-smoke
+          if [[ -f artifacts/memory-smoke/base/summary.json && -f artifacts/memory-smoke/head/summary.json ]]; then
+            /tmp/compare-memory-smoke.py \
+              artifacts/memory-smoke/base/summary.json \
+              artifacts/memory-smoke/head/summary.json \
+              artifacts/memory-smoke/comparison.json \
+              | tee artifacts/memory-smoke/comparison.txt
+          else
+            echo "base/head summary missing; skipping comparison" | tee artifacts/memory-smoke/comparison.txt
+          fi
+      - name: Upload memory smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: memory-smoke-results
+          path: artifacts/memory-smoke/
+          retention-days: 90
+
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,17 +250,28 @@ jobs:
         with:
           shared-key: check
           save-if: false
-      - name: Prepare harness scripts
+      - name: Detect harness availability
+        id: harness
         run: |
-          git show ${{ github.event.pull_request.head.sha }}:scripts/ci/memory-harness.sh > /tmp/memory-harness.sh
-          git show ${{ github.event.pull_request.head.sha }}:scripts/ci/compare-memory-smoke.py > /tmp/compare-memory-smoke.py
-          chmod +x /tmp/memory-harness.sh /tmp/compare-memory-smoke.py
+          if git cat-file -e "${{ github.event.pull_request.base.sha }}:scripts/ci/memory-harness.sh" \
+            && git cat-file -e "${{ github.event.pull_request.base.sha }}:scripts/ci/compare-memory-smoke.py"; then
+            echo "base_has_harness=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_has_harness=false" >> "$GITHUB_OUTPUT"
+          fi
+          if git cat-file -e "${{ github.event.pull_request.head.sha }}:scripts/ci/memory-harness.sh" \
+            && git cat-file -e "${{ github.event.pull_request.head.sha }}:scripts/ci/compare-memory-smoke.py"; then
+            echo "head_has_harness=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::head revision is missing memory harness scripts"
+            exit 1
+          fi
       - name: Run base memory smoke
         id: memory_base
-        continue-on-error: true
+        if: steps.harness.outputs.base_has_harness == 'true'
         run: |
           git checkout ${{ github.event.pull_request.base.sha }}
-          /tmp/memory-harness.sh \
+          scripts/ci/memory-harness.sh \
             --repo-root "$PWD" \
             --profile base \
             --duration-secs 300 \
@@ -269,29 +280,44 @@ jobs:
       - name: Run head memory smoke
         id: memory_head
         if: always()
-        continue-on-error: true
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          /tmp/memory-harness.sh \
+          scripts/ci/memory-harness.sh \
             --repo-root "$PWD" \
             --profile head \
             --duration-secs 300 \
             --sample-interval-secs 5 \
             --output-dir artifacts/memory-smoke/head
-      - name: Compare base/head summaries
-        if: always()
-        continue-on-error: true
+      - name: Record skipped comparison when base lacks harness
+        if: always() && steps.harness.outputs.base_has_harness != 'true'
         run: |
           mkdir -p artifacts/memory-smoke
-          if [[ -f artifacts/memory-smoke/base/summary.json && -f artifacts/memory-smoke/head/summary.json ]]; then
-            /tmp/compare-memory-smoke.py \
-              artifacts/memory-smoke/base/summary.json \
-              artifacts/memory-smoke/head/summary.json \
-              artifacts/memory-smoke/comparison.json \
-              | tee artifacts/memory-smoke/comparison.txt
-          else
-            echo "base/head summary missing; skipping comparison" | tee artifacts/memory-smoke/comparison.txt
+          cat > artifacts/memory-smoke/comparison.json <<'JSON'
+          {
+            "ok": false,
+            "skipped": true,
+            "reason": "base revision does not contain memory harness scripts"
+          }
+          JSON
+          echo "base revision does not contain memory harness scripts; skipped base/head comparison" \
+            | tee artifacts/memory-smoke/comparison.txt
+      - name: Compare base/head summaries
+        if: always() && steps.harness.outputs.base_has_harness == 'true'
+        run: |
+          mkdir -p artifacts/memory-smoke
+          if [[ ! -f artifacts/memory-smoke/base/summary.json ]]; then
+            echo "::error::base summary missing"
+            exit 1
           fi
+          if [[ ! -f artifacts/memory-smoke/head/summary.json ]]; then
+            echo "::error::head summary missing"
+            exit 1
+          fi
+          scripts/ci/compare-memory-smoke.py \
+            artifacts/memory-smoke/base/summary.json \
+            artifacts/memory-smoke/head/summary.json \
+            artifacts/memory-smoke/comparison.json \
+            | tee artifacts/memory-smoke/comparison.txt
       - name: Upload memory smoke artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -60,7 +60,6 @@ jobs:
           shared-key: check
           save-if: false
       - name: Run memory soak harness
-        continue-on-error: true
         run: |
           scripts/ci/memory-harness.sh \
             --repo-root "$PWD" \

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -44,3 +44,34 @@ jobs:
         # --test-threads=1: run tests sequentially for isolation (each test starts its own server)
         run: cargo test -- --ignored --nocapture --test-threads=1
         timeout-minutes: 25
+
+  memory-soak:
+    name: Memory Soak (report-only)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 95
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust-toolchain
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check
+          save-if: false
+      - name: Run memory soak harness
+        continue-on-error: true
+        run: |
+          scripts/ci/memory-harness.sh \
+            --repo-root "$PWD" \
+            --profile soak \
+            --duration-secs 3600 \
+            --sample-interval-secs 5 \
+            --output-dir artifacts/memory-soak
+      - name: Upload memory soak artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: memory-soak-results
+          path: artifacts/memory-soak/
+          retention-days: 30

--- a/scripts/ci/compare-memory-smoke.py
+++ b/scripts/ci/compare-memory-smoke.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+MIB = 1024 * 1024
+
+
+def load_summary(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(
+            "usage: scripts/ci/compare-memory-smoke.py <base-summary.json> <head-summary.json> <output-report.json>",
+            file=sys.stderr,
+        )
+        return 2
+
+    base_path = Path(sys.argv[1])
+    head_path = Path(sys.argv[2])
+    out_path = Path(sys.argv[3])
+
+    base = load_summary(base_path)
+    head = load_summary(head_path)
+
+    base_hwm = int(base.get("vm_hwm_bytes", 0))
+    head_hwm = int(head.get("vm_hwm_bytes", 0))
+    base_median = int(base.get("post_cleanup_rss_median_bytes", base.get("rss_median_bytes", 0)))
+    head_median = int(head.get("post_cleanup_rss_median_bytes", head.get("rss_median_bytes", 0)))
+
+    hwm_limit = int(base_hwm * 1.15 + 32 * MIB)
+    median_limit = int(base_median * 1.20 + 16 * MIB)
+
+    checks = {
+        "head_readiness_failures_is_zero": int(head.get("readiness_failures", 0)) == 0,
+        "head_rejected_writes_is_zero": int(head.get("rejected_writes_total", 0)) == 0,
+        "head_vm_hwm_within_threshold": head_hwm <= hwm_limit,
+        "head_post_cleanup_median_within_threshold": head_median <= median_limit,
+    }
+
+    report = {
+        "base_summary_path": str(base_path),
+        "head_summary_path": str(head_path),
+        "thresholds": {
+            "vm_hwm_limit_bytes": hwm_limit,
+            "post_cleanup_rss_median_limit_bytes": median_limit,
+        },
+        "base": {
+            "vm_hwm_bytes": base_hwm,
+            "post_cleanup_rss_median_bytes": base_median,
+        },
+        "head": {
+            "vm_hwm_bytes": head_hwm,
+            "post_cleanup_rss_median_bytes": head_median,
+            "readiness_failures": int(head.get("readiness_failures", 0)),
+            "rejected_writes_total": int(head.get("rejected_writes_total", 0)),
+        },
+        "checks": checks,
+        "ok": all(checks.values()),
+    }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+    print("Memory smoke comparison report")
+    print(f"  base vm_hwm_bytes: {base_hwm}")
+    print(f"  head vm_hwm_bytes: {head_hwm}")
+    print(f"  vm_hwm_limit_bytes: {hwm_limit}")
+    print(f"  base post_cleanup_rss_median_bytes: {base_median}")
+    print(f"  head post_cleanup_rss_median_bytes: {head_median}")
+    print(f"  post_cleanup_rss_median_limit_bytes: {median_limit}")
+    print("  checks:")
+    for name, value in checks.items():
+        print(f"    - {name}: {'PASS' if value else 'FAIL'}")
+
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/compare-memory-smoke.py
+++ b/scripts/ci/compare-memory-smoke.py
@@ -30,11 +30,15 @@ def main() -> int:
     head_hwm = int(head.get("vm_hwm_bytes", 0))
     base_median = int(base.get("post_cleanup_rss_median_bytes", base.get("rss_median_bytes", 0)))
     head_median = int(head.get("post_cleanup_rss_median_bytes", head.get("rss_median_bytes", 0)))
+    base_cleanup_samples = int(base.get("post_cleanup_rss_samples_count", 0))
+    head_cleanup_samples = int(head.get("post_cleanup_rss_samples_count", 0))
 
     hwm_limit = int(base_hwm * 1.15 + 32 * MIB)
     median_limit = int(base_median * 1.20 + 16 * MIB)
 
     checks = {
+        "base_post_cleanup_samples_present": base_cleanup_samples > 0,
+        "head_post_cleanup_samples_present": head_cleanup_samples > 0,
         "head_readiness_failures_is_zero": int(head.get("readiness_failures", 0)) == 0,
         "head_rejected_writes_is_zero": int(head.get("rejected_writes_total", 0)) == 0,
         "head_vm_hwm_within_threshold": head_hwm <= hwm_limit,
@@ -51,10 +55,12 @@ def main() -> int:
         "base": {
             "vm_hwm_bytes": base_hwm,
             "post_cleanup_rss_median_bytes": base_median,
+            "post_cleanup_rss_samples_count": base_cleanup_samples,
         },
         "head": {
             "vm_hwm_bytes": head_hwm,
             "post_cleanup_rss_median_bytes": head_median,
+            "post_cleanup_rss_samples_count": head_cleanup_samples,
             "readiness_failures": int(head.get("readiness_failures", 0)),
             "rejected_writes_total": int(head.get("rejected_writes_total", 0)),
         },
@@ -73,6 +79,8 @@ def main() -> int:
     print(f"  vm_hwm_limit_bytes: {hwm_limit}")
     print(f"  base post_cleanup_rss_median_bytes: {base_median}")
     print(f"  head post_cleanup_rss_median_bytes: {head_median}")
+    print(f"  base post_cleanup_rss_samples_count: {base_cleanup_samples}")
+    print(f"  head post_cleanup_rss_samples_count: {head_cleanup_samples}")
     print(f"  post_cleanup_rss_median_limit_bytes: {median_limit}")
     print("  checks:")
     for name, value in checks.items():

--- a/scripts/ci/memory-harness.sh
+++ b/scripts/ci/memory-harness.sh
@@ -14,6 +14,7 @@ Options:
   --repo-root DIR               Repository root (default: current directory)
   --state-dir DIR               Durable state directory (default: <output>/state)
   --max-retained-bytes N        Retained-byte cap (default: 268435456)
+  --iterator-ttl-secs N         Iterator TTL in seconds (default: 5)
   --records-per-cycle N         PutRecord calls per cycle (default: 200)
   --payload-bytes N             Raw payload bytes before base64 (default: 256)
   --skip-build                  Skip `cargo build --release --bin ferrokinesis`
@@ -28,10 +29,35 @@ require_cmd() {
     fi
 }
 
+absolute_path() {
+    python3 - "$1" <<'PY'
+import os
+import sys
+
+print(os.path.abspath(sys.argv[1]))
+PY
+}
+
 metric_value_from_text() {
     local text=$1
     local metric=$2
     awk -v metric="$metric" '$1 == metric { value = $2 } END { if (value != "") print value; else print "0" }' <<<"$text"
+}
+
+fetch_metrics_text() {
+    curl -sf "http://127.0.0.1:${PORT}/metrics" || true
+}
+
+write_phase() {
+    printf '%s' "$1" >"$PHASE_FILE"
+}
+
+read_phase() {
+    if [[ -f "$PHASE_FILE" ]]; then
+        cat "$PHASE_FILE"
+    else
+        printf 'startup'
+    fi
 }
 
 request_json() {
@@ -104,26 +130,56 @@ wait_stream_deleted() {
     return 1
 }
 
+wait_for_cleanup() {
+    local max_attempts=${1:-30}
+    local attempt=0
+    while (( attempt < max_attempts )); do
+        attempt=$((attempt + 1))
+        local metrics_text streams retained_records active_iterators open_shards
+        metrics_text="$(fetch_metrics_text)"
+        streams="$(metric_value_from_text "$metrics_text" "ferrokinesis_streams")"
+        retained_records="$(metric_value_from_text "$metrics_text" "ferrokinesis_retained_records")"
+        active_iterators="$(metric_value_from_text "$metrics_text" "ferrokinesis_active_iterators")"
+        open_shards="$(metric_value_from_text "$metrics_text" "ferrokinesis_open_shards")"
+        if [[ "$streams" == "0" && "$retained_records" == "0" && "$active_iterators" == "0" && "$open_shards" == "0" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "cleanup state not reached before timeout" >>"$HARNESS_LOG"
+    return 1
+}
+
+sample_once() {
+    local ts vmrss_kb vmhwm_kb vmrss_bytes vmhwm_bytes ready_http metrics_text metrics_json ready_http_json phase_json
+    ts="$(date -u +%s)"
+    if [[ -r "/proc/${SERVER_PID}/status" ]]; then
+        vmrss_kb="$(awk '/^VmRSS:/ {print $2; exit}' "/proc/${SERVER_PID}/status" 2>/dev/null || echo 0)"
+        vmhwm_kb="$(awk '/^VmHWM:/ {print $2; exit}' "/proc/${SERVER_PID}/status" 2>/dev/null || echo 0)"
+    else
+        vmrss_kb="$(ps -o rss= -p "$SERVER_PID" 2>/dev/null | awk '{print $1}' || echo 0)"
+        vmhwm_kb="$vmrss_kb"
+    fi
+    vmrss_bytes=$((vmrss_kb * 1024))
+    vmhwm_bytes=$((vmhwm_kb * 1024))
+    echo "${ts},${vmrss_bytes},${vmhwm_bytes}" >>"$RSS_FILE"
+
+    ready_http="$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PORT}/_health/ready" || printf '000')"
+    metrics_text="$(fetch_metrics_text)"
+    metrics_json="$(printf '%s' "$metrics_text" | jq -Rs .)"
+    ready_http_json="$(printf '%s' "$ready_http" | jq -Rs .)"
+    phase_json="$(read_phase | jq -Rs .)"
+    printf '{"ts":%s,"phase":%s,"ready_http":%s,"metrics":%s}\n' \
+        "$ts" \
+        "$phase_json" \
+        "$ready_http_json" \
+        "$metrics_json" \
+        >>"$METRICS_FILE"
+}
+
 sample_loop() {
     while kill -0 "$SERVER_PID" >/dev/null 2>&1; do
-        local ts vmrss_kb vmhwm_kb vmrss_bytes vmhwm_bytes ready_http metrics_text metrics_json
-        ts="$(date -u +%s)"
-        if [[ -r "/proc/${SERVER_PID}/status" ]]; then
-            vmrss_kb="$(awk '/^VmRSS:/ {print $2; exit}' "/proc/${SERVER_PID}/status" 2>/dev/null || echo 0)"
-            vmhwm_kb="$(awk '/^VmHWM:/ {print $2; exit}' "/proc/${SERVER_PID}/status" 2>/dev/null || echo 0)"
-        else
-            vmrss_kb="$(ps -o rss= -p "$SERVER_PID" 2>/dev/null | awk '{print $1}' || echo 0)"
-            vmhwm_kb="$vmrss_kb"
-        fi
-        vmrss_bytes=$((vmrss_kb * 1024))
-        vmhwm_bytes=$((vmhwm_kb * 1024))
-        echo "${ts},${vmrss_bytes},${vmhwm_bytes}" >>"$RSS_FILE"
-
-        ready_http="$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PORT}/_health/ready" || echo 000)"
-        metrics_text="$(curl -sf "http://127.0.0.1:${PORT}/metrics" || true)"
-        metrics_json="$(printf '%s' "$metrics_text" | jq -Rs .)"
-        echo "{\"ts\":${ts},\"ready_http\":${ready_http},\"metrics\":${metrics_json}}" >>"$METRICS_FILE"
-
+        sample_once
         sleep "$SAMPLE_INTERVAL_SECS"
     done
 }
@@ -136,6 +192,7 @@ PROFILE="smoke"
 REPO_ROOT="$(pwd)"
 STATE_DIR=""
 MAX_RETAINED_BYTES=268435456
+ITERATOR_TTL_SECS=5
 RECORDS_PER_CYCLE=200
 PAYLOAD_BYTES=256
 BUILD_BINARY=1
@@ -174,6 +231,10 @@ while [[ $# -gt 0 ]]; do
             MAX_RETAINED_BYTES=$2
             shift 2
             ;;
+        --iterator-ttl-secs)
+            ITERATOR_TTL_SECS=$2
+            shift 2
+            ;;
         --records-per-cycle)
             RECORDS_PER_CYCLE=$2
             shift 2
@@ -210,7 +271,8 @@ require_cmd jq
 require_cmd python3
 require_cmd base64
 
-OUTPUT_DIR="$(cd "$(dirname "$OUTPUT_DIR")" && pwd)/$(basename "$OUTPUT_DIR")"
+mkdir -p "$(dirname "$OUTPUT_DIR")"
+OUTPUT_DIR="$(absolute_path "$OUTPUT_DIR")"
 mkdir -p "$OUTPUT_DIR"
 
 HARNESS_LOG="${OUTPUT_DIR}/harness.log"
@@ -218,6 +280,7 @@ SERVER_LOG="${OUTPUT_DIR}/server.log"
 RSS_FILE="${OUTPUT_DIR}/rss.csv"
 METRICS_FILE="${OUTPUT_DIR}/metrics.ndjson"
 SUMMARY_FILE="${OUTPUT_DIR}/summary.json"
+PHASE_FILE="${OUTPUT_DIR}/phase.txt"
 
 if [[ -z "$STATE_DIR" ]]; then
     STATE_DIR="${OUTPUT_DIR}/state_dir"
@@ -248,9 +311,11 @@ trap cleanup EXIT
     echo "repo_root=${REPO_ROOT}"
     echo "state_dir=${STATE_DIR}"
     echo "max_retained_bytes=${MAX_RETAINED_BYTES}"
+    echo "iterator_ttl_secs=${ITERATOR_TTL_SECS}"
     echo "records_per_cycle=${RECORDS_PER_CYCLE}"
     echo "payload_bytes=${PAYLOAD_BYTES}"
 } >>"$HARNESS_LOG"
+write_phase "startup"
 
 cd "$REPO_ROOT"
 if [[ "$BUILD_BINARY" == "1" ]]; then
@@ -269,6 +334,7 @@ fi
     --state-dir "$STATE_DIR" \
     --snapshot-interval-secs 30 \
     --max-retained-bytes "$MAX_RETAINED_BYTES" \
+    --iterator-ttl-seconds "$ITERATOR_TTL_SECS" \
     --create-stream-ms 0 \
     --delete-stream-ms 0 \
     --update-stream-ms 0 \
@@ -299,6 +365,7 @@ PY
 while (( $(date -u +%s) < END_TS )); do
     STREAM_NAME="memory-gate-${PROFILE}-${CYCLES_COMPLETED}"
     echo "cycle ${CYCLES_COMPLETED}: stream=${STREAM_NAME}" >>"$HARNESS_LOG"
+    write_phase "workload"
 
     request_json "CreateStream" "{\"StreamName\":\"${STREAM_NAME}\",\"ShardCount\":1}" >/dev/null
     wait_stream_active "$STREAM_NAME" 45
@@ -333,11 +400,15 @@ while (( $(date -u +%s) < END_TS )); do
         fi
     done
 
+    write_phase "cleanup"
     request_json "DeleteStream" "{\"StreamName\":\"${STREAM_NAME}\"}" >/dev/null
     wait_stream_deleted "$STREAM_NAME" 60
+    wait_for_cleanup "$((ITERATOR_TTL_SECS + 30))"
+    sleep "$SAMPLE_INTERVAL_SECS"
     CYCLES_COMPLETED=$((CYCLES_COMPLETED + 1))
 done
 
+write_phase "complete"
 sleep "$SAMPLE_INTERVAL_SECS"
 
 FINAL_METRICS="$(curl -sf "http://127.0.0.1:${PORT}/metrics" || true)"
@@ -358,7 +429,7 @@ sample_interval_secs = int(sample_interval_secs)
 cycles_completed = int(cycles_completed)
 final_vmhwm_bytes = int(final_vmhwm_bytes)
 
-rss_values = []
+rss_samples = []
 with open(rss_file, "r", encoding="utf-8") as fh:
     next(fh, None)
     for line in fh:
@@ -368,7 +439,7 @@ with open(rss_file, "r", encoding="utf-8") as fh:
         parts = line.split(",")
         if len(parts) != 3:
             continue
-        rss_values.append(int(parts[1]))
+        rss_samples.append((int(parts[0]), int(parts[1])))
 
 readiness_failures = 0
 rejected_writes_total = 0
@@ -379,6 +450,7 @@ open_shards_max = 0
 active_iterators_max = 0
 replay_complete_last = 0
 last_snapshot_timestamp_ms_last = 0
+cleanup_timestamps = set()
 
 def metric_from_text(text: str, name: str, default: int = 0) -> int:
     value = default
@@ -402,23 +474,44 @@ with open(metrics_file, "r", encoding="utf-8") as fh:
         if not line:
             continue
         sample = json.loads(line)
-        ready_http = int(sample.get("ready_http", 0))
+        ready_http_raw = sample.get("ready_http", "000")
+        try:
+            ready_http = int(ready_http_raw)
+        except (TypeError, ValueError):
+            ready_http = 0
         if ready_http != 200:
             readiness_failures += 1
+        phase = sample.get("phase", "")
         text = sample.get("metrics", "")
+        retained_bytes = metric_from_text(text, "ferrokinesis_retained_bytes", 0)
+        retained_records = metric_from_text(text, "ferrokinesis_retained_records", 0)
+        streams = metric_from_text(text, "ferrokinesis_streams", 0)
+        open_shards = metric_from_text(text, "ferrokinesis_open_shards", 0)
+        active_iterators = metric_from_text(text, "ferrokinesis_active_iterators", 0)
         rejected_writes_total = metric_from_text(text, "ferrokinesis_rejected_writes_total", rejected_writes_total)
-        retained_bytes_max = max(retained_bytes_max, metric_from_text(text, "ferrokinesis_retained_bytes", 0))
-        retained_records_max = max(retained_records_max, metric_from_text(text, "ferrokinesis_retained_records", 0))
-        streams_max = max(streams_max, metric_from_text(text, "ferrokinesis_streams", 0))
-        open_shards_max = max(open_shards_max, metric_from_text(text, "ferrokinesis_open_shards", 0))
-        active_iterators_max = max(active_iterators_max, metric_from_text(text, "ferrokinesis_active_iterators", 0))
+        retained_bytes_max = max(retained_bytes_max, retained_bytes)
+        retained_records_max = max(retained_records_max, retained_records)
+        streams_max = max(streams_max, streams)
+        open_shards_max = max(open_shards_max, open_shards)
+        active_iterators_max = max(active_iterators_max, active_iterators)
         replay_complete_last = metric_from_text(text, "ferrokinesis_replay_complete", replay_complete_last)
         last_snapshot_timestamp_ms_last = metric_from_text(
             text, "ferrokinesis_last_snapshot_timestamp_ms", last_snapshot_timestamp_ms_last
         )
+        if (
+            phase == "cleanup"
+            and streams == 0
+            and open_shards == 0
+            and retained_records == 0
+            and active_iterators == 0
+        ):
+            cleanup_timestamps.add(int(sample["ts"]))
 
+rss_values = [value for _, value in rss_samples]
+cleanup_rss_values = [value for ts, value in rss_samples if ts in cleanup_timestamps]
 rss_peak = max(rss_values) if rss_values else 0
 rss_median = int(statistics.median(rss_values)) if rss_values else 0
+post_cleanup_rss_median = int(statistics.median(cleanup_rss_values)) if cleanup_rss_values else 0
 
 summary = {
     "profile": profile,
@@ -428,7 +521,8 @@ summary = {
     "rss_samples_count": len(rss_values),
     "vm_rss_peak_bytes": rss_peak,
     "rss_median_bytes": rss_median,
-    "post_cleanup_rss_median_bytes": rss_median,
+    "post_cleanup_rss_median_bytes": post_cleanup_rss_median,
+    "post_cleanup_rss_samples_count": len(cleanup_rss_values),
     "vm_hwm_bytes": max(final_vmhwm_bytes, rss_peak),
     "readiness_failures": readiness_failures,
     "rejected_writes_total": rejected_writes_total,

--- a/scripts/ci/memory-harness.sh
+++ b/scripts/ci/memory-harness.sh
@@ -1,0 +1,449 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/ci/memory-harness.sh [options]
+
+Options:
+  --output-dir DIR              Output directory for artifacts (required)
+  --duration-secs N             Workload duration in seconds (default: 300)
+  --sample-interval-secs N      Sampling interval in seconds (default: 5)
+  --port N                      Server port (default: 4567)
+  --profile NAME                Profile label in summary.json (default: smoke)
+  --repo-root DIR               Repository root (default: current directory)
+  --state-dir DIR               Durable state directory (default: <output>/state)
+  --max-retained-bytes N        Retained-byte cap (default: 268435456)
+  --records-per-cycle N         PutRecord calls per cycle (default: 200)
+  --payload-bytes N             Raw payload bytes before base64 (default: 256)
+  --skip-build                  Skip `cargo build --release --bin ferrokinesis`
+USAGE
+}
+
+require_cmd() {
+    local cmd=$1
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "missing required command: $cmd" >&2
+        exit 2
+    fi
+}
+
+metric_value_from_text() {
+    local text=$1
+    local metric=$2
+    awk -v metric="$metric" '$1 == metric { value = $2 } END { if (value != "") print value; else print "0" }' <<<"$text"
+}
+
+request_json() {
+    local target=$1
+    local payload=$2
+    local out status body
+    out="$(mktemp)"
+    status="$(
+        curl -sS -o "$out" -w "%{http_code}" \
+            -H "content-type: application/x-amz-json-1.1" \
+            -H "x-amz-target: Kinesis_20131202.${target}" \
+            -H "x-amz-date: 20250101T000000Z" \
+            -H "authorization: AWS4-HMAC-SHA256 Credential=test/20250101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=0000000000000000000000000000000000000000000000000000000000000000" \
+            --data "$payload" \
+            "http://127.0.0.1:${PORT}/" || true
+    )"
+    body="$(cat "$out")"
+    rm -f "$out"
+
+    if [[ "$status" != "200" ]]; then
+        echo "request ${target} failed with status ${status}: ${body}" >>"$HARNESS_LOG"
+        return 1
+    fi
+    printf '%s' "$body"
+}
+
+wait_until_ready() {
+    local max_attempts=${1:-60}
+    local attempt=0
+    while (( attempt < max_attempts )); do
+        attempt=$((attempt + 1))
+        if curl -sf "http://127.0.0.1:${PORT}/_health/ready" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+wait_stream_active() {
+    local stream_name=$1
+    local max_attempts=${2:-30}
+    local attempt=0
+    while (( attempt < max_attempts )); do
+        attempt=$((attempt + 1))
+        local body status
+        body="$(request_json "DescribeStreamSummary" "{\"StreamName\":\"${stream_name}\"}")" || true
+        status="$(jq -r '.StreamDescriptionSummary.StreamStatus // empty' <<<"$body")"
+        if [[ "$status" == "ACTIVE" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+wait_stream_deleted() {
+    local stream_name=$1
+    local max_attempts=${2:-40}
+    local attempt=0
+    while (( attempt < max_attempts )); do
+        attempt=$((attempt + 1))
+        local body
+        body="$(request_json "ListStreams" "{}")" || true
+        if ! jq -e --arg stream_name "$stream_name" '.StreamNames | index($stream_name)' <<<"$body" >/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+sample_loop() {
+    while kill -0 "$SERVER_PID" >/dev/null 2>&1; do
+        local ts vmrss_kb vmhwm_kb vmrss_bytes vmhwm_bytes ready_http metrics_text metrics_json
+        ts="$(date -u +%s)"
+        if [[ -r "/proc/${SERVER_PID}/status" ]]; then
+            vmrss_kb="$(awk '/^VmRSS:/ {print $2; exit}' "/proc/${SERVER_PID}/status" 2>/dev/null || echo 0)"
+            vmhwm_kb="$(awk '/^VmHWM:/ {print $2; exit}' "/proc/${SERVER_PID}/status" 2>/dev/null || echo 0)"
+        else
+            vmrss_kb="$(ps -o rss= -p "$SERVER_PID" 2>/dev/null | awk '{print $1}' || echo 0)"
+            vmhwm_kb="$vmrss_kb"
+        fi
+        vmrss_bytes=$((vmrss_kb * 1024))
+        vmhwm_bytes=$((vmhwm_kb * 1024))
+        echo "${ts},${vmrss_bytes},${vmhwm_bytes}" >>"$RSS_FILE"
+
+        ready_http="$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PORT}/_health/ready" || echo 000)"
+        metrics_text="$(curl -sf "http://127.0.0.1:${PORT}/metrics" || true)"
+        metrics_json="$(printf '%s' "$metrics_text" | jq -Rs .)"
+        echo "{\"ts\":${ts},\"ready_http\":${ready_http},\"metrics\":${metrics_json}}" >>"$METRICS_FILE"
+
+        sleep "$SAMPLE_INTERVAL_SECS"
+    done
+}
+
+OUTPUT_DIR=""
+DURATION_SECS=300
+SAMPLE_INTERVAL_SECS=5
+PORT=4567
+PROFILE="smoke"
+REPO_ROOT="$(pwd)"
+STATE_DIR=""
+MAX_RETAINED_BYTES=268435456
+RECORDS_PER_CYCLE=200
+PAYLOAD_BYTES=256
+BUILD_BINARY=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir)
+            OUTPUT_DIR=$2
+            shift 2
+            ;;
+        --duration-secs)
+            DURATION_SECS=$2
+            shift 2
+            ;;
+        --sample-interval-secs)
+            SAMPLE_INTERVAL_SECS=$2
+            shift 2
+            ;;
+        --port)
+            PORT=$2
+            shift 2
+            ;;
+        --profile)
+            PROFILE=$2
+            shift 2
+            ;;
+        --repo-root)
+            REPO_ROOT=$2
+            shift 2
+            ;;
+        --state-dir)
+            STATE_DIR=$2
+            shift 2
+            ;;
+        --max-retained-bytes)
+            MAX_RETAINED_BYTES=$2
+            shift 2
+            ;;
+        --records-per-cycle)
+            RECORDS_PER_CYCLE=$2
+            shift 2
+            ;;
+        --payload-bytes)
+            PAYLOAD_BYTES=$2
+            shift 2
+            ;;
+        --skip-build)
+            BUILD_BINARY=0
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+    echo "--output-dir is required" >&2
+    usage
+    exit 2
+fi
+
+require_cmd cargo
+require_cmd curl
+require_cmd jq
+require_cmd python3
+require_cmd base64
+
+OUTPUT_DIR="$(cd "$(dirname "$OUTPUT_DIR")" && pwd)/$(basename "$OUTPUT_DIR")"
+mkdir -p "$OUTPUT_DIR"
+
+HARNESS_LOG="${OUTPUT_DIR}/harness.log"
+SERVER_LOG="${OUTPUT_DIR}/server.log"
+RSS_FILE="${OUTPUT_DIR}/rss.csv"
+METRICS_FILE="${OUTPUT_DIR}/metrics.ndjson"
+SUMMARY_FILE="${OUTPUT_DIR}/summary.json"
+
+if [[ -z "$STATE_DIR" ]]; then
+    STATE_DIR="${OUTPUT_DIR}/state_dir"
+fi
+mkdir -p "$STATE_DIR"
+
+echo "timestamp,vm_rss_bytes,vm_hwm_bytes" >"$RSS_FILE"
+: >"$METRICS_FILE"
+: >"$HARNESS_LOG"
+: >"$SERVER_LOG"
+
+cleanup() {
+    if [[ -n "${SAMPLER_PID:-}" ]]; then
+        kill "$SAMPLER_PID" >/dev/null 2>&1 || true
+        wait "$SAMPLER_PID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${SERVER_PID:-}" ]]; then
+        kill "$SERVER_PID" >/dev/null 2>&1 || true
+        wait "$SERVER_PID" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+{
+    echo "profile=${PROFILE}"
+    echo "duration_secs=${DURATION_SECS}"
+    echo "sample_interval_secs=${SAMPLE_INTERVAL_SECS}"
+    echo "repo_root=${REPO_ROOT}"
+    echo "state_dir=${STATE_DIR}"
+    echo "max_retained_bytes=${MAX_RETAINED_BYTES}"
+    echo "records_per_cycle=${RECORDS_PER_CYCLE}"
+    echo "payload_bytes=${PAYLOAD_BYTES}"
+} >>"$HARNESS_LOG"
+
+cd "$REPO_ROOT"
+if [[ "$BUILD_BINARY" == "1" ]]; then
+    echo "building release binary..." >>"$HARNESS_LOG"
+    cargo build --release --bin ferrokinesis >>"$HARNESS_LOG" 2>&1
+fi
+
+SERVER_BIN="${REPO_ROOT}/target/release/ferrokinesis"
+if [[ ! -x "$SERVER_BIN" ]]; then
+    echo "server binary not found: $SERVER_BIN" >&2
+    exit 1
+fi
+
+"$SERVER_BIN" \
+    --port "$PORT" \
+    --state-dir "$STATE_DIR" \
+    --snapshot-interval-secs 30 \
+    --max-retained-bytes "$MAX_RETAINED_BYTES" \
+    --create-stream-ms 0 \
+    --delete-stream-ms 0 \
+    --update-stream-ms 0 \
+    >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+echo "server_pid=${SERVER_PID}" >>"$HARNESS_LOG"
+
+if ! wait_until_ready 90; then
+    echo "server failed readiness probe" >>"$HARNESS_LOG"
+    exit 1
+fi
+
+sample_loop &
+SAMPLER_PID=$!
+
+CYCLES_COMPLETED=0
+START_TS="$(date -u +%s)"
+END_TS=$((START_TS + DURATION_SECS))
+PAYLOAD_B64="$(python3 - "$PAYLOAD_BYTES" <<'PY'
+import base64
+import sys
+size = int(sys.argv[1])
+raw = b"A" * size
+print(base64.b64encode(raw).decode("ascii"), end="")
+PY
+)"
+
+while (( $(date -u +%s) < END_TS )); do
+    STREAM_NAME="memory-gate-${PROFILE}-${CYCLES_COMPLETED}"
+    echo "cycle ${CYCLES_COMPLETED}: stream=${STREAM_NAME}" >>"$HARNESS_LOG"
+
+    request_json "CreateStream" "{\"StreamName\":\"${STREAM_NAME}\",\"ShardCount\":1}" >/dev/null
+    wait_stream_active "$STREAM_NAME" 45
+
+    DESCRIBE_BODY="$(request_json "DescribeStream" "{\"StreamName\":\"${STREAM_NAME}\"}")"
+    SHARD_ID="$(jq -r '.StreamDescription.Shards[0].ShardId // empty' <<<"$DESCRIBE_BODY")"
+    if [[ -z "$SHARD_ID" ]]; then
+        echo "failed to resolve shard id for ${STREAM_NAME}" >>"$HARNESS_LOG"
+        exit 1
+    fi
+
+    for ((i = 0; i < RECORDS_PER_CYCLE; i++)); do
+        PARTITION_KEY="pk-${CYCLES_COMPLETED}-${i}"
+        request_json "PutRecord" \
+            "{\"StreamName\":\"${STREAM_NAME}\",\"PartitionKey\":\"${PARTITION_KEY}\",\"Data\":\"${PAYLOAD_B64}\"}" \
+            >/dev/null
+    done
+
+    ITER_BODY="$(request_json "GetShardIterator" "{\"StreamName\":\"${STREAM_NAME}\",\"ShardId\":\"${SHARD_ID}\",\"ShardIteratorType\":\"TRIM_HORIZON\"}")"
+    SHARD_ITERATOR="$(jq -r '.ShardIterator // empty' <<<"$ITER_BODY")"
+    if [[ -z "$SHARD_ITERATOR" ]]; then
+        echo "failed to acquire shard iterator for ${STREAM_NAME}" >>"$HARNESS_LOG"
+        exit 1
+    fi
+
+    for _ in $(seq 1 15); do
+        RECORDS_BODY="$(request_json "GetRecords" "{\"ShardIterator\":\"${SHARD_ITERATOR}\",\"Limit\":1000}")"
+        SHARD_ITERATOR="$(jq -r '.NextShardIterator // empty' <<<"$RECORDS_BODY")"
+        RECORD_COUNT="$(jq -r '.Records | length' <<<"$RECORDS_BODY")"
+        if [[ "$RECORD_COUNT" == "0" || -z "$SHARD_ITERATOR" ]]; then
+            break
+        fi
+    done
+
+    request_json "DeleteStream" "{\"StreamName\":\"${STREAM_NAME}\"}" >/dev/null
+    wait_stream_deleted "$STREAM_NAME" 60
+    CYCLES_COMPLETED=$((CYCLES_COMPLETED + 1))
+done
+
+sleep "$SAMPLE_INTERVAL_SECS"
+
+FINAL_METRICS="$(curl -sf "http://127.0.0.1:${PORT}/metrics" || true)"
+if [[ -r "/proc/${SERVER_PID}/status" ]]; then
+    FINAL_VMHWM_BYTES="$(( $(awk '/^VmHWM:/ {print $2; exit}' "/proc/${SERVER_PID}/status" 2>/dev/null || echo 0) * 1024 ))"
+else
+    FINAL_VMHWM_BYTES="$(( $(ps -o rss= -p "$SERVER_PID" 2>/dev/null | awk '{print $1}' || echo 0) * 1024 ))"
+fi
+
+python3 - "$RSS_FILE" "$METRICS_FILE" "$SUMMARY_FILE" "$PROFILE" "$DURATION_SECS" "$SAMPLE_INTERVAL_SECS" "$CYCLES_COMPLETED" "$FINAL_VMHWM_BYTES" <<'PY'
+import json
+import statistics
+import sys
+
+rss_file, metrics_file, summary_file, profile, duration_secs, sample_interval_secs, cycles_completed, final_vmhwm_bytes = sys.argv[1:]
+duration_secs = int(duration_secs)
+sample_interval_secs = int(sample_interval_secs)
+cycles_completed = int(cycles_completed)
+final_vmhwm_bytes = int(final_vmhwm_bytes)
+
+rss_values = []
+with open(rss_file, "r", encoding="utf-8") as fh:
+    next(fh, None)
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(",")
+        if len(parts) != 3:
+            continue
+        rss_values.append(int(parts[1]))
+
+readiness_failures = 0
+rejected_writes_total = 0
+retained_bytes_max = 0
+retained_records_max = 0
+streams_max = 0
+open_shards_max = 0
+active_iterators_max = 0
+replay_complete_last = 0
+last_snapshot_timestamp_ms_last = 0
+
+def metric_from_text(text: str, name: str, default: int = 0) -> int:
+    value = default
+    for raw in text.splitlines():
+        raw = raw.strip()
+        if not raw or raw.startswith("#"):
+            continue
+        parts = raw.split()
+        if len(parts) != 2:
+            continue
+        if parts[0] == name:
+            try:
+                value = int(float(parts[1]))
+            except ValueError:
+                pass
+    return value
+
+with open(metrics_file, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        sample = json.loads(line)
+        ready_http = int(sample.get("ready_http", 0))
+        if ready_http != 200:
+            readiness_failures += 1
+        text = sample.get("metrics", "")
+        rejected_writes_total = metric_from_text(text, "ferrokinesis_rejected_writes_total", rejected_writes_total)
+        retained_bytes_max = max(retained_bytes_max, metric_from_text(text, "ferrokinesis_retained_bytes", 0))
+        retained_records_max = max(retained_records_max, metric_from_text(text, "ferrokinesis_retained_records", 0))
+        streams_max = max(streams_max, metric_from_text(text, "ferrokinesis_streams", 0))
+        open_shards_max = max(open_shards_max, metric_from_text(text, "ferrokinesis_open_shards", 0))
+        active_iterators_max = max(active_iterators_max, metric_from_text(text, "ferrokinesis_active_iterators", 0))
+        replay_complete_last = metric_from_text(text, "ferrokinesis_replay_complete", replay_complete_last)
+        last_snapshot_timestamp_ms_last = metric_from_text(
+            text, "ferrokinesis_last_snapshot_timestamp_ms", last_snapshot_timestamp_ms_last
+        )
+
+rss_peak = max(rss_values) if rss_values else 0
+rss_median = int(statistics.median(rss_values)) if rss_values else 0
+
+summary = {
+    "profile": profile,
+    "duration_secs": duration_secs,
+    "sample_interval_secs": sample_interval_secs,
+    "cycles_completed": cycles_completed,
+    "rss_samples_count": len(rss_values),
+    "vm_rss_peak_bytes": rss_peak,
+    "rss_median_bytes": rss_median,
+    "post_cleanup_rss_median_bytes": rss_median,
+    "vm_hwm_bytes": max(final_vmhwm_bytes, rss_peak),
+    "readiness_failures": readiness_failures,
+    "rejected_writes_total": rejected_writes_total,
+    "retained_bytes_max": retained_bytes_max,
+    "retained_records_max": retained_records_max,
+    "streams_max": streams_max,
+    "open_shards_max": open_shards_max,
+    "active_iterators_max": active_iterators_max,
+    "replay_complete_last": replay_complete_last,
+    "last_snapshot_timestamp_ms_last": last_snapshot_timestamp_ms_last,
+}
+
+with open(summary_file, "w", encoding="utf-8") as fh:
+    json.dump(summary, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
+
+echo "summary written to ${SUMMARY_FILE}" >>"$HARNESS_LOG"


### PR DESCRIPTION
## Summary

First implementation slice for #41 (memory regression CI gate), intentionally report-only and non-blocking.

This PR adds:
- a reusable memory harness script that launches a real `ferrokinesis` process in durable mode and emits machine-readable artifacts
- a base-vs-head comparison helper with the proposed threshold formulas
- a report-only `memory-smoke` job in `.github/workflows/ci.yml` (runs on PRs)
- a report-only `memory-soak` job in `.github/workflows/stress.yml` (nightly/manual)

## What the harness collects

Per run it emits:
- `summary.json`
- `rss.csv`
- `metrics.ndjson`
- `server.log`
- `harness.log`

It samples:
- server process RSS/HWM (`/proc/<pid>/status` on Linux; local fallback for non-Linux)
- `/_health/ready`
- `/metrics`

And runs a deterministic create/write/read/delete stream cycle using the real Kinesis API path.

## Why this shape

This unblocks #41 without waiting for #25 to land by vendoring a small self-contained helper, while keeping the rollout report-only for baseline gathering.

## Follow-ups after this slice

- tighten the workload shape to the dedicated soak harness from #25 when available
- promote `memory-smoke` from report-only to hard gate after baseline stabilization
- promote nightly drift checks once stable

## Validation

- `bash -n scripts/ci/memory-harness.sh`
- `python3 -m py_compile scripts/ci/compare-memory-smoke.py`
- Local harness smoke run:
  - `scripts/ci/memory-harness.sh --profile local-check --duration-secs 25 --sample-interval-secs 5 --records-per-cycle 10 --payload-bytes 64 --skip-build --output-dir /tmp/ferro-memory-harness-local3`
- Local comparison check:
  - `scripts/ci/compare-memory-smoke.py /tmp/ferro-memory-harness-local3/summary.json /tmp/ferro-memory-harness-local3/summary.json /tmp/ferro-memory-harness-local3/comparison.json`

Refs: #41