### PR TITLE
feat(observability): bootstrap JSON logs and optional OTLP trace export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,6 +1278,9 @@ dependencies = [
  "md-5",
  "num-bigint",
  "num-traits",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "postcard",
  "proptest",
  "rand",
@@ -1294,6 +1297,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -1845,6 +1849,19 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -2449,6 +2466,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,6 +2575,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2601,6 +2714,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2773,7 +2909,9 @@ dependencies = [
  "cookie",
  "cookie_store",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -3458,6 +3596,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3524,6 +3673,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3531,11 +3717,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3618,6 +3808,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3627,12 +3843,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3948,6 +4167,16 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ server = [
     "dep:tracing-subscriber",
     "dep:tracing-opentelemetry",
     "dep:tower",
+    "dep:url",
     "axum/http1",
     "axum/http2",
     "axum/tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,12 @@ server = [
     "dep:clap",
     "dep:hyper",
     "dep:hyper-util",
+    "dep:opentelemetry",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry_sdk",
     "dep:toml",
     "dep:tracing-subscriber",
+    "dep:tracing-opentelemetry",
     "dep:tower",
     "axum/http1",
     "axum/http2",
@@ -112,7 +116,11 @@ toml = { version = "0.8", optional = true }
 tower = { version = "0.5", features = ["util"], optional = true }
 tower-http = { version = "0.6", features = ["trace"], optional = true }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
+tracing-opentelemetry = { version = "0.32", optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"], optional = true }
+opentelemetry = { version = "0.31", features = ["trace"], optional = true }
+opentelemetry-otlp = { version = "0.31", features = ["trace", "grpc-tonic", "http-proto"], optional = true }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"], optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "1", features = ["v4"] }
 wasm-bindgen = { version = "0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ ferrokinesis \
 ```
 
 If `--otlp-endpoint` is omitted, no OTLP exporter is started.
+When `--otlp-protocol http` is used with a base collector URL such as `http://localhost:4318`, ferrokinesis appends the standard `/v1/traces` path automatically.
 
 ## API & Test Coverage
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npm --prefix demo run dev
 - Health check endpoints (`/_health`, `/_health/ready`, `/_health/live`) for Docker/K8s
 - TOML configuration file support (`--config`)
 - Configurable AWS account ID, region, shard iterator TTL, and request body size limit
+- Structured JSON logging (`--log-format json`) and optional OTLP trace export
 - Retention period enforcement with configurable TTL-based record trimming
 - Graceful shutdown
 - TLS support with built-in certificate generation
@@ -204,6 +205,27 @@ The built-in `health-check` subcommand can be used for Docker `HEALTHCHECK`:
 ```dockerfile
 HEALTHCHECK CMD ["ferrokinesis", "health-check"]
 ```
+
+## Observability
+
+Use JSON logs for machine-readable output:
+
+```sh
+ferrokinesis --log-format json
+```
+
+Enable OTLP trace export (traces only in this iteration; `/metrics` remains the canonical metrics endpoint):
+
+```sh
+ferrokinesis \
+  --log-format json \
+  --otlp-endpoint http://localhost:4317 \
+  --otlp-protocol grpc \
+  --otel-service-name ferrokinesis \
+  --otel-sample-ratio 1.0
+```
+
+If `--otlp-endpoint` is omitted, no OTLP exporter is started.
 
 ## API & Test Coverage
 

--- a/ferrokinesis.example.toml
+++ b/ferrokinesis.example.toml
@@ -71,7 +71,7 @@
 # CLI: --otel-service-name | Env: FERROKINESIS_OTEL_SERVICE_NAME
 # otel_service_name = "ferrokinesis"
 
-# Enable per-request access logging (default: false, requires "access-log" feature)
+# Enable structured per-request completion logs (default: false, requires "access-log" feature)
 # CLI: --access-log | Env: FERROKINESIS_ACCESS_LOG
 # access_log = false
 

--- a/ferrokinesis.example.toml
+++ b/ferrokinesis.example.toml
@@ -55,6 +55,7 @@
 # log_format = "plain"
 
 # Optional OTLP endpoint for trace export (disabled when omitted)
+# For OTLP/HTTP, a base URL like http://localhost:4318 automatically uses /v1/traces.
 # CLI: --otlp-endpoint | Env: FERROKINESIS_OTLP_ENDPOINT
 # otlp_endpoint = "http://localhost:4317"
 

--- a/ferrokinesis.example.toml
+++ b/ferrokinesis.example.toml
@@ -50,6 +50,26 @@
 # CLI: --log-level | Env: FERROKINESIS_LOG_LEVEL
 # log_level = "info"
 
+# Log format (plain or json, default: "plain")
+# CLI: --log-format | Env: FERROKINESIS_LOG_FORMAT
+# log_format = "plain"
+
+# Optional OTLP endpoint for trace export (disabled when omitted)
+# CLI: --otlp-endpoint | Env: FERROKINESIS_OTLP_ENDPOINT
+# otlp_endpoint = "http://localhost:4317"
+
+# OTLP transport protocol (grpc or http, default: "grpc")
+# CLI: --otlp-protocol | Env: FERROKINESIS_OTLP_PROTOCOL
+# otlp_protocol = "grpc"
+
+# Trace sample ratio in range 0.0..=1.0 (default: 1.0)
+# CLI: --otel-sample-ratio | Env: FERROKINESIS_OTEL_SAMPLE_RATIO
+# otel_sample_ratio = 1.0
+
+# OpenTelemetry service.name resource value (default: "ferrokinesis")
+# CLI: --otel-service-name | Env: FERROKINESIS_OTEL_SERVICE_NAME
+# otel_service_name = "ferrokinesis"
+
 # Enable per-request access logging (default: false, requires "access-log" feature)
 # CLI: --access-log | Env: FERROKINESIS_ACCESS_LOG
 # access_log = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -254,8 +254,8 @@ pub fn load_config(path: &Path) -> Result<FileConfig, ConfigError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::NamedTempFile;
     use std::io::Write;
+    use tempfile::NamedTempFile;
 
     #[test]
     fn load_config_rejects_zero_max_retained_bytes() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,16 @@ pub struct FileConfig {
     pub max_request_body_mb: Option<u64>,
     /// Log level (`off`, `error`, `warn`, `info`, `debug`, `trace`). Defaults to `"info"`.
     pub log_level: Option<String>,
+    /// Log format (`plain` or `json`). Defaults to `"plain"`.
+    pub log_format: Option<String>,
+    /// Optional OTLP endpoint for exporting traces.
+    pub otlp_endpoint: Option<String>,
+    /// OTLP protocol (`grpc` or `http`). Defaults to `"grpc"` when OTLP is enabled.
+    pub otlp_protocol: Option<String>,
+    /// Optional trace sample ratio (`0.0..=1.0`). Defaults to `1.0`.
+    pub otel_sample_ratio: Option<f64>,
+    /// Optional OpenTelemetry `service.name` resource value. Defaults to `"ferrokinesis"`.
+    pub otel_service_name: Option<String>,
     /// Enable per-request access logging. Defaults to `false`.
     #[cfg(feature = "access-log")]
     pub access_log: Option<bool>,
@@ -171,6 +181,30 @@ pub fn load_config(path: &Path) -> Result<FileConfig, ConfigError> {
             ),
         });
     }
+    if let Some(ref format) = config.log_format
+        && !["plain", "json"].contains(&format.as_str())
+    {
+        return Err(ConfigError::Validation {
+            path: path.display().to_string(),
+            message: format!("log_format must be one of: plain, json — got \"{format}\""),
+        });
+    }
+    if let Some(ref protocol) = config.otlp_protocol
+        && !["grpc", "http"].contains(&protocol.as_str())
+    {
+        return Err(ConfigError::Validation {
+            path: path.display().to_string(),
+            message: format!("otlp_protocol must be one of: grpc, http — got \"{protocol}\""),
+        });
+    }
+    if let Some(ratio) = config.otel_sample_ratio
+        && !(0.0..=1.0).contains(&ratio)
+    {
+        return Err(ConfigError::Validation {
+            path: path.display().to_string(),
+            message: format!("otel_sample_ratio must be between 0.0 and 1.0, got {ratio}"),
+        });
+    }
     #[cfg(feature = "mirror")]
     if let Some(ref mirror) = config.mirror
         && let Some(concurrency) = mirror.concurrency
@@ -221,6 +255,7 @@ pub fn load_config(path: &Path) -> Result<FileConfig, ConfigError> {
 mod tests {
     use super::*;
     use tempfile::NamedTempFile;
+    use std::io::Write;
 
     #[test]
     fn load_config_rejects_zero_max_retained_bytes() {
@@ -251,6 +286,49 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("snapshot_interval_secs must be between 0 and 86400")
+        );
+    }
+
+    fn write_temp_toml(contents: &str) -> NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().expect("create temp config file");
+        file.write_all(contents.as_bytes())
+            .expect("write temp config file");
+        file
+    }
+
+    #[test]
+    fn rejects_invalid_log_format() {
+        let file = write_temp_toml("log_format = \"pretty\"\n");
+        let err = match load_config(file.path()) {
+            Ok(_) => panic!("invalid log_format should fail"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, ConfigError::Validation { .. }));
+        assert!(err.to_string().contains("log_format must be one of"));
+    }
+
+    #[test]
+    fn rejects_invalid_otlp_protocol() {
+        let file = write_temp_toml("otlp_protocol = \"tcp\"\n");
+        let err = match load_config(file.path()) {
+            Ok(_) => panic!("invalid otlp_protocol should fail"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, ConfigError::Validation { .. }));
+        assert!(err.to_string().contains("otlp_protocol must be one of"));
+    }
+
+    #[test]
+    fn rejects_out_of_range_otel_sample_ratio() {
+        let file = write_temp_toml("otel_sample_ratio = 1.1\n");
+        let err = match load_config(file.path()) {
+            Ok(_) => panic!("invalid otel_sample_ratio should fail"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, ConfigError::Validation { .. }));
+        assert!(
+            err.to_string()
+                .contains("otel_sample_ratio must be between 0.0 and 1.0")
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,7 +94,7 @@ pub struct FileConfig {
     pub otel_sample_ratio: Option<f64>,
     /// Optional OpenTelemetry `service.name` resource value. Defaults to `"ferrokinesis"`.
     pub otel_service_name: Option<String>,
-    /// Enable per-request access logging. Defaults to `false`.
+    /// Enable structured per-request completion logs. Defaults to `false`.
     #[cfg(feature = "access-log")]
     pub access_log: Option<bool>,
     /// Path to write captured PutRecord/PutRecords data (NDJSON).

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,19 @@ use std::process;
 use std::process::ExitCode;
 use std::time::Duration;
 use tracing_subscriber::prelude::*;
+use url::Url;
 
 const DEFAULT_LOG_FORMAT: &str = "plain";
 const DEFAULT_OTLP_PROTOCOL: &str = "grpc";
 const DEFAULT_OTEL_SAMPLE_RATIO: f64 = 1.0;
 const DEFAULT_OTEL_SERVICE_NAME: &str = "ferrokinesis";
+
+#[derive(Clone, Debug, Default)]
+struct TracingBootstrap {
+    otlp_enabled: bool,
+    startup_warning: Option<String>,
+    tracer_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "ferrokinesis")]
@@ -264,7 +272,7 @@ fn init_tracing_subscriber(
     otlp_protocol: OtlpProtocol,
     otel_sample_ratio: f64,
     otel_service_name: &str,
-) -> Result<(), String> {
+) -> Result<TracingBootstrap, String> {
     let mut env_filter = if std::env::var("RUST_LOG").is_ok_and(|v| !v.is_empty()) {
         tracing_subscriber::EnvFilter::from_default_env()
     } else {
@@ -279,6 +287,7 @@ fn init_tracing_subscriber(
         }
     }
 
+    let mut bootstrap = TracingBootstrap::default();
     let otel_layer = match otlp_endpoint {
         Some(endpoint) => match build_otel_trace_layer(
             endpoint,
@@ -286,11 +295,15 @@ fn init_tracing_subscriber(
             otel_sample_ratio,
             otel_service_name,
         ) {
-            Ok(layer) => Some(layer),
+            Ok((layer, tracer_provider)) => {
+                bootstrap.otlp_enabled = true;
+                bootstrap.tracer_provider = Some(tracer_provider);
+                Some(layer)
+            }
             Err(err) => {
-                eprintln!(
-                    "warning: failed to initialize OTLP trace exporter ({err}); continuing without OTLP export"
-                );
+                bootstrap.startup_warning = Some(format!(
+                    "failed to initialize OTLP trace exporter ({err}); continuing without OTLP export"
+                ));
                 None
             }
         },
@@ -318,7 +331,11 @@ fn init_tracing_subscriber(
             .map_err(|e| format!("failed to initialize tracing subscriber: {e}"))?,
     }
 
-    if let Some(endpoint) = otlp_endpoint {
+    if let Some(warning) = bootstrap.startup_warning.as_deref() {
+        tracing::warn!(%warning);
+    } else if let Some(endpoint) = otlp_endpoint
+        && bootstrap.otlp_enabled
+    {
         tracing::info!(
             endpoint,
             protocol = otlp_protocol.as_str(),
@@ -328,7 +345,7 @@ fn init_tracing_subscriber(
         );
     }
 
-    Ok(())
+    Ok(bootstrap)
 }
 
 fn build_otel_trace_layer(
@@ -337,12 +354,16 @@ fn build_otel_trace_layer(
     sample_ratio: f64,
     service_name: &str,
 ) -> Result<
-    tracing_opentelemetry::OpenTelemetryLayer<
-        tracing_subscriber::Registry,
-        opentelemetry_sdk::trace::Tracer,
-    >,
+    (
+        tracing_opentelemetry::OpenTelemetryLayer<
+            tracing_subscriber::Registry,
+            opentelemetry_sdk::trace::Tracer,
+        >,
+        opentelemetry_sdk::trace::SdkTracerProvider,
+    ),
     String,
 > {
+    let endpoint = resolve_otlp_endpoint(endpoint, protocol)?;
     let resource = opentelemetry_sdk::Resource::builder()
         .with_service_name(service_name.to_owned())
         .build();
@@ -350,12 +371,12 @@ fn build_otel_trace_layer(
     let span_exporter = match protocol {
         OtlpProtocol::Grpc => opentelemetry_otlp::SpanExporter::builder()
             .with_tonic()
-            .with_endpoint(endpoint.to_owned())
+            .with_endpoint(endpoint)
             .build()
             .map_err(|e| format!("failed to build OTLP gRPC trace exporter: {e}"))?,
         OtlpProtocol::Http => opentelemetry_otlp::SpanExporter::builder()
             .with_http()
-            .with_endpoint(endpoint.to_owned())
+            .with_endpoint(endpoint)
             .build()
             .map_err(|e| format!("failed to build OTLP HTTP trace exporter: {e}"))?,
     };
@@ -368,9 +389,36 @@ fn build_otel_trace_layer(
         .with_batch_exporter(span_exporter)
         .build();
     let tracer = tracer_provider.tracer("ferrokinesis");
-    opentelemetry::global::set_tracer_provider(tracer_provider);
+    opentelemetry::global::set_tracer_provider(tracer_provider.clone());
 
-    Ok(tracing_opentelemetry::layer().with_tracer(tracer))
+    Ok((
+        tracing_opentelemetry::layer().with_tracer(tracer),
+        tracer_provider,
+    ))
+}
+
+fn resolve_otlp_endpoint(endpoint: &str, protocol: OtlpProtocol) -> Result<String, String> {
+    match protocol {
+        OtlpProtocol::Grpc => Ok(endpoint.to_owned()),
+        OtlpProtocol::Http => normalize_otlp_http_endpoint(endpoint),
+    }
+}
+
+fn normalize_otlp_http_endpoint(endpoint: &str) -> Result<String, String> {
+    let mut url = Url::parse(endpoint)
+        .map_err(|e| format!("invalid OTLP HTTP endpoint {endpoint:?}: {e}"))?;
+    if matches!(url.path(), "" | "/") {
+        url.set_path("/v1/traces");
+    }
+    Ok(url.into())
+}
+
+fn shutdown_tracing(bootstrap: &TracingBootstrap) {
+    if let Some(provider) = bootstrap.tracer_provider.as_ref()
+        && let Err(err) = provider.shutdown()
+    {
+        tracing::warn!("failed to shut down OTLP tracer provider cleanly: {err}");
+    }
 }
 
 fn resolve_store_options(
@@ -969,7 +1017,7 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    if let Err(err) = init_tracing_subscriber(
+    let tracing_bootstrap = match init_tracing_subscriber(
         &log_level,
         log_format,
         #[cfg(feature = "access-log")]
@@ -979,9 +1027,12 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
         otel_sample_ratio,
         &otel_service_name,
     ) {
-        eprintln!("{err}");
-        return ExitCode::FAILURE;
-    }
+        Ok(bootstrap) => bootstrap,
+        Err(err) => {
+            eprintln!("{err}");
+            return ExitCode::FAILURE;
+        }
+    };
 
     let capture_path = args.capture.or(file_cfg.capture);
     let scrub = args.scrub || file_cfg.scrub.unwrap_or(false);
@@ -1083,7 +1134,7 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
             let handle = axum_server::Handle::new();
             let server_handle = handle.clone();
 
-            let server = tokio::spawn(async move {
+            let mut server = tokio::spawn(async move {
                 axum_server::bind_rustls(
                     addr.parse::<std::net::SocketAddr>()
                         .expect("constructed addr always parses"),
@@ -1094,37 +1145,53 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
                 .await
             });
 
-            tokio::select! {
-                result = server => {
+            let exit_code = tokio::select! {
+                result = &mut server => {
                     match result {
-                        Ok(Ok(())) => return ExitCode::SUCCESS,
+                        Ok(Ok(())) => ExitCode::SUCCESS,
                         Ok(Err(e)) => {
                             tracing::error!("server error: {e}");
-                            return ExitCode::FAILURE;
+                            ExitCode::FAILURE
                         }
                         Err(e) => {
                             tracing::error!("server task panicked: {e}");
-                            return ExitCode::FAILURE;
+                            ExitCode::FAILURE
                         }
                     }
                 }
                 _ = shutdown_signal() => {
                     tracing::info!("shutting down gracefully...");
                     handle.graceful_shutdown(Some(Duration::from_secs(10)));
-                    return ExitCode::SUCCESS;
+                    match server.await {
+                        Ok(Ok(())) => ExitCode::SUCCESS,
+                        Ok(Err(e)) => {
+                            tracing::error!("server error during shutdown: {e}");
+                            ExitCode::FAILURE
+                        }
+                        Err(e) => {
+                            tracing::error!("server task panicked during shutdown: {e}");
+                            ExitCode::FAILURE
+                        }
+                    }
                 }
-            }
+            };
+            shutdown_tracing(&tracing_bootstrap);
+            return exit_code;
         }
     }
 
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     tracing::info!("Listening at http://{addr}");
 
-    if let Err(e) = ferrokinesis::serve_plain_http(listener, app, shutdown_signal()).await {
-        tracing::error!("server error: {e}");
-        return ExitCode::FAILURE;
-    }
-    ExitCode::SUCCESS
+    let exit_code =
+        if let Err(e) = ferrokinesis::serve_plain_http(listener, app, shutdown_signal()).await {
+            tracing::error!("server error: {e}");
+            ExitCode::FAILURE
+        } else {
+            ExitCode::SUCCESS
+        };
+    shutdown_tracing(&tracing_bootstrap);
+    exit_code
 }
 
 #[cfg(test)]
@@ -1254,5 +1321,25 @@ mod tests {
         assert_eq!(OtlpProtocol::parse("grpc").unwrap(), OtlpProtocol::Grpc);
         assert_eq!(OtlpProtocol::parse("http").unwrap(), OtlpProtocol::Http);
         assert!(OtlpProtocol::parse("udp").is_err());
+    }
+
+    #[test]
+    fn normalize_otlp_http_endpoint_defaults_to_v1_traces() {
+        assert_eq!(
+            normalize_otlp_http_endpoint("http://127.0.0.1:4318").unwrap(),
+            "http://127.0.0.1:4318/v1/traces"
+        );
+        assert_eq!(
+            normalize_otlp_http_endpoint("http://127.0.0.1:4318/").unwrap(),
+            "http://127.0.0.1:4318/v1/traces"
+        );
+    }
+
+    #[test]
+    fn normalize_otlp_http_endpoint_preserves_explicit_path() {
+        assert_eq!(
+            normalize_otlp_http_endpoint("http://127.0.0.1:4318/custom").unwrap(),
+            "http://127.0.0.1:4318/custom"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,7 @@ struct ServeArgs {
     #[arg(long, env = "FERROKINESIS_OTEL_SERVICE_NAME")]
     otel_service_name: Option<String>,
 
-    /// Enable per-request access logging (controls tower-http traces independently of RUST_LOG)
+    /// Enable structured per-request completion logs
     #[cfg(feature = "access-log")]
     #[arg(long, env = "FERROKINESIS_ACCESS_LOG",
           default_missing_value = "true", num_args = 0..=1)]
@@ -267,7 +267,6 @@ impl OtlpProtocol {
 fn init_tracing_subscriber(
     log_level: &str,
     log_format: LogFormat,
-    #[cfg(feature = "access-log")] access_log: bool,
     otlp_endpoint: Option<&str>,
     otlp_protocol: OtlpProtocol,
     otel_sample_ratio: f64,
@@ -280,11 +279,7 @@ fn init_tracing_subscriber(
     };
     #[cfg(feature = "access-log")]
     {
-        if access_log {
-            env_filter = env_filter.add_directive("tower_http::trace=info".parse().unwrap());
-        } else {
-            env_filter = env_filter.add_directive("tower_http::trace=off".parse().unwrap());
-        }
+        env_filter = env_filter.add_directive("tower_http::trace=off".parse().unwrap());
     }
 
     let mut bootstrap = TracingBootstrap::default();
@@ -1020,8 +1015,6 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
     let tracing_bootstrap = match init_tracing_subscriber(
         &log_level,
         log_format,
-        #[cfg(feature = "access-log")]
-        access_log,
         otlp_endpoint.as_deref(),
         otlp_protocol,
         otel_sample_ratio,
@@ -1062,6 +1055,12 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
 
     let (app, _store) = ferrokinesis::create_app_with_capture(options, capture_writer);
     let app = app.layer(DefaultBodyLimit::max(max_bytes));
+    #[cfg(feature = "access-log")]
+    let app = if access_log {
+        app.layer(axum::Extension(ferrokinesis::server::RequestLogging))
+    } else {
+        app
+    };
     #[cfg(feature = "mirror")]
     let app = {
         let mirror_cfg = file_cfg.mirror.unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,20 @@ use ferrokinesis::store::{
     DEFAULT_DURABLE_SNAPSHOT_INTERVAL_SECS, DurableStateOptions, StoreOptions,
     validate_durable_settings,
 };
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::WithExportConfig;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process;
 use std::process::ExitCode;
 use std::time::Duration;
+use tracing_subscriber::prelude::*;
+
+const DEFAULT_LOG_FORMAT: &str = "plain";
+const DEFAULT_OTLP_PROTOCOL: &str = "grpc";
+const DEFAULT_OTEL_SAMPLE_RATIO: f64 = 1.0;
+const DEFAULT_OTEL_SERVICE_NAME: &str = "ferrokinesis";
 
 #[derive(Parser, Debug)]
 #[command(name = "ferrokinesis")]
@@ -112,6 +120,26 @@ struct ServeArgs {
           value_parser = ["off", "error", "warn", "info", "debug", "trace"])]
     log_level: Option<String>,
 
+    /// Log format (plain or json)
+    #[arg(long, env = "FERROKINESIS_LOG_FORMAT", value_parser = ["plain", "json"])]
+    log_format: Option<String>,
+
+    /// Optional OTLP collector endpoint for trace export
+    #[arg(long, env = "FERROKINESIS_OTLP_ENDPOINT")]
+    otlp_endpoint: Option<String>,
+
+    /// OTLP transport protocol (grpc or http)
+    #[arg(long, env = "FERROKINESIS_OTLP_PROTOCOL", value_parser = ["grpc", "http"])]
+    otlp_protocol: Option<String>,
+
+    /// OpenTelemetry trace sample ratio (0.0 to 1.0)
+    #[arg(long, env = "FERROKINESIS_OTEL_SAMPLE_RATIO", value_parser = parse_sample_ratio)]
+    otel_sample_ratio: Option<f64>,
+
+    /// OpenTelemetry service.name resource attribute
+    #[arg(long, env = "FERROKINESIS_OTEL_SERVICE_NAME")]
+    otel_service_name: Option<String>,
+
     /// Enable per-request access logging (controls tower-http traces independently of RUST_LOG)
     #[cfg(feature = "access-log")]
     #[arg(long, env = "FERROKINESIS_ACCESS_LOG",
@@ -174,6 +202,175 @@ struct ServeArgs {
 /// Resolve a value using precedence: CLI/env > config file > default.
 fn resolve<T>(cli: Option<T>, file: Option<T>, default: impl FnOnce() -> T) -> T {
     cli.or(file).unwrap_or_else(default)
+}
+
+fn parse_sample_ratio(raw: &str) -> Result<f64, String> {
+    let ratio = raw
+        .parse::<f64>()
+        .map_err(|e| format!("invalid ratio {raw:?}: {e}"))?;
+    if (0.0..=1.0).contains(&ratio) {
+        Ok(ratio)
+    } else {
+        Err(format!(
+            "sample ratio must be between 0.0 and 1.0, got {ratio}"
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LogFormat {
+    Plain,
+    Json,
+}
+
+impl LogFormat {
+    fn parse(raw: &str) -> Result<Self, String> {
+        match raw {
+            "plain" => Ok(Self::Plain),
+            "json" => Ok(Self::Json),
+            _ => Err(format!("unsupported log format {raw:?}")),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OtlpProtocol {
+    Grpc,
+    Http,
+}
+
+impl OtlpProtocol {
+    fn parse(raw: &str) -> Result<Self, String> {
+        match raw {
+            "grpc" => Ok(Self::Grpc),
+            "http" => Ok(Self::Http),
+            _ => Err(format!("unsupported OTLP protocol {raw:?}")),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Grpc => "grpc",
+            Self::Http => "http",
+        }
+    }
+}
+
+fn init_tracing_subscriber(
+    log_level: &str,
+    log_format: LogFormat,
+    #[cfg(feature = "access-log")] access_log: bool,
+    otlp_endpoint: Option<&str>,
+    otlp_protocol: OtlpProtocol,
+    otel_sample_ratio: f64,
+    otel_service_name: &str,
+) -> Result<(), String> {
+    let mut env_filter = if std::env::var("RUST_LOG").is_ok_and(|v| !v.is_empty()) {
+        tracing_subscriber::EnvFilter::from_default_env()
+    } else {
+        tracing_subscriber::EnvFilter::new(log_level)
+    };
+    #[cfg(feature = "access-log")]
+    {
+        if access_log {
+            env_filter = env_filter.add_directive("tower_http::trace=info".parse().unwrap());
+        } else {
+            env_filter = env_filter.add_directive("tower_http::trace=off".parse().unwrap());
+        }
+    }
+
+    let otel_layer = match otlp_endpoint {
+        Some(endpoint) => match build_otel_trace_layer(
+            endpoint,
+            otlp_protocol,
+            otel_sample_ratio,
+            otel_service_name,
+        ) {
+            Ok(layer) => Some(layer),
+            Err(err) => {
+                eprintln!(
+                    "warning: failed to initialize OTLP trace exporter ({err}); continuing without OTLP export"
+                );
+                None
+            }
+        },
+        None => None,
+    };
+
+    match log_format {
+        LogFormat::Plain => tracing_subscriber::registry()
+            .with(otel_layer)
+            .with(tracing_subscriber::fmt::layer().with_target(false))
+            .with(env_filter)
+            .try_init()
+            .map_err(|e| format!("failed to initialize tracing subscriber: {e}"))?,
+        LogFormat::Json => tracing_subscriber::registry()
+            .with(otel_layer)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_target(false)
+                    .with_current_span(true)
+                    .with_span_list(true),
+            )
+            .with(env_filter)
+            .try_init()
+            .map_err(|e| format!("failed to initialize tracing subscriber: {e}"))?,
+    }
+
+    if let Some(endpoint) = otlp_endpoint {
+        tracing::info!(
+            endpoint,
+            protocol = otlp_protocol.as_str(),
+            sample_ratio = otel_sample_ratio,
+            service_name = otel_service_name,
+            "OTLP trace export enabled"
+        );
+    }
+
+    Ok(())
+}
+
+fn build_otel_trace_layer(
+    endpoint: &str,
+    protocol: OtlpProtocol,
+    sample_ratio: f64,
+    service_name: &str,
+) -> Result<
+    tracing_opentelemetry::OpenTelemetryLayer<
+        tracing_subscriber::Registry,
+        opentelemetry_sdk::trace::Tracer,
+    >,
+    String,
+> {
+    let resource = opentelemetry_sdk::Resource::builder()
+        .with_service_name(service_name.to_owned())
+        .build();
+
+    let span_exporter = match protocol {
+        OtlpProtocol::Grpc => opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(endpoint.to_owned())
+            .build()
+            .map_err(|e| format!("failed to build OTLP gRPC trace exporter: {e}"))?,
+        OtlpProtocol::Http => opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_endpoint(endpoint.to_owned())
+            .build()
+            .map_err(|e| format!("failed to build OTLP HTTP trace exporter: {e}"))?,
+    };
+
+    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_resource(resource)
+        .with_sampler(opentelemetry_sdk::trace::Sampler::TraceIdRatioBased(
+            sample_ratio,
+        ))
+        .with_batch_exporter(span_exporter)
+        .build();
+    let tracer = tracer_provider.tracer("ferrokinesis");
+    opentelemetry::global::set_tracer_provider(tracer_provider);
+
+    Ok(tracing_opentelemetry::layer().with_tracer(tracer))
 }
 
 fn resolve_store_options(
@@ -742,32 +939,49 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
     let port = resolve(args.port, file_cfg.port, || 4567);
     let max_request_body_mb = resolve(args.max_request_body_mb, file_cfg.max_request_body_mb, || 7);
     let log_level: String = resolve(args.log_level, file_cfg.log_level, || "info".into());
+    let log_format = resolve(args.log_format, file_cfg.log_format, || {
+        DEFAULT_LOG_FORMAT.into()
+    });
+    let otlp_endpoint = args.otlp_endpoint.or(file_cfg.otlp_endpoint);
+    let otlp_protocol = resolve(args.otlp_protocol, file_cfg.otlp_protocol, || {
+        DEFAULT_OTLP_PROTOCOL.into()
+    });
+    let otel_sample_ratio = resolve(args.otel_sample_ratio, file_cfg.otel_sample_ratio, || {
+        DEFAULT_OTEL_SAMPLE_RATIO
+    });
+    let otel_service_name = resolve(args.otel_service_name, file_cfg.otel_service_name, || {
+        DEFAULT_OTEL_SERVICE_NAME.into()
+    });
     #[cfg(feature = "access-log")]
     let access_log = resolve(args.access_log, file_cfg.access_log, || false);
 
-    // Initialize tracing subscriber.
-    // RUST_LOG takes precedence when set; otherwise use the resolved log_level.
-    #[cfg_attr(not(feature = "access-log"), allow(unused_mut))]
-    let mut env_filter = if std::env::var("RUST_LOG").is_ok_and(|v| !v.is_empty()) {
-        tracing_subscriber::EnvFilter::from_default_env()
-    } else {
-        tracing_subscriber::EnvFilter::new(&log_level)
-    };
-    // Always apply access-log directive, regardless of RUST_LOG.
-    // Later add_directive calls override earlier ones for the same target.
-    #[cfg(feature = "access-log")]
-    {
-        if access_log {
-            env_filter = env_filter.add_directive("tower_http::trace=info".parse().unwrap());
-        } else {
-            env_filter = env_filter.add_directive("tower_http::trace=off".parse().unwrap());
+    let log_format = match LogFormat::parse(&log_format) {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!("invalid log format: {err}");
+            return ExitCode::FAILURE;
         }
+    };
+    let otlp_protocol = match OtlpProtocol::parse(&otlp_protocol) {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!("invalid OTLP protocol: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Err(err) = init_tracing_subscriber(
+        &log_level,
+        log_format,
+        #[cfg(feature = "access-log")]
+        access_log,
+        otlp_endpoint.as_deref(),
+        otlp_protocol,
+        otel_sample_ratio,
+        &otel_service_name,
+    ) {
+        eprintln!("{err}");
+        return ExitCode::FAILURE;
     }
-
-    tracing_subscriber::fmt()
-        .with_env_filter(env_filter)
-        .with_target(false)
-        .init();
 
     let capture_path = args.capture.or(file_cfg.capture);
     let scrub = args.scrub || file_cfg.scrub.unwrap_or(false);
@@ -937,6 +1151,11 @@ mod tests {
             snapshot_interval_secs: None,
             max_retained_bytes: None,
             log_level: None,
+            log_format: None,
+            otlp_endpoint: None,
+            otlp_protocol: None,
+            otel_sample_ratio: None,
+            otel_service_name: None,
             #[cfg(feature = "access-log")]
             access_log: None,
             capture: None,
@@ -1012,5 +1231,28 @@ mod tests {
         assert_eq!(durable.snapshot_interval_secs, 17);
         assert_eq!(durable.max_retained_bytes, Some(2048));
         assert_eq!(options.max_retained_bytes, Some(2048));
+    }
+
+    #[test]
+    fn parse_sample_ratio_accepts_bounds() {
+        assert_eq!(parse_sample_ratio("0.0").unwrap(), 0.0);
+        assert_eq!(parse_sample_ratio("1.0").unwrap(), 1.0);
+    }
+
+    #[test]
+    fn parse_sample_ratio_rejects_out_of_range() {
+        assert!(parse_sample_ratio("-0.1").is_err());
+        assert!(parse_sample_ratio("1.01").is_err());
+    }
+
+    #[test]
+    fn parse_log_format_and_protocol() {
+        assert_eq!(LogFormat::parse("plain").unwrap(), LogFormat::Plain);
+        assert_eq!(LogFormat::parse("json").unwrap(), LogFormat::Json);
+        assert!(LogFormat::parse("pretty").is_err());
+
+        assert_eq!(OtlpProtocol::parse("grpc").unwrap(), OtlpProtocol::Grpc);
+        assert_eq!(OtlpProtocol::parse("http").unwrap(), OtlpProtocol::Http);
+        assert!(OtlpProtocol::parse("udp").is_err());
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -504,7 +504,17 @@ pub async fn handler(
                     log_and_send_error(&span, &response_headers, response_content_type, &err)
                 }
             };
-            return finalize_response(&store, Some(operation), None, request_started_ms, response);
+            let response = finalize_response(&store, Some(operation), None, request_started_ms, response);
+            let latency_us = elapsed_request_micros(request_started_ms);
+            log_request_completion(
+                &span,
+                operation,
+                &request_id,
+                response.status(),
+                latency_us,
+                None,
+            );
+            return response;
         }
 
         #[cfg(target_arch = "wasm32")]
@@ -515,7 +525,17 @@ pub async fn handler(
             );
             let response =
                 log_and_send_error(&span, &response_headers, response_content_type, &err);
-            return finalize_response(&store, Some(operation), None, request_started_ms, response);
+            let response = finalize_response(&store, Some(operation), None, request_started_ms, response);
+            let latency_us = elapsed_request_micros(request_started_ms);
+            log_request_completion(
+                &span,
+                operation,
+                &request_id,
+                response.status(),
+                latency_us,
+                Some(err.body.error_type.as_str()),
+            );
+            return response;
         }
     }
 
@@ -525,7 +545,7 @@ pub async fn handler(
         .await;
 
     // Build response first (borrows result), then move result into the mirror
-    let (response, mirrorable_result) = match dispatch_result {
+    let (response, error_type, mirrorable_result) = match dispatch_result {
         Ok(opt_result) => {
             tracing::debug!(parent: &span, "ok");
             let response = match &opt_result {
@@ -538,12 +558,12 @@ pub async fn handler(
                     (StatusCode::OK, response_headers, "").into_response()
                 }
             };
-            (response, Ok(opt_result))
+            (response, None, Ok(opt_result))
         }
         Err(err) => {
             let response =
                 log_and_send_error(&span, &response_headers, response_content_type, &err);
-            (response, Err(err))
+            (response, Some(err.body.error_type.clone()), Err(err))
         }
     };
 
@@ -570,7 +590,18 @@ pub async fn handler(
         let _ = (mirror, mirrorable_result);
     }
 
-    finalize_response(&store, Some(operation), None, request_started_ms, response)
+    let response = finalize_response(&store, Some(operation), None, request_started_ms, response);
+    let latency_us = elapsed_request_micros(request_started_ms);
+    log_request_completion(
+        &span,
+        operation,
+        &request_id,
+        response.status(),
+        latency_us,
+        error_type.as_deref(),
+    );
+
+    response
 }
 
 fn elapsed_request_micros(request_started_ms: u64) -> u64 {
@@ -614,6 +645,36 @@ fn send_kinesis_error(
             .expect("error_type must be valid ASCII"),
     );
     send_json_response(headers, content_type, &err.body, err.status_code)
+}
+
+fn log_request_completion(
+    span: &tracing::Span,
+    operation: Operation,
+    request_id: &str,
+    status: StatusCode,
+    latency_us: u64,
+    error_type: Option<&str>,
+) {
+    if let Some(error_type) = error_type {
+        tracing::info!(
+            parent: span,
+            %operation,
+            request_id,
+            status_code = status.as_u16(),
+            latency_us,
+            error_type,
+            "request completed"
+        );
+    } else {
+        tracing::info!(
+            parent: span,
+            %operation,
+            request_id,
+            status_code = status.as_u16(),
+            latency_us,
+            "request completed"
+        );
+    }
 }
 
 fn log_and_send_error(

--- a/src/server.rs
+++ b/src/server.rs
@@ -504,7 +504,8 @@ pub async fn handler(
                     log_and_send_error(&span, &response_headers, response_content_type, &err)
                 }
             };
-            let response = finalize_response(&store, Some(operation), None, request_started_ms, response);
+            let response =
+                finalize_response(&store, Some(operation), None, request_started_ms, response);
             let latency_us = elapsed_request_micros(request_started_ms);
             log_request_completion(
                 &span,
@@ -525,7 +526,8 @@ pub async fn handler(
             );
             let response =
                 log_and_send_error(&span, &response_headers, response_content_type, &err);
-            let response = finalize_response(&store, Some(operation), None, request_started_ms, response);
+            let response =
+                finalize_response(&store, Some(operation), None, request_started_ms, response);
             let latency_us = elapsed_request_micros(request_started_ms);
             log_request_completion(
                 &span,

--- a/src/server.rs
+++ b/src/server.rs
@@ -85,6 +85,24 @@ pub async fn handler(
     async move {
         let mut response_headers = HeaderMap::new();
         response_headers.insert("x-amzn-RequestId", request_id.parse().unwrap());
+        let complete = |operation: Option<Operation>,
+                        pre_operation_failure: Option<PreOperationFailureReason>,
+                        response: Response,
+                        error_type: Option<&str>| {
+            complete_response(
+                &store,
+                RequestCompletion {
+                    span: &request_span,
+                    request_id: &request_id,
+                    request_logging: &request_logging,
+                    operation,
+                    pre_operation_failure,
+                    request_started_ms,
+                    error_type,
+                },
+                response,
+            )
+        };
 
         let has_origin = headers.get("origin").is_some();
 
@@ -109,14 +127,9 @@ pub async fn handler(
                 }
                 response_headers.insert("Access-Control-Max-Age", "172800".parse().unwrap());
                 response_headers.insert("Content-Length", "0".parse().unwrap());
-                return complete_response(
-                    &store,
-                    &request_span,
-                    &request_id,
-                    &request_logging,
+                return complete(
                     None,
                     None,
-                    request_started_ms,
                     (StatusCode::OK, response_headers, "").into_response(),
                     None,
                 );
@@ -135,14 +148,9 @@ pub async fn handler(
                 "x-amzn-ErrorType",
                 constants::ACCESS_DENIED.parse().unwrap(),
             );
-            return complete_response(
-                &store,
-                &request_span,
-                &request_id,
-                &request_logging,
+            return complete(
                 None,
                 Some(PreOperationFailureReason::AccessDenied),
-                request_started_ms,
                 send_xml_error(
                     h,
                     constants::ACCESS_DENIED,
@@ -197,16 +205,11 @@ pub async fn handler(
                 constants::UNKNOWN_OPERATION
             };
             let err = KinesisErrorResponse::client_error(error_type, None);
-            return complete_response(
-                &store,
-                &request_span,
-                &request_id,
-                &request_logging,
+            return complete(
                 operation,
                 operation
                     .is_none()
                     .then_some(PreOperationFailureReason::UnknownOperation),
-                request_started_ms,
                 send_kinesis_error(&response_headers, response_content_type, &err),
                 Some(error_type),
             );
@@ -219,16 +222,11 @@ pub async fn handler(
                     "x-amzn-ErrorType",
                     constants::ACCESS_DENIED.parse().unwrap(),
                 );
-                return complete_response(
-                    &store,
-                    &request_span,
-                    &request_id,
-                    &request_logging,
+                return complete(
                     operation,
                     operation
                         .is_none()
                         .then_some(PreOperationFailureReason::AccessDenied),
-                    request_started_ms,
                     send_xml_error(
                         h,
                         constants::ACCESS_DENIED,
@@ -243,16 +241,11 @@ pub async fn handler(
                 "x-amzn-ErrorType",
                 constants::UNKNOWN_OPERATION.parse().unwrap(),
             );
-            return complete_response(
-                &store,
-                &request_span,
-                &request_id,
-                &request_logging,
+            return complete(
                 operation,
                 operation
                     .is_none()
                     .then_some(PreOperationFailureReason::UnknownOperation),
-                request_started_ms,
                 send_xml_error_code(h, constants::UNKNOWN_OPERATION, 404),
                 Some(constants::UNKNOWN_OPERATION),
             );
@@ -273,16 +266,11 @@ pub async fn handler(
             Some(Value::Object(map)) => Value::Object(map),
             Some(_) | None => {
                 if content_type == "application/json" {
-                    return complete_response(
-                        &store,
-                        &request_span,
-                        &request_id,
-                        &request_logging,
+                    return complete(
                         operation,
                         operation
                             .is_none()
                             .then_some(PreOperationFailureReason::SerializationException),
-                        request_started_ms,
                         send_json_response(
                             response_headers.clone(),
                             "application/json",
@@ -297,16 +285,11 @@ pub async fn handler(
                 }
                 let err =
                     KinesisErrorResponse::client_error(constants::SERIALIZATION_EXCEPTION, None);
-                return complete_response(
-                    &store,
-                    &request_span,
-                    &request_id,
-                    &request_logging,
+                return complete(
                     operation,
                     operation
                         .is_none()
                         .then_some(PreOperationFailureReason::SerializationException),
-                    request_started_ms,
                     send_kinesis_error(&response_headers, response_content_type, &err),
                     Some(constants::SERIALIZATION_EXCEPTION),
                 );
@@ -315,16 +298,11 @@ pub async fn handler(
 
         // After this point, application/json doesn't progress further
         if content_type == "application/json" {
-            return complete_response(
-                &store,
-                &request_span,
-                &request_id,
-                &request_logging,
+            return complete(
                 operation,
                 operation
                     .is_none()
                     .then_some(PreOperationFailureReason::UnknownOperation),
-                request_started_ms,
                 send_json_response(
                     response_headers.clone(),
                     "application/json",
@@ -340,14 +318,9 @@ pub async fn handler(
 
         let Some(operation) = operation else {
             let err = KinesisErrorResponse::client_error(constants::UNKNOWN_OPERATION, None);
-            return complete_response(
-                &store,
-                &request_span,
-                &request_id,
-                &request_logging,
+            return complete(
                 None,
                 Some(PreOperationFailureReason::UnknownOperation),
-                request_started_ms,
                 send_kinesis_error(&response_headers, response_content_type, &err),
                 Some(constants::UNKNOWN_OPERATION),
             );
@@ -356,14 +329,9 @@ pub async fn handler(
 
         if let Err(err) = store.check_available() {
             let error_type = err.body.error_type.clone();
-            return complete_response(
-                &store,
-                &request_span,
-                &request_id,
-                &request_logging,
+            return complete(
                 Some(operation),
                 None,
-                request_started_ms,
                 send_kinesis_error(&response_headers, response_content_type, &err),
                 Some(error_type.as_str()),
             );
@@ -371,14 +339,9 @@ pub async fn handler(
 
         if !service_valid {
             let err = KinesisErrorResponse::client_error(constants::UNKNOWN_OPERATION, None);
-            return complete_response(
-                &store,
-                &request_span,
-                &request_id,
-                &request_logging,
+            return complete(
                 Some(operation),
                 None,
-                request_started_ms,
                 send_kinesis_error(&response_headers, response_content_type, &err),
                 Some(constants::UNKNOWN_OPERATION),
             );
@@ -390,14 +353,9 @@ pub async fn handler(
         let auth_query = query_string.contains("X-Amz-Algorithm");
 
         if auth_header.is_some() && auth_query {
-            return complete_response(
-                &store,
-                &request_span,
-                &request_id,
-                &request_logging,
+            return complete(
                 Some(operation),
                 Some(PreOperationFailureReason::InvalidSignature),
-                request_started_ms,
                 send_error_response(
                     &response_headers,
                     content_valid,
@@ -411,14 +369,9 @@ pub async fn handler(
         }
 
         if auth_header.is_none() && !auth_query {
-            return complete_response(
-                &store,
-                &request_span,
-                &request_id,
-                &request_logging,
+            return complete(
                 Some(operation),
                 Some(PreOperationFailureReason::MissingAuthToken),
-                request_started_ms,
                 send_error_response(
                     &response_headers,
                     content_valid,
@@ -457,14 +410,9 @@ pub async fn handler(
             }
             if !msg.is_empty() {
                 msg += &format!("Authorization={auth}");
-                return complete_response(
-                    &store,
-                    &request_span,
-                    &request_id,
-                    &request_logging,
+                return complete(
                     Some(operation),
                     Some(PreOperationFailureReason::IncompleteSignature),
-                    request_started_ms,
                     send_error_response(
                         &response_headers,
                         content_valid,
@@ -508,14 +456,9 @@ pub async fn handler(
             }
             if !msg.is_empty() {
                 msg += "Re-examine the query-string parameters.";
-                return complete_response(
-                    &store,
-                    &request_span,
-                    &request_id,
-                    &request_logging,
+                return complete(
                     Some(operation),
                     Some(PreOperationFailureReason::IncompleteSignature),
-                    request_started_ms,
                     send_error_response(
                         &response_headers,
                         content_valid,
@@ -538,14 +481,9 @@ pub async fn handler(
             Ok(d) => d,
             Err(err) => {
                 let error_type = err.body.error_type.clone();
-                return complete_response(
-                    &store,
-                    &request_span,
-                    &request_id,
-                    &request_logging,
+                return complete(
                     Some(operation),
                     None,
-                    request_started_ms,
                     send_kinesis_error(&response_headers, response_content_type, &err),
                     Some(error_type.as_str()),
                 );
@@ -554,14 +492,9 @@ pub async fn handler(
 
         if let Err(err) = validation::check_validations(&data, &field_refs, None) {
             let error_type = err.body.error_type.clone();
-            return complete_response(
-                &store,
-                &request_span,
-                &request_id,
-                &request_logging,
+            return complete(
                 Some(operation),
                 None,
-                request_started_ms,
                 send_kinesis_error(&response_headers, response_content_type, &err),
                 Some(error_type.as_str()),
             );
@@ -611,14 +544,9 @@ pub async fn handler(
                     .get("x-amzn-ErrorType")
                     .and_then(|value| value.to_str().ok())
                     .map(str::to_owned);
-                return complete_response(
-                    &store,
-                    &request_span,
-                    &request_id,
-                    &request_logging,
+                return complete(
                     Some(operation),
                     None,
-                    request_started_ms,
                     response,
                     error_type.as_deref(),
                 );
@@ -633,14 +561,9 @@ pub async fn handler(
                 let response =
                     log_and_send_error(&request_span, &response_headers, response_content_type, &err);
                 let error_type = err.body.error_type.clone();
-                return complete_response(
-                    &store,
-                    &request_span,
-                    &request_id,
-                    &request_logging,
+                return complete(
                     Some(operation),
                     None,
-                    request_started_ms,
                     response,
                     Some(error_type.as_str()),
                 );
@@ -700,14 +623,9 @@ pub async fn handler(
             let _ = (mirror, mirrorable_result);
         }
 
-        complete_response(
-            &store,
-            &request_span,
-            &request_id,
-            &request_logging,
+        complete(
             Some(operation),
             None,
-            request_started_ms,
             response,
             error_type.as_deref(),
         )
@@ -720,6 +638,16 @@ fn elapsed_request_micros(request_started_ms: u64) -> u64 {
     crate::util::current_time_ms()
         .saturating_sub(request_started_ms)
         .saturating_mul(1000)
+}
+
+struct RequestCompletion<'a> {
+    span: &'a tracing::Span,
+    request_id: &'a str,
+    request_logging: &'a RequestLoggingExt,
+    operation: Option<Operation>,
+    pre_operation_failure: Option<PreOperationFailureReason>,
+    request_started_ms: u64,
+    error_type: Option<&'a str>,
 }
 
 fn finalize_response(
@@ -745,35 +673,33 @@ fn finalize_response(
 
 fn complete_response(
     store: &Store,
-    span: &tracing::Span,
-    request_id: &str,
-    request_logging: &RequestLoggingExt,
-    operation: Option<Operation>,
-    pre_operation_failure: Option<PreOperationFailureReason>,
-    request_started_ms: u64,
+    completion: RequestCompletion<'_>,
     response: Response,
-    error_type: Option<&str>,
 ) -> Response {
     let response = finalize_response(
         store,
-        operation,
-        pre_operation_failure,
-        request_started_ms,
+        completion.operation,
+        completion.pre_operation_failure,
+        completion.request_started_ms,
         response,
     );
-    let latency_us = elapsed_request_micros(request_started_ms);
-    span.record("status_code", &response.status().as_u16());
-    if let Some(error_type) = error_type {
-        span.record("error_type", &tracing::field::display(error_type));
+    let latency_us = elapsed_request_micros(completion.request_started_ms);
+    completion
+        .span
+        .record("status_code", response.status().as_u16());
+    if let Some(error_type) = completion.error_type {
+        completion
+            .span
+            .record("error_type", tracing::field::display(error_type));
     }
-    if request_logging_enabled(request_logging) {
+    if request_logging_enabled(completion.request_logging) {
         log_request_completion(
-            span,
-            operation,
-            request_id,
+            completion.span,
+            completion.operation,
+            completion.request_id,
             response.status(),
             latency_us,
-            error_type,
+            completion.error_type,
         );
     }
     response
@@ -781,7 +707,7 @@ fn complete_response(
 
 fn record_operation(span: &tracing::Span, operation: Option<Operation>) {
     if let Some(operation) = operation {
-        span.record("operation", &tracing::field::display(operation));
+        span.record("operation", tracing::field::display(operation));
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,7 @@ use crate::mirror::Mirror;
 use crate::store::Store;
 use crate::validation;
 use axum::body::Bytes;
-#[cfg(feature = "mirror")]
+#[cfg(any(feature = "access-log", feature = "mirror"))]
 use axum::extract::Extension;
 use axum::extract::{Request, State};
 use axum::http::{HeaderMap, Method, StatusCode, Uri};
@@ -35,6 +35,16 @@ use tracing::Instrument;
 type MirrorExt = Option<Extension<Arc<Mirror>>>;
 #[cfg(not(feature = "mirror"))]
 type MirrorExt = ();
+#[cfg(feature = "access-log")]
+type RequestLoggingExt = Option<Extension<RequestLogging>>;
+#[cfg(not(feature = "access-log"))]
+type RequestLoggingExt = ();
+
+/// Marker extension layered by the binary to enable structured request completion logs.
+#[cfg(feature = "access-log")]
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug)]
+pub struct RequestLogging;
 
 /// Axum fallback handler implementing the Kinesis wire protocol.
 ///
@@ -57,141 +67,81 @@ pub async fn handler(
     uri: Uri,
     headers: HeaderMap,
     State(store): State<Store>,
+    request_logging: RequestLoggingExt,
     mirror: MirrorExt,
     body: Bytes,
 ) -> Response {
     let request_id = uuid::Uuid::new_v4().to_string();
     let request_started_ms = crate::util::current_time_ms();
+    let span = tracing::info_span!(
+        "kinesis",
+        request_id = %request_id,
+        operation = tracing::field::Empty,
+        status_code = tracing::field::Empty,
+        error_type = tracing::field::Empty,
+    );
+    let request_span = span.clone();
 
-    let mut response_headers = HeaderMap::new();
-    response_headers.insert("x-amzn-RequestId", request_id.parse().unwrap());
+    async move {
+        let mut response_headers = HeaderMap::new();
+        response_headers.insert("x-amzn-RequestId", request_id.parse().unwrap());
 
-    let has_origin = headers.get("origin").is_some();
+        let has_origin = headers.get("origin").is_some();
 
-    if method != Method::OPTIONS || !has_origin {
-        let id2 = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            rand::random::<[u8; 72]>(),
-        );
-        response_headers.insert("x-amz-id-2", id2.parse().unwrap());
-    }
+        if method != Method::OPTIONS || !has_origin {
+            let id2 = base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                rand::random::<[u8; 72]>(),
+            );
+            response_headers.insert("x-amz-id-2", id2.parse().unwrap());
+        }
 
-    // CORS handling
-    if has_origin {
-        response_headers.insert("Access-Control-Allow-Origin", "*".parse().unwrap());
+        // CORS handling
+        if has_origin {
+            response_headers.insert("Access-Control-Allow-Origin", "*".parse().unwrap());
 
-        if method == Method::OPTIONS {
-            if let Some(req_headers) = headers.get("access-control-request-headers") {
-                response_headers.insert("Access-Control-Allow-Headers", req_headers.clone());
+            if method == Method::OPTIONS {
+                if let Some(req_headers) = headers.get("access-control-request-headers") {
+                    response_headers.insert("Access-Control-Allow-Headers", req_headers.clone());
+                }
+                if let Some(req_method) = headers.get("access-control-request-method") {
+                    response_headers.insert("Access-Control-Allow-Methods", req_method.clone());
+                }
+                response_headers.insert("Access-Control-Max-Age", "172800".parse().unwrap());
+                response_headers.insert("Content-Length", "0".parse().unwrap());
+                return complete_response(
+                    &store,
+                    &request_span,
+                    &request_id,
+                    &request_logging,
+                    None,
+                    None,
+                    request_started_ms,
+                    (StatusCode::OK, response_headers, "").into_response(),
+                    None,
+                );
             }
-            if let Some(req_method) = headers.get("access-control-request-method") {
-                response_headers.insert("Access-Control-Allow-Methods", req_method.clone());
-            }
-            response_headers.insert("Access-Control-Max-Age", "172800".parse().unwrap());
-            response_headers.insert("Content-Length", "0".parse().unwrap());
-            return finalize_response(
-                &store,
-                None,
-                None,
-                request_started_ms,
-                (StatusCode::OK, response_headers, "").into_response(),
+
+            response_headers.insert(
+                "Access-Control-Expose-Headers",
+                "x-amzn-RequestId,x-amzn-ErrorType,x-amz-request-id,x-amz-id-2,x-amzn-ErrorMessage,Date".parse().unwrap(),
             );
         }
 
-        response_headers.insert(
-            "Access-Control-Expose-Headers",
-            "x-amzn-RequestId,x-amzn-ErrorType,x-amz-request-id,x-amz-id-2,x-amzn-ErrorMessage,Date".parse().unwrap(),
-        );
-    }
-
-    // Non-POST methods
-    if method != Method::POST {
-        let mut h = response_headers.clone();
-        h.insert(
-            "x-amzn-ErrorType",
-            constants::ACCESS_DENIED.parse().unwrap(),
-        );
-        return finalize_response(
-            &store,
-            None,
-            Some(PreOperationFailureReason::AccessDenied),
-            request_started_ms,
-            send_xml_error(
-                h,
-                constants::ACCESS_DENIED,
-                "Unable to determine service/operation name to be authorized",
-                403,
-            ),
-        );
-    }
-
-    // Parse content type
-    let content_type = headers
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("")
-        .split(';')
-        .next()
-        .unwrap_or("")
-        .trim();
-
-    let content_valid = matches!(
-        content_type,
-        "application/x-amz-json-1.1" | "application/x-amz-cbor-1.1" | "application/json"
-    );
-
-    // Parse target
-    let target = headers
-        .get("x-amz-target")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-
-    let parts: Vec<&str> = target.splitn(2, '.').collect();
-    let service = parts.first().copied().unwrap_or("");
-    let operation_str = if parts.len() > 1 { parts[1] } else { "" };
-
-    let service_valid = service == constants::KINESIS_API;
-    let operation = operation_str.parse::<Operation>().ok();
-    let operation_valid = operation.is_some();
-
-    let response_content_type = if content_type == constants::CONTENT_TYPE_JSON {
-        constants::CONTENT_TYPE_JSON
-    } else {
-        constants::CONTENT_TYPE_CBOR
-    };
-
-    // Check body
-    if body.is_empty() {
-        let error_type = if service_valid && operation_valid {
-            constants::SERIALIZATION_EXCEPTION
-        } else {
-            constants::UNKNOWN_OPERATION
-        };
-        let err = KinesisErrorResponse::client_error(error_type, None);
-        return finalize_response(
-            &store,
-            operation,
-            operation
-                .is_none()
-                .then_some(PreOperationFailureReason::UnknownOperation),
-            request_started_ms,
-            send_kinesis_error(&response_headers, response_content_type, &err),
-        );
-    }
-
-    if !content_valid {
-        if service.is_empty() || operation_str.is_empty() {
+        // Non-POST methods
+        if method != Method::POST {
             let mut h = response_headers.clone();
             h.insert(
                 "x-amzn-ErrorType",
                 constants::ACCESS_DENIED.parse().unwrap(),
             );
-            return finalize_response(
+            return complete_response(
                 &store,
-                operation,
-                operation
-                    .is_none()
-                    .then_some(PreOperationFailureReason::AccessDenied),
+                &request_span,
+                &request_id,
+                &request_logging,
+                None,
+                Some(PreOperationFailureReason::AccessDenied),
                 request_started_ms,
                 send_xml_error(
                     h,
@@ -199,411 +149,571 @@ pub async fn handler(
                     "Unable to determine service/operation name to be authorized",
                     403,
                 ),
+                Some(constants::ACCESS_DENIED),
             );
         }
-        let mut h = response_headers.clone();
-        h.insert(
-            "x-amzn-ErrorType",
-            constants::UNKNOWN_OPERATION.parse().unwrap(),
-        );
-        return finalize_response(
-            &store,
-            operation,
-            operation
-                .is_none()
-                .then_some(PreOperationFailureReason::UnknownOperation),
-            request_started_ms,
-            send_xml_error_code(h, constants::UNKNOWN_OPERATION, 404),
-        );
-    }
 
-    // Parse body
-    let data: Option<Value> = if content_type == constants::CONTENT_TYPE_CBOR {
-        // Parse via ciborium::Value to handle CBOR byte strings (major type 2),
-        // which SDK v2 clients send for Blob fields like Data.
-        ciborium::from_reader::<ciborium::Value, _>(&body[..])
-            .ok()
-            .map(|v| cbor_to_json(&v))
-    } else {
-        serde_json::from_slice(&body).ok()
-    };
+        // Parse content type
+        let content_type = headers
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .trim();
 
-    let data = match data {
-        Some(Value::Object(map)) => Value::Object(map),
-        Some(_) | None => {
-            if content_type == "application/json" {
-                return finalize_response(
+        let content_valid = matches!(
+            content_type,
+            "application/x-amz-json-1.1" | "application/x-amz-cbor-1.1" | "application/json"
+        );
+
+        // Parse target
+        let target = headers
+            .get("x-amz-target")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        let parts: Vec<&str> = target.splitn(2, '.').collect();
+        let service = parts.first().copied().unwrap_or("");
+        let operation_str = if parts.len() > 1 { parts[1] } else { "" };
+
+        let service_valid = service == constants::KINESIS_API;
+        let operation = operation_str.parse::<Operation>().ok();
+        let operation_valid = operation.is_some();
+        record_operation(&request_span, operation);
+
+        let response_content_type = if content_type == constants::CONTENT_TYPE_JSON {
+            constants::CONTENT_TYPE_JSON
+        } else {
+            constants::CONTENT_TYPE_CBOR
+        };
+
+        // Check body
+        if body.is_empty() {
+            let error_type = if service_valid && operation_valid {
+                constants::SERIALIZATION_EXCEPTION
+            } else {
+                constants::UNKNOWN_OPERATION
+            };
+            let err = KinesisErrorResponse::client_error(error_type, None);
+            return complete_response(
+                &store,
+                &request_span,
+                &request_id,
+                &request_logging,
+                operation,
+                operation
+                    .is_none()
+                    .then_some(PreOperationFailureReason::UnknownOperation),
+                request_started_ms,
+                send_kinesis_error(&response_headers, response_content_type, &err),
+                Some(error_type),
+            );
+        }
+
+        if !content_valid {
+            if service.is_empty() || operation_str.is_empty() {
+                let mut h = response_headers.clone();
+                h.insert(
+                    "x-amzn-ErrorType",
+                    constants::ACCESS_DENIED.parse().unwrap(),
+                );
+                return complete_response(
                     &store,
+                    &request_span,
+                    &request_id,
+                    &request_logging,
+                    operation,
+                    operation
+                        .is_none()
+                        .then_some(PreOperationFailureReason::AccessDenied),
+                    request_started_ms,
+                    send_xml_error(
+                        h,
+                        constants::ACCESS_DENIED,
+                        "Unable to determine service/operation name to be authorized",
+                        403,
+                    ),
+                    Some(constants::ACCESS_DENIED),
+                );
+            }
+            let mut h = response_headers.clone();
+            h.insert(
+                "x-amzn-ErrorType",
+                constants::UNKNOWN_OPERATION.parse().unwrap(),
+            );
+            return complete_response(
+                &store,
+                &request_span,
+                &request_id,
+                &request_logging,
+                operation,
+                operation
+                    .is_none()
+                    .then_some(PreOperationFailureReason::UnknownOperation),
+                request_started_ms,
+                send_xml_error_code(h, constants::UNKNOWN_OPERATION, 404),
+                Some(constants::UNKNOWN_OPERATION),
+            );
+        }
+
+        // Parse body
+        let data: Option<Value> = if content_type == constants::CONTENT_TYPE_CBOR {
+            // Parse via ciborium::Value to handle CBOR byte strings (major type 2),
+            // which SDK v2 clients send for Blob fields like Data.
+            ciborium::from_reader::<ciborium::Value, _>(&body[..])
+                .ok()
+                .map(|v| cbor_to_json(&v))
+        } else {
+            serde_json::from_slice(&body).ok()
+        };
+
+        let data = match data {
+            Some(Value::Object(map)) => Value::Object(map),
+            Some(_) | None => {
+                if content_type == "application/json" {
+                    return complete_response(
+                        &store,
+                        &request_span,
+                        &request_id,
+                        &request_logging,
+                        operation,
+                        operation
+                            .is_none()
+                            .then_some(PreOperationFailureReason::SerializationException),
+                        request_started_ms,
+                        send_json_response(
+                            response_headers.clone(),
+                            "application/json",
+                            &json!({
+                                "Output": {"__type": "com.amazon.coral.service#SerializationException"},
+                                "Version": "1.0",
+                            }),
+                            400,
+                        ),
+                        Some(constants::SERIALIZATION_EXCEPTION),
+                    );
+                }
+                let err =
+                    KinesisErrorResponse::client_error(constants::SERIALIZATION_EXCEPTION, None);
+                return complete_response(
+                    &store,
+                    &request_span,
+                    &request_id,
+                    &request_logging,
                     operation,
                     operation
                         .is_none()
                         .then_some(PreOperationFailureReason::SerializationException),
                     request_started_ms,
-                    send_json_response(
-                        response_headers.clone(),
-                        "application/json",
-                        &json!({
-                            "Output": {"__type": "com.amazon.coral.service#SerializationException"},
-                            "Version": "1.0",
-                        }),
-                        400,
-                    ),
+                    send_kinesis_error(&response_headers, response_content_type, &err),
+                    Some(constants::SERIALIZATION_EXCEPTION),
                 );
             }
-            let err = KinesisErrorResponse::client_error(constants::SERIALIZATION_EXCEPTION, None);
-            return finalize_response(
+        };
+
+        // After this point, application/json doesn't progress further
+        if content_type == "application/json" {
+            return complete_response(
                 &store,
+                &request_span,
+                &request_id,
+                &request_logging,
                 operation,
                 operation
                     .is_none()
-                    .then_some(PreOperationFailureReason::SerializationException),
+                    .then_some(PreOperationFailureReason::UnknownOperation),
+                request_started_ms,
+                send_json_response(
+                    response_headers.clone(),
+                    "application/json",
+                    &json!({
+                        "Output": {"__type": "com.amazon.coral.service#UnknownOperationException"},
+                        "Version": "1.0",
+                    }),
+                    404,
+                ),
+                Some(constants::UNKNOWN_OPERATION),
+            );
+        }
+
+        let Some(operation) = operation else {
+            let err = KinesisErrorResponse::client_error(constants::UNKNOWN_OPERATION, None);
+            return complete_response(
+                &store,
+                &request_span,
+                &request_id,
+                &request_logging,
+                None,
+                Some(PreOperationFailureReason::UnknownOperation),
                 request_started_ms,
                 send_kinesis_error(&response_headers, response_content_type, &err),
+                Some(constants::UNKNOWN_OPERATION),
             );
-        }
-    };
+        };
+        record_operation(&request_span, Some(operation));
 
-    // After this point, application/json doesn't progress further
-    if content_type == "application/json" {
-        return finalize_response(
-            &store,
-            operation,
-            operation
-                .is_none()
-                .then_some(PreOperationFailureReason::UnknownOperation),
-            request_started_ms,
-            send_json_response(
-                response_headers.clone(),
-                "application/json",
-                &json!({
-                    "Output": {"__type": "com.amazon.coral.service#UnknownOperationException"},
-                    "Version": "1.0",
-                }),
-                404,
-            ),
-        );
-    }
-
-    let Some(operation) = operation else {
-        let err = KinesisErrorResponse::client_error(constants::UNKNOWN_OPERATION, None);
-        return finalize_response(
-            &store,
-            None,
-            Some(PreOperationFailureReason::UnknownOperation),
-            request_started_ms,
-            send_kinesis_error(&response_headers, response_content_type, &err),
-        );
-    };
-
-    if let Err(err) = store.check_available() {
-        return finalize_response(
-            &store,
-            Some(operation),
-            None,
-            request_started_ms,
-            send_kinesis_error(&response_headers, response_content_type, &err),
-        );
-    }
-
-    if !service_valid {
-        let err = KinesisErrorResponse::client_error(constants::UNKNOWN_OPERATION, None);
-        return finalize_response(
-            &store,
-            Some(operation),
-            None,
-            request_started_ms,
-            send_kinesis_error(&response_headers, response_content_type, &err),
-        );
-    }
-
-    // Auth checking
-    let auth_header = headers.get("authorization").and_then(|v| v.to_str().ok());
-    let query_string = uri.query().unwrap_or("");
-    let auth_query = query_string.contains("X-Amz-Algorithm");
-
-    if auth_header.is_some() && auth_query {
-        return finalize_response(
-            &store,
-            Some(operation),
-            Some(PreOperationFailureReason::InvalidSignature),
-            request_started_ms,
-            send_error_response(
-                &response_headers,
-                content_valid,
-                response_content_type,
-                constants::INVALID_SIGNATURE,
-                "Found both 'X-Amz-Algorithm' as a query-string param and 'Authorization' as HTTP header.",
-                400,
-            ),
-        );
-    }
-
-    if auth_header.is_none() && !auth_query {
-        return finalize_response(
-            &store,
-            Some(operation),
-            Some(PreOperationFailureReason::MissingAuthToken),
-            request_started_ms,
-            send_error_response(
-                &response_headers,
-                content_valid,
-                response_content_type,
-                constants::MISSING_AUTH_TOKEN,
-                "Missing Authentication Token",
-                400,
-            ),
-        );
-    }
-
-    if let Some(auth) = auth_header {
-        let mut msg = String::new();
-        let auth_params: std::collections::HashMap<String, String> = auth
-            .split([',', ' '])
-            .skip(1)
-            .filter(|s| !s.is_empty())
-            .filter_map(|s| {
-                let kv: Vec<&str> = s.trim().splitn(2, '=').collect();
-                if kv.len() == 2 {
-                    Some((kv[0].to_string(), kv[1].to_string()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        for param in ["Credential", "Signature", "SignedHeaders"] {
-            if !auth_params.contains_key(param) {
-                msg += &format!("Authorization header requires '{param}' parameter. ");
-            }
-        }
-        if !headers.contains_key("x-amz-date") && !headers.contains_key("date") {
-            msg += "Authorization header requires existence of either a 'X-Amz-Date' or a 'Date' header. ";
-        }
-        if !msg.is_empty() {
-            msg += &format!("Authorization={auth}");
-            return finalize_response(
+        if let Err(err) = store.check_available() {
+            let error_type = err.body.error_type.clone();
+            return complete_response(
                 &store,
-                Some(operation),
-                Some(PreOperationFailureReason::IncompleteSignature),
-                request_started_ms,
-                send_error_response(
-                    &response_headers,
-                    content_valid,
-                    response_content_type,
-                    constants::INCOMPLETE_SIGNATURE,
-                    &msg,
-                    403,
-                ),
-            );
-        }
-    } else {
-        // Query auth
-        let query_params: std::collections::HashMap<String, String> = uri
-            .query()
-            .unwrap_or("")
-            .split('&')
-            .filter_map(|s| {
-                let kv: Vec<&str> = s.splitn(2, '=').collect();
-                if kv.len() == 2 {
-                    Some((kv[0].to_string(), kv[1].to_string()))
-                } else if !kv[0].is_empty() {
-                    Some((kv[0].to_string(), String::new()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        let mut msg = String::new();
-        for param in [
-            "X-Amz-Algorithm",
-            "X-Amz-Credential",
-            "X-Amz-Signature",
-            "X-Amz-SignedHeaders",
-            "X-Amz-Date",
-        ] {
-            if !query_params.contains_key(param) || query_params[param].is_empty() {
-                msg += &format!("AWS query-string parameters must include '{param}'. ");
-            }
-        }
-        if !msg.is_empty() {
-            msg += "Re-examine the query-string parameters.";
-            return finalize_response(
-                &store,
-                Some(operation),
-                Some(PreOperationFailureReason::IncompleteSignature),
-                request_started_ms,
-                send_error_response(
-                    &response_headers,
-                    content_valid,
-                    response_content_type,
-                    constants::INCOMPLETE_SIGNATURE,
-                    &msg,
-                    403,
-                ),
-            );
-        }
-    }
-
-    // Validate request data
-    let validation_rules = operation.validation_rules();
-    let field_refs: Vec<(&str, &validation::FieldDef)> =
-        validation_rules.iter().map(|(k, v)| (*k, v)).collect();
-
-    let data = match validation::check_types(&data, &field_refs) {
-        Ok(d) => d,
-        Err(err) => {
-            return finalize_response(
-                &store,
+                &request_span,
+                &request_id,
+                &request_logging,
                 Some(operation),
                 None,
                 request_started_ms,
                 send_kinesis_error(&response_headers, response_content_type, &err),
+                Some(error_type.as_str()),
             );
         }
-    };
 
-    if let Err(err) = validation::check_validations(&data, &field_refs, None) {
-        return finalize_response(
-            &store,
-            Some(operation),
-            None,
-            request_started_ms,
-            send_kinesis_error(&response_headers, response_content_type, &err),
-        );
-    }
+        if !service_valid {
+            let err = KinesisErrorResponse::client_error(constants::UNKNOWN_OPERATION, None);
+            return complete_response(
+                &store,
+                &request_span,
+                &request_id,
+                &request_logging,
+                Some(operation),
+                None,
+                request_started_ms,
+                send_kinesis_error(&response_headers, response_content_type, &err),
+                Some(constants::UNKNOWN_OPERATION),
+            );
+        }
 
-    let span = tracing::info_span!("kinesis", %operation, %request_id);
+        // Auth checking
+        let auth_header = headers.get("authorization").and_then(|v| v.to_str().ok());
+        let query_string = uri.query().unwrap_or("");
+        let auth_query = query_string.contains("X-Amz-Algorithm");
 
-    // Handle SubscribeToShard separately (streaming response)
-    if operation == Operation::SubscribeToShard {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let response = match store.check_available() {
-                Ok(()) => match actions::subscribe_to_shard::execute_streaming(
+        if auth_header.is_some() && auth_query {
+            return complete_response(
+                &store,
+                &request_span,
+                &request_id,
+                &request_logging,
+                Some(operation),
+                Some(PreOperationFailureReason::InvalidSignature),
+                request_started_ms,
+                send_error_response(
+                    &response_headers,
+                    content_valid,
+                    response_content_type,
+                    constants::INVALID_SIGNATURE,
+                    "Found both 'X-Amz-Algorithm' as a query-string param and 'Authorization' as HTTP header.",
+                    400,
+                ),
+                Some(constants::INVALID_SIGNATURE),
+            );
+        }
+
+        if auth_header.is_none() && !auth_query {
+            return complete_response(
+                &store,
+                &request_span,
+                &request_id,
+                &request_logging,
+                Some(operation),
+                Some(PreOperationFailureReason::MissingAuthToken),
+                request_started_ms,
+                send_error_response(
+                    &response_headers,
+                    content_valid,
+                    response_content_type,
+                    constants::MISSING_AUTH_TOKEN,
+                    "Missing Authentication Token",
+                    400,
+                ),
+                Some(constants::MISSING_AUTH_TOKEN),
+            );
+        }
+
+        if let Some(auth) = auth_header {
+            let mut msg = String::new();
+            let auth_params: std::collections::HashMap<String, String> = auth
+                .split([',', ' '])
+                .skip(1)
+                .filter(|s| !s.is_empty())
+                .filter_map(|s| {
+                    let kv: Vec<&str> = s.trim().splitn(2, '=').collect();
+                    if kv.len() == 2 {
+                        Some((kv[0].to_string(), kv[1].to_string()))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            for param in ["Credential", "Signature", "SignedHeaders"] {
+                if !auth_params.contains_key(param) {
+                    msg += &format!("Authorization header requires '{param}' parameter. ");
+                }
+            }
+            if !headers.contains_key("x-amz-date") && !headers.contains_key("date") {
+                msg += "Authorization header requires existence of either a 'X-Amz-Date' or a 'Date' header. ";
+            }
+            if !msg.is_empty() {
+                msg += &format!("Authorization={auth}");
+                return complete_response(
                     &store,
-                    data,
-                    response_content_type,
-                )
-                .instrument(span.clone())
-                .await
-                {
-                    Ok(body) => {
-                        tracing::debug!(parent: &span, "ok");
-                        response_headers.insert(
-                            "Content-Type",
-                            "application/vnd.amazon.eventstream".parse().unwrap(),
-                        );
-                        (StatusCode::OK, response_headers, body).into_response()
-                    }
-                    Err(ref err) => {
-                        log_and_send_error(&span, &response_headers, response_content_type, err)
-                    }
-                },
-                Err(err) => {
-                    log_and_send_error(&span, &response_headers, response_content_type, &err)
-                }
-            };
-            let response =
-                finalize_response(&store, Some(operation), None, request_started_ms, response);
-            let latency_us = elapsed_request_micros(request_started_ms);
-            log_request_completion(
-                &span,
-                operation,
-                &request_id,
-                response.status(),
-                latency_us,
-                None,
-            );
-            return response;
-        }
-
-        #[cfg(target_arch = "wasm32")]
-        {
-            let err = KinesisErrorResponse::client_error(
-                constants::INVALID_ARGUMENT,
-                Some("SubscribeToShard is not supported in this build."),
-            );
-            let response =
-                log_and_send_error(&span, &response_headers, response_content_type, &err);
-            let response =
-                finalize_response(&store, Some(operation), None, request_started_ms, response);
-            let latency_us = elapsed_request_micros(request_started_ms);
-            log_request_completion(
-                &span,
-                operation,
-                &request_id,
-                response.status(),
-                latency_us,
-                Some(err.body.error_type.as_str()),
-            );
-            return response;
-        }
-    }
-
-    // Execute action
-    let dispatch_result = actions::dispatch(&store, operation, data)
-        .instrument(span.clone())
-        .await;
-
-    // Build response first (borrows result), then move result into the mirror
-    let (response, error_type, mirrorable_result) = match dispatch_result {
-        Ok(opt_result) => {
-            tracing::debug!(parent: &span, "ok");
-            let response = match &opt_result {
-                Some(result) => {
-                    send_value_response(response_headers, response_content_type, result, 200)
-                }
-                None => {
-                    response_headers.insert("Content-Type", response_content_type.parse().unwrap());
-                    response_headers.insert("Content-Length", "0".parse().unwrap());
-                    (StatusCode::OK, response_headers, "").into_response()
-                }
-            };
-            (response, None, Ok(opt_result))
-        }
-        Err(err) => {
-            let response =
-                log_and_send_error(&span, &response_headers, response_content_type, &err);
-            (response, Some(err.body.error_type.clone()), Err(err))
-        }
-    };
-
-    // Mirror write operations (fire-and-forget) — result moved, not cloned
-    #[cfg(feature = "mirror")]
-    if let Some(Extension(ref mirror)) = mirror
-        && Mirror::should_mirror(&operation)
-    {
-        match mirrorable_result {
-            Ok(result) => {
-                mirror.spawn_forward(target.to_string(), content_type.to_string(), body, result);
+                    &request_span,
+                    &request_id,
+                    &request_logging,
+                    Some(operation),
+                    Some(PreOperationFailureReason::IncompleteSignature),
+                    request_started_ms,
+                    send_error_response(
+                        &response_headers,
+                        content_valid,
+                        response_content_type,
+                        constants::INCOMPLETE_SIGNATURE,
+                        &msg,
+                        403,
+                    ),
+                    Some(constants::INCOMPLETE_SIGNATURE),
+                );
             }
-            Err(e) => {
-                tracing::debug!(
-                    parent: &span,
-                    error_type = %e.body.error_type,
-                    "skipping mirror: local dispatch failed"
+        } else {
+            // Query auth
+            let query_params: std::collections::HashMap<String, String> = uri
+                .query()
+                .unwrap_or("")
+                .split('&')
+                .filter_map(|s| {
+                    let kv: Vec<&str> = s.splitn(2, '=').collect();
+                    if kv.len() == 2 {
+                        Some((kv[0].to_string(), kv[1].to_string()))
+                    } else if !kv[0].is_empty() {
+                        Some((kv[0].to_string(), String::new()))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            let mut msg = String::new();
+            for param in [
+                "X-Amz-Algorithm",
+                "X-Amz-Credential",
+                "X-Amz-Signature",
+                "X-Amz-SignedHeaders",
+                "X-Amz-Date",
+            ] {
+                if !query_params.contains_key(param) || query_params[param].is_empty() {
+                    msg += &format!("AWS query-string parameters must include '{param}'. ");
+                }
+            }
+            if !msg.is_empty() {
+                msg += "Re-examine the query-string parameters.";
+                return complete_response(
+                    &store,
+                    &request_span,
+                    &request_id,
+                    &request_logging,
+                    Some(operation),
+                    Some(PreOperationFailureReason::IncompleteSignature),
+                    request_started_ms,
+                    send_error_response(
+                        &response_headers,
+                        content_valid,
+                        response_content_type,
+                        constants::INCOMPLETE_SIGNATURE,
+                        &msg,
+                        403,
+                    ),
+                    Some(constants::INCOMPLETE_SIGNATURE),
                 );
             }
         }
-    }
-    #[cfg(not(feature = "mirror"))]
-    {
-        let _ = (mirror, mirrorable_result);
-    }
 
-    let response = finalize_response(&store, Some(operation), None, request_started_ms, response);
-    let latency_us = elapsed_request_micros(request_started_ms);
-    log_request_completion(
-        &span,
-        operation,
-        &request_id,
-        response.status(),
-        latency_us,
-        error_type.as_deref(),
-    );
+        // Validate request data
+        let validation_rules = operation.validation_rules();
+        let field_refs: Vec<(&str, &validation::FieldDef)> =
+            validation_rules.iter().map(|(k, v)| (*k, v)).collect();
 
-    response
+        let data = match validation::check_types(&data, &field_refs) {
+            Ok(d) => d,
+            Err(err) => {
+                let error_type = err.body.error_type.clone();
+                return complete_response(
+                    &store,
+                    &request_span,
+                    &request_id,
+                    &request_logging,
+                    Some(operation),
+                    None,
+                    request_started_ms,
+                    send_kinesis_error(&response_headers, response_content_type, &err),
+                    Some(error_type.as_str()),
+                );
+            }
+        };
+
+        if let Err(err) = validation::check_validations(&data, &field_refs, None) {
+            let error_type = err.body.error_type.clone();
+            return complete_response(
+                &store,
+                &request_span,
+                &request_id,
+                &request_logging,
+                Some(operation),
+                None,
+                request_started_ms,
+                send_kinesis_error(&response_headers, response_content_type, &err),
+                Some(error_type.as_str()),
+            );
+        }
+
+        // Handle SubscribeToShard separately (streaming response)
+        if operation == Operation::SubscribeToShard {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let response = match store.check_available() {
+                    Ok(()) => match actions::subscribe_to_shard::execute_streaming(
+                        &store,
+                        data,
+                        response_content_type,
+                    )
+                    .instrument(request_span.clone())
+                    .await
+                    {
+                        Ok(body) => {
+                            tracing::debug!(parent: &request_span, "ok");
+                            response_headers.insert(
+                                "Content-Type",
+                                "application/vnd.amazon.eventstream".parse().unwrap(),
+                            );
+                            (StatusCode::OK, response_headers, body).into_response()
+                        }
+                        Err(ref err) => {
+                            log_and_send_error(
+                                &request_span,
+                                &response_headers,
+                                response_content_type,
+                                err,
+                            )
+                        }
+                    },
+                    Err(err) => {
+                        log_and_send_error(
+                            &request_span,
+                            &response_headers,
+                            response_content_type,
+                            &err,
+                        )
+                    }
+                };
+                let error_type = response
+                    .headers()
+                    .get("x-amzn-ErrorType")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_owned);
+                return complete_response(
+                    &store,
+                    &request_span,
+                    &request_id,
+                    &request_logging,
+                    Some(operation),
+                    None,
+                    request_started_ms,
+                    response,
+                    error_type.as_deref(),
+                );
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            {
+                let err = KinesisErrorResponse::client_error(
+                    constants::INVALID_ARGUMENT,
+                    Some("SubscribeToShard is not supported in this build."),
+                );
+                let response =
+                    log_and_send_error(&request_span, &response_headers, response_content_type, &err);
+                let error_type = err.body.error_type.clone();
+                return complete_response(
+                    &store,
+                    &request_span,
+                    &request_id,
+                    &request_logging,
+                    Some(operation),
+                    None,
+                    request_started_ms,
+                    response,
+                    Some(error_type.as_str()),
+                );
+            }
+        }
+
+        // Execute action
+        let dispatch_result = actions::dispatch(&store, operation, data)
+            .instrument(request_span.clone())
+            .await;
+
+        // Build response first (borrows result), then move result into the mirror
+        let (response, error_type, mirrorable_result) = match dispatch_result {
+            Ok(opt_result) => {
+                tracing::debug!(parent: &request_span, "ok");
+                let response = match &opt_result {
+                    Some(result) => {
+                        send_value_response(response_headers, response_content_type, result, 200)
+                    }
+                    None => {
+                        response_headers
+                            .insert("Content-Type", response_content_type.parse().unwrap());
+                        response_headers.insert("Content-Length", "0".parse().unwrap());
+                        (StatusCode::OK, response_headers, "").into_response()
+                    }
+                };
+                (response, None, Ok(opt_result))
+            }
+            Err(err) => {
+                let response =
+                    log_and_send_error(&request_span, &response_headers, response_content_type, &err);
+                let error_type = err.body.error_type.clone();
+                (response, Some(error_type), Err(err))
+            }
+        };
+
+        // Mirror write operations (fire-and-forget) — result moved, not cloned
+        #[cfg(feature = "mirror")]
+        if let Some(Extension(ref mirror)) = mirror
+            && Mirror::should_mirror(&operation)
+        {
+            match mirrorable_result {
+                Ok(result) => {
+                    mirror.spawn_forward(target.to_string(), content_type.to_string(), body, result);
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        parent: &request_span,
+                        error_type = %e.body.error_type,
+                        "skipping mirror: local dispatch failed"
+                    );
+                }
+            }
+        }
+        #[cfg(not(feature = "mirror"))]
+        {
+            let _ = (mirror, mirrorable_result);
+        }
+
+        complete_response(
+            &store,
+            &request_span,
+            &request_id,
+            &request_logging,
+            Some(operation),
+            None,
+            request_started_ms,
+            response,
+            error_type.as_deref(),
+        )
+    }
+    .instrument(span)
+    .await
 }
 
 fn elapsed_request_micros(request_started_ms: u64) -> u64 {
@@ -633,6 +743,60 @@ fn finalize_response(
     response
 }
 
+fn complete_response(
+    store: &Store,
+    span: &tracing::Span,
+    request_id: &str,
+    request_logging: &RequestLoggingExt,
+    operation: Option<Operation>,
+    pre_operation_failure: Option<PreOperationFailureReason>,
+    request_started_ms: u64,
+    response: Response,
+    error_type: Option<&str>,
+) -> Response {
+    let response = finalize_response(
+        store,
+        operation,
+        pre_operation_failure,
+        request_started_ms,
+        response,
+    );
+    let latency_us = elapsed_request_micros(request_started_ms);
+    span.record("status_code", &response.status().as_u16());
+    if let Some(error_type) = error_type {
+        span.record("error_type", &tracing::field::display(error_type));
+    }
+    if request_logging_enabled(request_logging) {
+        log_request_completion(
+            span,
+            operation,
+            request_id,
+            response.status(),
+            latency_us,
+            error_type,
+        );
+    }
+    response
+}
+
+fn record_operation(span: &tracing::Span, operation: Option<Operation>) {
+    if let Some(operation) = operation {
+        span.record("operation", &tracing::field::display(operation));
+    }
+}
+
+fn request_logging_enabled(request_logging: &RequestLoggingExt) -> bool {
+    #[cfg(feature = "access-log")]
+    {
+        request_logging.is_some()
+    }
+    #[cfg(not(feature = "access-log"))]
+    {
+        let _ = request_logging;
+        false
+    }
+}
+
 fn send_kinesis_error(
     extra_headers: &HeaderMap,
     content_type: &str,
@@ -651,13 +815,15 @@ fn send_kinesis_error(
 
 fn log_request_completion(
     span: &tracing::Span,
-    operation: Operation,
+    operation: Option<Operation>,
     request_id: &str,
     status: StatusCode,
     latency_us: u64,
     error_type: Option<&str>,
 ) {
-    if let Some(error_type) = error_type {
+    if let Some(error_type) = error_type
+        && let Some(operation) = operation
+    {
         tracing::info!(
             parent: span,
             %operation,
@@ -667,10 +833,27 @@ fn log_request_completion(
             error_type,
             "request completed"
         );
-    } else {
+    } else if let Some(operation) = operation {
         tracing::info!(
             parent: span,
             %operation,
+            request_id,
+            status_code = status.as_u16(),
+            latency_us,
+            "request completed"
+        );
+    } else if let Some(error_type) = error_type {
+        tracing::info!(
+            parent: span,
+            request_id,
+            status_code = status.as_u16(),
+            latency_us,
+            error_type,
+            "request completed"
+        );
+    } else {
+        tracing::info!(
+            parent: span,
             request_id,
             status_code = status.as_u16(),
             latency_us,

--- a/tests/observability_runtime.rs
+++ b/tests/observability_runtime.rs
@@ -1,0 +1,281 @@
+#![cfg(unix)]
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{StatusCode, Uri};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde_json::{Value, json};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener as StdTcpListener};
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::process::{Child, Command};
+use tokio::sync::oneshot;
+
+#[derive(Clone, Debug)]
+struct CapturedRequest {
+    path: String,
+    body_len: usize,
+}
+
+struct OtlpCaptureServer {
+    addr: SocketAddr,
+    requests: Arc<Mutex<Vec<CapturedRequest>>>,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl OtlpCaptureServer {
+    async fn spawn() -> Self {
+        async fn capture(
+            State(requests): State<Arc<Mutex<Vec<CapturedRequest>>>>,
+            uri: Uri,
+            body: Bytes,
+        ) -> (StatusCode, Json<Value>) {
+            requests.lock().unwrap().push(CapturedRequest {
+                path: uri.path().to_owned(),
+                body_len: body.len(),
+            });
+            (StatusCode::OK, Json(json!({})))
+        }
+
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/", post(capture))
+            .route("/{*path}", post(capture))
+            .with_state(requests.clone());
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        Self {
+            addr,
+            requests,
+            shutdown: Some(shutdown_tx),
+            task: Some(task),
+        }
+    }
+
+    fn snapshot(&self) -> Vec<CapturedRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    async fn shutdown(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.await.unwrap();
+        }
+    }
+}
+
+fn allocate_port() -> u16 {
+    StdTcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn spawn_server(args: &[&str]) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_ferrokinesis"))
+        .args(args)
+        .env_remove("RUST_LOG")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ferrokinesis")
+}
+
+async fn wait_for_ready(port: u16) {
+    let client = reqwest::Client::new();
+    let url = format!("http://127.0.0.1:{port}/_health/ready");
+    for _ in 0..80 {
+        if let Ok(response) = client.get(&url).send().await
+            && response.status().is_success()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("server on port {port} did not become ready");
+}
+
+async fn create_stream(port: u16) {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("http://127.0.0.1:{port}/"))
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+        .header(
+            "Authorization",
+            "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=abcd1234",
+        )
+        .header("X-Amz-Date", "20150101T000000Z")
+        .json(&json!({"StreamName": "obs-test", "ShardCount": 1}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+async fn terminate_server(child: Child) -> std::process::Output {
+    let pid = child.id().expect("child pid");
+    let status = std::process::Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status()
+        .expect("send SIGTERM");
+    assert!(status.success(), "failed to send SIGTERM to pid {pid}");
+
+    tokio::time::timeout(Duration::from_secs(10), child.wait_with_output())
+        .await
+        .expect("wait for ferrokinesis shutdown")
+        .expect("collect ferrokinesis output")
+}
+
+fn combined_output(output: &std::process::Output) -> String {
+    let mut bytes = output.stdout.clone();
+    bytes.extend_from_slice(&output.stderr);
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+fn parse_json_log_lines(output: &std::process::Output) -> Vec<Value> {
+    combined_output(output)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<Value>(line).expect("valid json log line"))
+        .collect()
+}
+
+#[tokio::test]
+async fn otlp_http_base_endpoint_flushes_to_v1_traces_on_sigterm() {
+    let capture = OtlpCaptureServer::spawn().await;
+    let port = allocate_port();
+    let endpoint = format!("http://{}", capture.addr);
+    let child = spawn_server(&[
+        "--port",
+        &port.to_string(),
+        "--otlp-endpoint",
+        &endpoint,
+        "--otlp-protocol",
+        "http",
+        "--log-level",
+        "info",
+    ]);
+
+    wait_for_ready(port).await;
+    create_stream(port).await;
+
+    let output = terminate_server(child).await;
+    assert!(
+        output.status.success(),
+        "server shutdown failed: {}",
+        combined_output(&output)
+    );
+
+    let requests = capture.snapshot();
+    capture.shutdown().await;
+
+    assert!(
+        !requests.is_empty(),
+        "expected OTLP collector to receive at least one trace export"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.path == "/v1/traces" && request.body_len > 0),
+        "expected OTLP HTTP export to POST to /v1/traces, got {requests:?}"
+    );
+}
+
+#[tokio::test]
+async fn json_request_logs_include_operation_and_request_id() {
+    let port = allocate_port();
+    let child = spawn_server(&[
+        "--port",
+        &port.to_string(),
+        "--log-format",
+        "json",
+        "--log-level",
+        "info",
+    ]);
+
+    wait_for_ready(port).await;
+    create_stream(port).await;
+
+    let output = terminate_server(child).await;
+    assert!(
+        output.status.success(),
+        "server shutdown failed: {}",
+        combined_output(&output)
+    );
+
+    let logs = parse_json_log_lines(&output);
+    let request_log = logs
+        .iter()
+        .find(|line| {
+            line.get("fields")
+                .and_then(Value::as_object)
+                .is_some_and(|fields| {
+                    fields.get("message") == Some(&Value::String("request completed".into()))
+                        && fields.get("operation") == Some(&Value::String("CreateStream".into()))
+                        && fields
+                            .get("request_id")
+                            .and_then(Value::as_str)
+                            .is_some_and(|request_id| !request_id.is_empty())
+                })
+        })
+        .cloned();
+    assert!(
+        request_log.is_some(),
+        "expected JSON logs to include operation and request_id, got {}",
+        combined_output(&output)
+    );
+}
+
+#[tokio::test]
+async fn otlp_init_warning_does_not_claim_export_enabled() {
+    let port = allocate_port();
+    let child = spawn_server(&[
+        "--port",
+        &port.to_string(),
+        "--log-format",
+        "json",
+        "--otlp-endpoint",
+        "not-a-url",
+        "--otlp-protocol",
+        "http",
+        "--log-level",
+        "info",
+    ]);
+
+    wait_for_ready(port).await;
+
+    let output = terminate_server(child).await;
+    assert!(
+        output.status.success(),
+        "server shutdown failed: {}",
+        combined_output(&output)
+    );
+
+    let stderr = combined_output(&output);
+    assert!(
+        stderr.contains("failed to initialize OTLP trace exporter"),
+        "expected startup warning for OTLP init failure, got {stderr}"
+    );
+    assert!(
+        !stderr.contains("OTLP trace export enabled"),
+        "server should not claim OTLP export is enabled after init failure: {stderr}"
+    );
+}

--- a/tests/observability_runtime.rs
+++ b/tests/observability_runtime.rs
@@ -130,6 +130,19 @@ async fn create_stream(port: u16) {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
+async fn missing_auth_token(port: u16) {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("http://127.0.0.1:{port}/"))
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+        .json(&json!({"StreamName": "obs-test", "ShardCount": 1}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
 async fn terminate_server(child: Child) -> std::process::Output {
     let pid = child.id().expect("child pid");
     let status = std::process::Command::new("kill")
@@ -155,6 +168,19 @@ fn parse_json_log_lines(output: &std::process::Output) -> Vec<Value> {
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(|line| serde_json::from_str::<Value>(line).expect("valid json log line"))
+        .collect()
+}
+
+fn request_completion_logs(output: &std::process::Output) -> Vec<Value> {
+    parse_json_log_lines(output)
+        .into_iter()
+        .filter(|line| {
+            line.get("fields")
+                .and_then(Value::as_object)
+                .is_some_and(|fields| {
+                    fields.get("message") == Some(&Value::String("request completed".into()))
+                })
+        })
         .collect()
 }
 
@@ -207,6 +233,7 @@ async fn json_request_logs_include_operation_and_request_id() {
         &port.to_string(),
         "--log-format",
         "json",
+        "--access-log",
         "--log-level",
         "info",
     ]);
@@ -221,7 +248,7 @@ async fn json_request_logs_include_operation_and_request_id() {
         combined_output(&output)
     );
 
-    let logs = parse_json_log_lines(&output);
+    let logs = request_completion_logs(&output);
     let request_log = logs
         .iter()
         .find(|line| {
@@ -240,6 +267,84 @@ async fn json_request_logs_include_operation_and_request_id() {
     assert!(
         request_log.is_some(),
         "expected JSON logs to include operation and request_id, got {}",
+        combined_output(&output)
+    );
+    assert!(
+        !combined_output(&output).contains("finished processing request"),
+        "expected custom completion log to replace tower_http access logs, got {}",
+        combined_output(&output)
+    );
+}
+
+#[tokio::test]
+async fn json_request_logs_are_disabled_without_access_log() {
+    let port = allocate_port();
+    let child = spawn_server(&[
+        "--port",
+        &port.to_string(),
+        "--log-format",
+        "json",
+        "--log-level",
+        "info",
+    ]);
+
+    wait_for_ready(port).await;
+    create_stream(port).await;
+
+    let output = terminate_server(child).await;
+    assert!(
+        output.status.success(),
+        "server shutdown failed: {}",
+        combined_output(&output)
+    );
+
+    assert!(
+        request_completion_logs(&output).is_empty(),
+        "did not expect request completion logs without --access-log, got {}",
+        combined_output(&output)
+    );
+}
+
+#[tokio::test]
+async fn json_request_logs_include_early_auth_failures() {
+    let port = allocate_port();
+    let child = spawn_server(&[
+        "--port",
+        &port.to_string(),
+        "--log-format",
+        "json",
+        "--access-log",
+        "--log-level",
+        "info",
+    ]);
+
+    wait_for_ready(port).await;
+    missing_auth_token(port).await;
+
+    let output = terminate_server(child).await;
+    assert!(
+        output.status.success(),
+        "server shutdown failed: {}",
+        combined_output(&output)
+    );
+
+    let request_log = request_completion_logs(&output).into_iter().find(|line| {
+        line.get("fields")
+            .and_then(Value::as_object)
+            .is_some_and(|fields| {
+                fields.get("error_type")
+                    == Some(&Value::String("MissingAuthenticationTokenException".into()))
+                    && fields.get("status_code") == Some(&Value::Number(400.into()))
+                    && fields.get("operation") == Some(&Value::String("CreateStream".into()))
+                    && fields
+                        .get("request_id")
+                        .and_then(Value::as_str)
+                        .is_some_and(|request_id| !request_id.is_empty())
+            })
+    });
+    assert!(
+        request_log.is_some(),
+        "expected early auth failure to emit a request completion log, got {}",
         combined_output(&output)
     );
 }


### PR DESCRIPTION
## Summary
- add phase-1 observability config surface for issue #52 (`log_format`, `otlp_endpoint`, `otlp_protocol`, `otel_sample_ratio`, `otel_service_name`)
- refactor server tracing bootstrap to layered `tracing_subscriber` setup with `plain` or `json` formatters
- add optional OTLP trace exporter plumbing (gRPC/HTTP) that is only initialized when `otlp_endpoint` is configured
- keep `/metrics` untouched as the canonical metrics surface (no OTLP metrics in this PR)
- add config validation tests and parser tests for the new observability knobs
- document the new options in README.md and ferrokinesis.example.toml

## Validation
- cargo check -p ferrokinesis --bin ferrokinesis
- cargo check -p ferrokinesis --all-targets
- cargo test -p ferrokinesis --lib config::tests::
- cargo test -p ferrokinesis --bin ferrokinesis parse_

## Notes
- OTLP exporter initialization failures degrade gracefully (stderr warning + continue).
- default startup path remains plain logs with no OTLP exporter tasks/collector traffic when `--otlp-endpoint` is omitted.

Part of #52.