### PR TITLE
Add feature-gated chaos mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ server = [
     "tokio/signal",
 ]
 access-log = ["dep:tower-http"]
+chaos = ["server"]
 wasi = ["rt", "dep:httparse", "dep:tower", "dep:tracing-subscriber"]
 wasm = [
     "dep:getrandom",

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -163,44 +163,42 @@ fn build_store_options(
     validate_durable_settings(snapshot_interval_secs, max_retained_bytes)
         .map_err(|err| err.to_string())?;
 
-    Ok(StoreOptions {
-        create_stream_ms: options
-            .create_stream_ms
-            .unwrap_or(defaults.create_stream_ms),
-        delete_stream_ms: options
-            .delete_stream_ms
-            .unwrap_or(defaults.delete_stream_ms),
-        update_stream_ms: options
-            .update_stream_ms
-            .unwrap_or(defaults.update_stream_ms),
-        shard_limit: options.shard_limit.unwrap_or(defaults.shard_limit),
-        iterator_ttl_seconds: options
-            .iterator_ttl_seconds
-            .unwrap_or(defaults.iterator_ttl_seconds),
-        subscribe_to_shard_event_record_limit: defaults.subscribe_to_shard_event_record_limit,
-        subscribe_to_shard_session_ms: defaults.subscribe_to_shard_session_ms,
-        retention_check_interval_secs: options
-            .retention_check_interval_secs
-            .unwrap_or(defaults.retention_check_interval_secs),
-        enforce_limits: options.enforce_limits.unwrap_or(defaults.enforce_limits),
-        durable: defaults
-            .durable
-            .as_ref()
-            .map(|durable| DurableStateOptions {
-                state_dir: durable.state_dir.clone(),
-                snapshot_interval_secs: durable.snapshot_interval_secs,
-                max_retained_bytes,
-            }),
-        max_retained_bytes,
-        aws_account_id: options
-            .account_id
-            .clone()
-            .unwrap_or_else(|| defaults.aws_account_id.clone()),
-        aws_region: options
-            .region
-            .clone()
-            .unwrap_or_else(|| defaults.aws_region.clone()),
-    })
+    let mut resolved = defaults.clone();
+    resolved.create_stream_ms = options
+        .create_stream_ms
+        .unwrap_or(defaults.create_stream_ms);
+    resolved.delete_stream_ms = options
+        .delete_stream_ms
+        .unwrap_or(defaults.delete_stream_ms);
+    resolved.update_stream_ms = options
+        .update_stream_ms
+        .unwrap_or(defaults.update_stream_ms);
+    resolved.shard_limit = options.shard_limit.unwrap_or(defaults.shard_limit);
+    resolved.iterator_ttl_seconds = options
+        .iterator_ttl_seconds
+        .unwrap_or(defaults.iterator_ttl_seconds);
+    resolved.retention_check_interval_secs = options
+        .retention_check_interval_secs
+        .unwrap_or(defaults.retention_check_interval_secs);
+    resolved.enforce_limits = options.enforce_limits.unwrap_or(defaults.enforce_limits);
+    resolved.durable = defaults
+        .durable
+        .as_ref()
+        .map(|durable| DurableStateOptions {
+            state_dir: durable.state_dir.clone(),
+            snapshot_interval_secs: durable.snapshot_interval_secs,
+            max_retained_bytes,
+        });
+    resolved.max_retained_bytes = max_retained_bytes;
+    resolved.aws_account_id = options
+        .account_id
+        .clone()
+        .unwrap_or_else(|| defaults.aws_account_id.clone());
+    resolved.aws_region = options
+        .region
+        .clone()
+        .unwrap_or_else(|| defaults.aws_region.clone());
+    Ok(resolved)
 }
 
 #[cfg(test)]

--- a/ferrokinesis.example.toml
+++ b/ferrokinesis.example.toml
@@ -42,6 +42,14 @@
 # CLI: --retention-check-interval-secs | Env: FERROKINESIS_RETENTION_CHECK_INTERVAL_SECS
 # retention_check_interval_secs = 0
 
+# Enable chaos scenarios from a JSON config file (requires the "chaos" feature)
+# CLI: --chaos | Env: FERROKINESIS_CHAOS
+# chaos = false
+
+# Path to the JSON chaos configuration file (requires the "chaos" feature)
+# CLI: --chaos-config | Env: FERROKINESIS_CHAOS_CONFIG
+# chaos_config = "/tmp/chaos.json"
+
 # Maximum request body size in megabytes (min: 1, max: 4096, default: 7)
 # CLI: --max-request-body-mb | Env: FERROKINESIS_MAX_REQUEST_BODY_MB
 # max_request_body_mb = 7

--- a/src/actions/put_records.rs
+++ b/src/actions/put_records.rs
@@ -141,7 +141,6 @@ pub(crate) async fn execute_with_outcome(
             }
         } as u64;
 
-        let reservation = match store
         #[cfg(feature = "chaos")]
         if let Some(failure) = chaos_failures[i].as_ref() {
             failed_record_count += 1;

--- a/src/actions/put_records.rs
+++ b/src/actions/put_records.rs
@@ -40,7 +40,22 @@ fn build_capture_refs<'a>(
         .collect()
 }
 
+#[cfg_attr(not(feature = "chaos"), allow(dead_code))]
+pub(crate) struct ExecuteOutcome {
+    pub(crate) body: Option<Value>,
+    pub(crate) chaos_affected: bool,
+}
+
 pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, KinesisErrorResponse> {
+    execute_with_outcome(store, data)
+        .await
+        .map(|outcome| outcome.body)
+}
+
+pub(crate) async fn execute_with_outcome(
+    store: &Store,
+    data: Value,
+) -> Result<ExecuteOutcome, KinesisErrorResponse> {
     let stream_name = store.resolve_stream_name(&data)?;
     store.check_writable()?;
 
@@ -103,11 +118,15 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
     let allocations = store
         .allocate_sequences_batch(&stream_name, &hash_keys)
         .await?;
+    #[cfg(feature = "chaos")]
+    let chaos_failures = store.chaos_put_records_failures(&stream_name, &allocations);
 
     let mut return_records: Vec<Value> = Vec::with_capacity(records.len());
     let mut batch: Vec<(String, StoredRecordRef<'_>)> = Vec::with_capacity(records.len());
     let mut reservations = Vec::with_capacity(records.len());
     let mut failed_record_count = 0u64;
+    #[cfg(feature = "chaos")]
+    let mut chaos_affected = false;
 
     for (i, record) in records.iter().enumerate() {
         let alloc = &allocations[i];
@@ -121,6 +140,18 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
                 record_data.len()
             }
         } as u64;
+
+        let reservation = match store
+        #[cfg(feature = "chaos")]
+        if let Some(failure) = chaos_failures[i].as_ref() {
+            failed_record_count += 1;
+            chaos_affected = true;
+            return_records.push(json!({
+                constants::ERROR_CODE: failure.error_code,
+                "ErrorMessage": failure.error_message,
+            }));
+            continue;
+        }
 
         let reservation = match store
             .try_reserve_shard_throughput(&stream_name, &alloc.shard_id, decoded_len, alloc.now)
@@ -175,10 +206,16 @@ pub async fn execute(store: &Store, data: Value) -> Result<Option<Value>, Kinesi
         failed = failed_record_count,
         "records put"
     );
-    Ok(Some(json!({
-        "FailedRecordCount": failed_record_count,
-        "Records": return_records,
-    })))
+    Ok(ExecuteOutcome {
+        body: Some(json!({
+            "FailedRecordCount": failed_record_count,
+            "Records": return_records,
+        })),
+        #[cfg(feature = "chaos")]
+        chaos_affected,
+        #[cfg(not(feature = "chaos"))]
+        chaos_affected: false,
+    })
 }
 
 #[cfg(all(test, feature = "server"))]

--- a/src/bin/wasi.rs
+++ b/src/bin/wasi.rs
@@ -208,45 +208,42 @@ impl WasiConfig {
         validate_durable_settings(Some(snapshot_interval_secs), max_retained_bytes)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
 
+        let mut store_options = defaults.clone();
+        store_options.create_stream_ms =
+            read_parsed_env(&mut read, "FERROKINESIS_CREATE_STREAM_MS")?
+                .unwrap_or(defaults.create_stream_ms);
+        store_options.delete_stream_ms =
+            read_parsed_env(&mut read, "FERROKINESIS_DELETE_STREAM_MS")?
+                .unwrap_or(defaults.delete_stream_ms);
+        store_options.update_stream_ms =
+            read_parsed_env(&mut read, "FERROKINESIS_UPDATE_STREAM_MS")?
+                .unwrap_or(defaults.update_stream_ms);
+        store_options.shard_limit =
+            read_parsed_env(&mut read, "FERROKINESIS_SHARD_LIMIT")?.unwrap_or(defaults.shard_limit);
+        store_options.iterator_ttl_seconds =
+            read_parsed_env(&mut read, "FERROKINESIS_ITERATOR_TTL_SECONDS")?
+                .unwrap_or(defaults.iterator_ttl_seconds);
+        store_options.retention_check_interval_secs =
+            read_parsed_env(&mut read, "FERROKINESIS_RETENTION_CHECK_INTERVAL_SECS")?
+                .unwrap_or(defaults.retention_check_interval_secs);
+        store_options.enforce_limits = read_parsed_env(&mut read, "FERROKINESIS_ENFORCE_LIMITS")?
+            .unwrap_or(defaults.enforce_limits);
+        store_options.durable = state_dir.map(|state_dir| DurableStateOptions {
+            state_dir,
+            snapshot_interval_secs,
+            max_retained_bytes,
+        });
+        store_options.max_retained_bytes = max_retained_bytes;
+        store_options.aws_account_id =
+            read("AWS_ACCOUNT_ID")?.unwrap_or_else(|| defaults.aws_account_id.clone());
+        store_options.aws_region = aws_region;
+
         Ok(Self {
             port,
             max_request_body_mb,
             log_level: read("FERROKINESIS_LOG_LEVEL")?
                 .unwrap_or_else(|| DEFAULT_LOG_LEVEL.to_string()),
-            store_options: StoreOptions {
-                create_stream_ms: read_parsed_env(&mut read, "FERROKINESIS_CREATE_STREAM_MS")?
-                    .unwrap_or(defaults.create_stream_ms),
-                delete_stream_ms: read_parsed_env(&mut read, "FERROKINESIS_DELETE_STREAM_MS")?
-                    .unwrap_or(defaults.delete_stream_ms),
-                update_stream_ms: read_parsed_env(&mut read, "FERROKINESIS_UPDATE_STREAM_MS")?
-                    .unwrap_or(defaults.update_stream_ms),
-                shard_limit: read_parsed_env(&mut read, "FERROKINESIS_SHARD_LIMIT")?
-                    .unwrap_or(defaults.shard_limit),
-                iterator_ttl_seconds: read_parsed_env(
-                    &mut read,
-                    "FERROKINESIS_ITERATOR_TTL_SECONDS",
-                )?
-                .unwrap_or(defaults.iterator_ttl_seconds),
-                subscribe_to_shard_event_record_limit: defaults
-                    .subscribe_to_shard_event_record_limit,
-                subscribe_to_shard_session_ms: defaults.subscribe_to_shard_session_ms,
-                retention_check_interval_secs: read_parsed_env(
-                    &mut read,
-                    "FERROKINESIS_RETENTION_CHECK_INTERVAL_SECS",
-                )?
-                .unwrap_or(defaults.retention_check_interval_secs),
-                enforce_limits: read_parsed_env(&mut read, "FERROKINESIS_ENFORCE_LIMITS")?
-                    .unwrap_or(defaults.enforce_limits),
-                durable: state_dir.map(|state_dir| DurableStateOptions {
-                    state_dir,
-                    snapshot_interval_secs,
-                    max_retained_bytes,
-                }),
-                max_retained_bytes,
-                aws_account_id: read("AWS_ACCOUNT_ID")?
-                    .unwrap_or_else(|| defaults.aws_account_id.clone()),
-                aws_region,
-            },
+            store_options,
         })
     }
 

--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -1,0 +1,851 @@
+//! Chaos configuration, runtime controller, and operational HTTP endpoints.
+
+use crate::actions::Operation;
+use crate::error::KinesisErrorResponse;
+use crate::store::{SequenceAllocation, Store};
+use crate::util::current_time_ms;
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+const LATENCY_SAMPLE_RATE: f64 = 0.01;
+const REQUEST_THROTTLE_MESSAGE: &str = "Rate exceeded for shard.";
+const INTERNAL_FAILURE_MESSAGE: &str = "Internal service failure.";
+const ALL_OPERATIONS: &[Operation] = &[
+    Operation::AddTagsToStream,
+    Operation::CreateStream,
+    Operation::DecreaseStreamRetentionPeriod,
+    Operation::DeleteResourcePolicy,
+    Operation::DeleteStream,
+    Operation::DeregisterStreamConsumer,
+    Operation::DescribeAccountSettings,
+    Operation::DescribeLimits,
+    Operation::DescribeStream,
+    Operation::DescribeStreamConsumer,
+    Operation::DescribeStreamSummary,
+    Operation::DisableEnhancedMonitoring,
+    Operation::EnableEnhancedMonitoring,
+    Operation::GetRecords,
+    Operation::GetResourcePolicy,
+    Operation::GetShardIterator,
+    Operation::IncreaseStreamRetentionPeriod,
+    Operation::ListShards,
+    Operation::ListStreamConsumers,
+    Operation::ListStreams,
+    Operation::ListTagsForResource,
+    Operation::ListTagsForStream,
+    Operation::MergeShards,
+    Operation::PutRecord,
+    Operation::PutRecords,
+    Operation::PutResourcePolicy,
+    Operation::RegisterStreamConsumer,
+    Operation::RemoveTagsFromStream,
+    Operation::SplitShard,
+    Operation::StartStreamEncryption,
+    Operation::StopStreamEncryption,
+    Operation::SubscribeToShard,
+    Operation::TagResource,
+    Operation::UntagResource,
+    Operation::UpdateAccountSettings,
+    Operation::UpdateMaxRecordSize,
+    Operation::UpdateShardCount,
+    Operation::UpdateStreamMode,
+    Operation::UpdateStreamWarmThroughput,
+];
+
+/// Errors that can occur while loading a chaos JSON configuration file.
+#[derive(Debug, thiserror::Error)]
+pub enum ChaosConfigError {
+    /// The chaos config file could not be read from disk.
+    #[error("failed to read chaos config {path}: {source}")]
+    Read {
+        /// Path to the chaos config file.
+        path: String,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+    /// The chaos config file contents could not be parsed as JSON.
+    #[error("failed to parse chaos config {path}: {source}")]
+    Parse {
+        /// Path to the chaos config file.
+        path: String,
+        /// Underlying JSON parse error.
+        source: serde_json::Error,
+    },
+    /// The chaos config failed semantic validation.
+    #[error("invalid value in chaos config {path}: {message}")]
+    Validation {
+        /// Path to the chaos config file.
+        path: String,
+        /// Human-readable description of the constraint violation.
+        message: String,
+    },
+}
+
+/// Validated chaos configuration used to construct the runtime controller.
+#[derive(Debug, Clone, Default)]
+pub struct ChaosConfig {
+    seed: u64,
+    scenarios: Vec<ScenarioDefinition>,
+}
+
+impl ChaosConfig {
+    /// Disable every loaded scenario, preserving the config for runtime toggling.
+    pub fn disable_all(&mut self) {
+        for scenario in &mut self.scenarios {
+            scenario.enabled = false;
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ScenarioDefinition {
+    id: String,
+    operations: Vec<Operation>,
+    enabled: bool,
+    kind: ScenarioKind,
+}
+
+#[derive(Debug, Clone)]
+enum ScenarioKind {
+    ErrorRate {
+        rate: f64,
+        error: RequestChaosError,
+    },
+    ThroughputBurst {
+        burst_duration_ms: u64,
+        burst_interval_ms: u64,
+    },
+    Outage,
+    Latency {
+        p99_add_ms: u64,
+    },
+    PartialFailure {
+        rate: f64,
+        error: PartialFailureError,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+enum RequestChaosError {
+    #[serde(rename = "InternalFailure")]
+    InternalFailure,
+    #[serde(rename = "ServiceUnavailable")]
+    ServiceUnavailable,
+}
+
+impl RequestChaosError {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InternalFailure => "InternalFailure",
+            Self::ServiceUnavailable => "ServiceUnavailable",
+        }
+    }
+
+    fn to_response(self) -> KinesisErrorResponse {
+        match self {
+            Self::InternalFailure => KinesisErrorResponse::server_error(Some(self.as_str()), None),
+            Self::ServiceUnavailable => KinesisErrorResponse::new(503, self.as_str(), None),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+enum PartialFailureError {
+    #[serde(rename = "InternalFailure")]
+    InternalFailure,
+    #[serde(rename = "ProvisionedThroughputExceededException")]
+    ProvisionedThroughputExceededException,
+}
+
+impl PartialFailureError {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InternalFailure => "InternalFailure",
+            Self::ProvisionedThroughputExceededException => {
+                "ProvisionedThroughputExceededException"
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawChaosConfig {
+    seed: Option<u64>,
+    scenarios: Vec<RawScenario>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum RawScenario {
+    ErrorRate {
+        id: String,
+        operations: Option<Vec<String>>,
+        enabled: Option<bool>,
+        rate: f64,
+        #[serde(default)]
+        error: Option<RequestChaosError>,
+    },
+    ThroughputBurst {
+        id: String,
+        operations: Option<Vec<String>>,
+        enabled: Option<bool>,
+        burst_duration_ms: u64,
+        burst_interval_ms: u64,
+    },
+    Outage {
+        id: String,
+        operations: Option<Vec<String>>,
+        enabled: Option<bool>,
+    },
+    Latency {
+        id: String,
+        operations: Option<Vec<String>>,
+        enabled: Option<bool>,
+        p99_add_ms: u64,
+    },
+    PartialFailure {
+        id: String,
+        operations: Option<Vec<String>>,
+        enabled: Option<bool>,
+        rate: f64,
+        #[serde(default)]
+        error: Option<PartialFailureError>,
+    },
+}
+
+struct RuntimeScenario {
+    definition: ScenarioDefinition,
+    enabled: AtomicBool,
+    enabled_at_ms: AtomicU64,
+    salt: u64,
+}
+
+/// Request-level chaos decisions for a single Kinesis API call.
+#[derive(Debug, Default)]
+pub(crate) struct RequestPlan {
+    pub(crate) terminal_error: Option<KinesisErrorResponse>,
+    pub(crate) latency_ms: u64,
+    pub(crate) chaos_affected: bool,
+}
+
+/// Per-record chaos failure information for `PutRecords`.
+#[derive(Debug, Clone)]
+pub(crate) struct PutRecordsFailure {
+    pub(crate) error_code: String,
+    pub(crate) error_message: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ChaosApiError {
+    #[error("unknown scenario ids: {0}")]
+    UnknownIds(String),
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ChaosStatus {
+    seed: u64,
+    scenarios: Vec<ScenarioStatus>,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioStatus {
+    id: String,
+    #[serde(rename = "type")]
+    scenario_type: &'static str,
+    operations: Vec<String>,
+    enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rate: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    burst_duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    burst_interval_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    p99_add_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ToggleRequest {
+    ids: Option<Vec<String>>,
+}
+
+/// Runtime chaos controller shared across handlers.
+pub(crate) struct ChaosController {
+    seed: u64,
+    request_counter: AtomicU64,
+    partial_failure_counter: AtomicU64,
+    scenarios: Vec<RuntimeScenario>,
+}
+
+impl ChaosController {
+    pub(crate) fn new(config: ChaosConfig) -> Self {
+        let started_at_ms = current_time_ms();
+        let scenarios = config
+            .scenarios
+            .into_iter()
+            .map(|definition| RuntimeScenario {
+                salt: hash_string(&definition.id),
+                enabled: AtomicBool::new(definition.enabled),
+                enabled_at_ms: AtomicU64::new(if definition.enabled { started_at_ms } else { 0 }),
+                definition,
+            })
+            .collect();
+
+        Self {
+            seed: config.seed,
+            request_counter: AtomicU64::new(0),
+            partial_failure_counter: AtomicU64::new(0),
+            scenarios,
+        }
+    }
+
+    pub(crate) fn request_plan(&self, operation: Operation) -> RequestPlan {
+        let ordinal = self.request_counter.fetch_add(1, Ordering::Relaxed);
+        let now_ms = current_time_ms();
+        let mut plan = RequestPlan::default();
+
+        for scenario in &self.scenarios {
+            if !scenario.enabled.load(Ordering::Relaxed)
+                || !scenario.definition.operations.contains(&operation)
+            {
+                continue;
+            }
+            if matches!(scenario.definition.kind, ScenarioKind::Outage) {
+                plan.terminal_error = Some(RequestChaosError::ServiceUnavailable.to_response());
+                plan.chaos_affected = true;
+                break;
+            }
+        }
+
+        if plan.terminal_error.is_none() {
+            for scenario in &self.scenarios {
+                if !scenario.enabled.load(Ordering::Relaxed)
+                    || !scenario.definition.operations.contains(&operation)
+                {
+                    continue;
+                }
+                if let ScenarioKind::ThroughputBurst {
+                    burst_duration_ms,
+                    burst_interval_ms,
+                } = scenario.definition.kind
+                    && in_burst(
+                        scenario.enabled_at_ms.load(Ordering::Relaxed),
+                        now_ms,
+                        burst_duration_ms,
+                        burst_interval_ms,
+                    )
+                {
+                    plan.terminal_error = Some(provisioned_throughput_error());
+                    plan.chaos_affected = true;
+                    break;
+                }
+            }
+        }
+
+        if plan.terminal_error.is_none() {
+            for scenario in &self.scenarios {
+                if !scenario.enabled.load(Ordering::Relaxed)
+                    || !scenario.definition.operations.contains(&operation)
+                {
+                    continue;
+                }
+                if let ScenarioKind::ErrorRate { rate, error } = scenario.definition.kind
+                    && sample(self.seed, scenario.salt, ordinal, 0, rate)
+                {
+                    plan.terminal_error = Some(error.to_response());
+                    plan.chaos_affected = true;
+                    break;
+                }
+            }
+        }
+
+        for scenario in &self.scenarios {
+            if !scenario.enabled.load(Ordering::Relaxed)
+                || !scenario.definition.operations.contains(&operation)
+            {
+                continue;
+            }
+            if let ScenarioKind::Latency { p99_add_ms } = scenario.definition.kind
+                && sample(self.seed, scenario.salt, ordinal, 1, LATENCY_SAMPLE_RATE)
+            {
+                plan.latency_ms += p99_add_ms;
+                plan.chaos_affected = true;
+            }
+        }
+
+        plan
+    }
+
+    pub(crate) fn put_records_failures(
+        &self,
+        stream_name: &str,
+        account_id: &str,
+        allocations: &[SequenceAllocation],
+    ) -> Vec<Option<PutRecordsFailure>> {
+        let ordinal = self.partial_failure_counter.fetch_add(1, Ordering::Relaxed);
+        let mut failures = vec![None; allocations.len()];
+
+        for (record_ix, alloc) in allocations.iter().enumerate() {
+            for scenario in &self.scenarios {
+                if !scenario.enabled.load(Ordering::Relaxed)
+                    || !scenario
+                        .definition
+                        .operations
+                        .contains(&Operation::PutRecords)
+                {
+                    continue;
+                }
+                if let ScenarioKind::PartialFailure { rate, error } = scenario.definition.kind
+                    && sample(self.seed, scenario.salt, ordinal, record_ix as u64, rate)
+                {
+                    failures[record_ix] = Some(PutRecordsFailure {
+                        error_code: error.as_str().to_string(),
+                        error_message: match error {
+                            PartialFailureError::InternalFailure => {
+                                INTERNAL_FAILURE_MESSAGE.to_string()
+                            }
+                            PartialFailureError::ProvisionedThroughputExceededException => {
+                                format!(
+                                    "Rate exceeded for shard {} in stream {} under account {}.",
+                                    alloc.shard_id, stream_name, account_id
+                                )
+                            }
+                        },
+                    });
+                    break;
+                }
+            }
+        }
+
+        failures
+    }
+
+    pub(crate) fn status(&self) -> ChaosStatus {
+        ChaosStatus {
+            seed: self.seed,
+            scenarios: self
+                .scenarios
+                .iter()
+                .map(|scenario| ScenarioStatus {
+                    id: scenario.definition.id.clone(),
+                    scenario_type: scenario.definition.kind.type_name(),
+                    operations: scenario
+                        .definition
+                        .operations
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect(),
+                    enabled: scenario.enabled.load(Ordering::Relaxed),
+                    error: scenario.definition.kind.error_name().map(str::to_string),
+                    rate: scenario.definition.kind.rate(),
+                    burst_duration_ms: scenario.definition.kind.burst_duration_ms(),
+                    burst_interval_ms: scenario.definition.kind.burst_interval_ms(),
+                    p99_add_ms: scenario.definition.kind.p99_add_ms(),
+                })
+                .collect(),
+        }
+    }
+
+    pub(crate) fn set_enabled(
+        &self,
+        ids: Option<&[String]>,
+        enabled: bool,
+    ) -> Result<ChaosStatus, ChaosApiError> {
+        let now_ms = current_time_ms();
+        match ids {
+            Some(ids) if !ids.is_empty() => {
+                let requested: BTreeSet<&str> = ids.iter().map(String::as_str).collect();
+                let known: BTreeSet<&str> = self
+                    .scenarios
+                    .iter()
+                    .map(|scenario| scenario.definition.id.as_str())
+                    .collect();
+                let unknown: Vec<&str> = requested.difference(&known).copied().collect();
+                if !unknown.is_empty() {
+                    return Err(ChaosApiError::UnknownIds(unknown.join(", ")));
+                }
+
+                for scenario in &self.scenarios {
+                    if requested.contains(scenario.definition.id.as_str()) {
+                        scenario
+                            .enabled_at_ms
+                            .store(if enabled { now_ms } else { 0 }, Ordering::Relaxed);
+                        scenario.enabled.store(enabled, Ordering::Relaxed);
+                    }
+                }
+            }
+            _ => {
+                for scenario in &self.scenarios {
+                    scenario
+                        .enabled_at_ms
+                        .store(if enabled { now_ms } else { 0 }, Ordering::Relaxed);
+                    scenario.enabled.store(enabled, Ordering::Relaxed);
+                }
+            }
+        }
+
+        Ok(self.status())
+    }
+}
+
+impl ScenarioKind {
+    fn type_name(&self) -> &'static str {
+        match self {
+            Self::ErrorRate { .. } => "error_rate",
+            Self::ThroughputBurst { .. } => "throughput_burst",
+            Self::Outage => "outage",
+            Self::Latency { .. } => "latency",
+            Self::PartialFailure { .. } => "partial_failure",
+        }
+    }
+
+    fn error_name(&self) -> Option<&'static str> {
+        match self {
+            Self::ErrorRate { error, .. } => Some(error.as_str()),
+            Self::PartialFailure { error, .. } => Some(error.as_str()),
+            _ => None,
+        }
+    }
+
+    fn rate(&self) -> Option<f64> {
+        match self {
+            Self::ErrorRate { rate, .. } | Self::PartialFailure { rate, .. } => Some(*rate),
+            _ => None,
+        }
+    }
+
+    fn burst_duration_ms(&self) -> Option<u64> {
+        match self {
+            Self::ThroughputBurst {
+                burst_duration_ms, ..
+            } => Some(*burst_duration_ms),
+            _ => None,
+        }
+    }
+
+    fn burst_interval_ms(&self) -> Option<u64> {
+        match self {
+            Self::ThroughputBurst {
+                burst_interval_ms, ..
+            } => Some(*burst_interval_ms),
+            _ => None,
+        }
+    }
+
+    fn p99_add_ms(&self) -> Option<u64> {
+        match self {
+            Self::Latency { p99_add_ms } => Some(*p99_add_ms),
+            _ => None,
+        }
+    }
+}
+
+/// Load and validate a chaos JSON configuration file.
+pub fn load_chaos_config(path: &Path) -> Result<ChaosConfig, ChaosConfigError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ChaosConfigError::Read {
+        path: path.display().to_string(),
+        source,
+    })?;
+    let raw: RawChaosConfig =
+        serde_json::from_str(&content).map_err(|source| ChaosConfigError::Parse {
+            path: path.display().to_string(),
+            source,
+        })?;
+
+    let mut ids = BTreeSet::new();
+    let mut scenarios = Vec::with_capacity(raw.scenarios.len());
+    for raw_scenario in raw.scenarios {
+        let definition = build_scenario_definition(raw_scenario).map_err(|message| {
+            ChaosConfigError::Validation {
+                path: path.display().to_string(),
+                message,
+            }
+        })?;
+        if !ids.insert(definition.id.clone()) {
+            return Err(ChaosConfigError::Validation {
+                path: path.display().to_string(),
+                message: format!("duplicate scenario id {:?}", definition.id),
+            });
+        }
+        scenarios.push(definition);
+    }
+
+    Ok(ChaosConfig {
+        seed: raw.seed.unwrap_or_default(),
+        scenarios,
+    })
+}
+
+pub(crate) async fn status(State(store): State<Store>) -> Response {
+    axum::Json(store.chaos_status()).into_response()
+}
+
+pub(crate) async fn enable(State(store): State<Store>, body: Bytes) -> Response {
+    toggle(store, body, true).await
+}
+
+pub(crate) async fn disable(State(store): State<Store>, body: Bytes) -> Response {
+    toggle(store, body, false).await
+}
+
+async fn toggle(store: Store, body: Bytes, enabled: bool) -> Response {
+    let request = if body.is_empty() {
+        ToggleRequest::default()
+    } else {
+        match serde_json::from_slice::<ToggleRequest>(&body) {
+            Ok(request) => request,
+            Err(err) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    axum::Json(serde_json::json!({
+                        "message": format!("invalid chaos toggle request: {err}")
+                    })),
+                )
+                    .into_response();
+            }
+        }
+    };
+
+    match store.set_chaos_enabled(request.ids.as_deref(), enabled) {
+        Ok(status) => (StatusCode::OK, axum::Json(status)).into_response(),
+        Err(err) => (
+            StatusCode::BAD_REQUEST,
+            axum::Json(serde_json::json!({ "message": err.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+fn build_scenario_definition(raw: RawScenario) -> Result<ScenarioDefinition, String> {
+    match raw {
+        RawScenario::ErrorRate {
+            id,
+            operations,
+            enabled,
+            rate,
+            error,
+        } => Ok(ScenarioDefinition {
+            operations: parse_operations(operations, ALL_OPERATIONS, None)?,
+            id,
+            enabled: enabled.unwrap_or(false),
+            kind: ScenarioKind::ErrorRate {
+                rate: validate_rate(rate)?,
+                error: error.unwrap_or(RequestChaosError::InternalFailure),
+            },
+        }),
+        RawScenario::ThroughputBurst {
+            id,
+            operations,
+            enabled,
+            burst_duration_ms,
+            burst_interval_ms,
+        } => Ok(ScenarioDefinition {
+            operations: parse_operations(
+                operations,
+                &[Operation::PutRecord, Operation::PutRecords],
+                Some(&[
+                    Operation::PutRecord,
+                    Operation::PutRecords,
+                    Operation::GetRecords,
+                ]),
+            )?,
+            id,
+            enabled: enabled.unwrap_or(false),
+            kind: ScenarioKind::ThroughputBurst {
+                burst_duration_ms: validate_positive(
+                    burst_duration_ms,
+                    "burst_duration_ms must be greater than 0",
+                )?,
+                burst_interval_ms: validate_positive(
+                    burst_interval_ms,
+                    "burst_interval_ms must be greater than 0",
+                )?,
+            },
+        }),
+        RawScenario::Outage {
+            id,
+            operations,
+            enabled,
+        } => Ok(ScenarioDefinition {
+            operations: parse_operations(operations, ALL_OPERATIONS, None)?,
+            id,
+            enabled: enabled.unwrap_or(false),
+            kind: ScenarioKind::Outage,
+        }),
+        RawScenario::Latency {
+            id,
+            operations,
+            enabled,
+            p99_add_ms,
+        } => Ok(ScenarioDefinition {
+            operations: parse_operations(operations, ALL_OPERATIONS, None)?,
+            id,
+            enabled: enabled.unwrap_or(false),
+            kind: ScenarioKind::Latency {
+                p99_add_ms: validate_positive(p99_add_ms, "p99_add_ms must be greater than 0")?,
+            },
+        }),
+        RawScenario::PartialFailure {
+            id,
+            operations,
+            enabled,
+            rate,
+            error,
+        } => Ok(ScenarioDefinition {
+            operations: parse_operations(
+                operations,
+                &[Operation::PutRecords],
+                Some(&[Operation::PutRecords]),
+            )?,
+            id,
+            enabled: enabled.unwrap_or(false),
+            kind: ScenarioKind::PartialFailure {
+                rate: validate_rate(rate)?,
+                error: error.unwrap_or(PartialFailureError::InternalFailure),
+            },
+        }),
+    }
+}
+
+fn parse_operations(
+    raw: Option<Vec<String>>,
+    defaults: &[Operation],
+    allowed: Option<&[Operation]>,
+) -> Result<Vec<Operation>, String> {
+    let parsed = match raw {
+        Some(operations) if !operations.is_empty() => operations
+            .into_iter()
+            .map(|operation| {
+                operation
+                    .parse::<Operation>()
+                    .map_err(|_| format!("unknown operation {:?}", operation))
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        _ => defaults.to_vec(),
+    };
+
+    if let Some(allowed) = allowed {
+        for operation in &parsed {
+            if !allowed.contains(operation) {
+                return Err(format!(
+                    "operation {operation} is not allowed for this scenario"
+                ));
+            }
+        }
+    }
+
+    Ok(parsed)
+}
+
+fn validate_positive(value: u64, message: &str) -> Result<u64, String> {
+    if value == 0 {
+        Err(message.to_string())
+    } else {
+        Ok(value)
+    }
+}
+
+fn validate_rate(rate: f64) -> Result<f64, String> {
+    if rate > 0.0 && rate <= 1.0 {
+        Ok(rate)
+    } else {
+        Err(format!("rate must be in (0.0, 1.0], got {rate}"))
+    }
+}
+
+fn provisioned_throughput_error() -> KinesisErrorResponse {
+    KinesisErrorResponse::client_error(
+        "ProvisionedThroughputExceededException",
+        Some(REQUEST_THROTTLE_MESSAGE),
+    )
+}
+
+fn in_burst(started_at_ms: u64, now_ms: u64, duration_ms: u64, interval_ms: u64) -> bool {
+    if started_at_ms == 0 {
+        return false;
+    }
+    let elapsed = now_ms.saturating_sub(started_at_ms);
+    let window = elapsed % interval_ms;
+    window < duration_ms.min(interval_ms)
+}
+
+fn sample(seed: u64, scenario_salt: u64, ordinal: u64, extra: u64, rate: f64) -> bool {
+    if rate >= 1.0 {
+        return true;
+    }
+
+    let mixed =
+        splitmix64(seed ^ scenario_salt ^ ordinal.wrapping_mul(0x9e37_79b9_7f4a_7c15) ^ extra);
+    let threshold = (rate * u64::MAX as f64) as u64;
+    mixed <= threshold
+}
+
+fn hash_string(value: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_operations_uses_defaults_for_empty_lists() {
+        let operations = parse_operations(Some(vec![]), &[Operation::PutRecords], None).unwrap();
+        assert_eq!(operations, vec![Operation::PutRecords]);
+    }
+
+    #[test]
+    fn validate_rate_rejects_out_of_range_values() {
+        assert!(validate_rate(0.0).is_err());
+        assert!(validate_rate(1.1).is_err());
+    }
+
+    #[test]
+    fn throughput_burst_defaults_to_write_operations() {
+        let definition = build_scenario_definition(RawScenario::ThroughputBurst {
+            id: "burst".into(),
+            operations: None,
+            enabled: Some(true),
+            burst_duration_ms: 100,
+            burst_interval_ms: 1_000,
+        })
+        .unwrap();
+
+        assert_eq!(
+            definition.operations,
+            vec![Operation::PutRecord, Operation::PutRecords]
+        );
+    }
+
+    #[test]
+    fn partial_failure_rejects_non_put_records_operations() {
+        let err = build_scenario_definition(RawScenario::PartialFailure {
+            id: "partial".into(),
+            operations: Some(vec!["PutRecord".into()]),
+            enabled: None,
+            rate: 0.5,
+            error: None,
+        })
+        .unwrap_err();
+
+        assert!(err.contains("not allowed"));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,12 @@ pub struct FileConfig {
     pub snapshot_interval_secs: Option<u64>,
     /// Hard cap on retained serialized record bytes.
     pub max_retained_bytes: Option<u64>,
+    /// Enable chaos scenarios loaded from `chaos_config`.
+    #[cfg(feature = "chaos")]
+    pub chaos: Option<bool>,
+    /// Path to the JSON chaos configuration file.
+    #[cfg(feature = "chaos")]
+    pub chaos_config: Option<PathBuf>,
     /// Maximum request body size in megabytes. Defaults to `5`.
     pub max_request_body_mb: Option<u64>,
     /// Log level (`off`, `error`, `warn`, `info`, `debug`, `trace`). Defaults to `"info"`.
@@ -203,6 +209,13 @@ pub fn load_config(path: &Path) -> Result<FileConfig, ConfigError> {
         return Err(ConfigError::Validation {
             path: path.display().to_string(),
             message: format!("otel_sample_ratio must be between 0.0 and 1.0, got {ratio}"),
+        });
+    }
+    #[cfg(feature = "chaos")]
+    if config.chaos == Some(true) && config.chaos_config.is_none() {
+        return Err(ConfigError::Validation {
+            path: path.display().to_string(),
+            message: "chaos requires chaos_config to be set".into(),
         });
     }
     #[cfg(feature = "mirror")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,9 @@
 pub mod actions;
 #[cfg(feature = "server")]
 pub mod capture;
+#[cfg(feature = "chaos")]
+#[doc(hidden)]
+pub mod chaos;
 #[cfg(feature = "server")]
 pub mod config;
 #[doc(hidden)]
@@ -83,6 +86,8 @@ use axum::Router;
 #[cfg(all(feature = "server", not(target_arch = "wasm32")))]
 use axum::body::Body;
 use axum::middleware;
+#[cfg(feature = "chaos")]
+use axum::routing::post;
 use axum::routing::{any, get};
 #[cfg(all(feature = "server", not(target_arch = "wasm32")))]
 use hyper::body::Incoming;
@@ -175,7 +180,15 @@ pub fn create_router(store: Store) -> Router {
         .route("/_health", get(health::health))
         .route("/_health/live", get(health::live))
         .route("/_health/ready", get(health::ready))
-        .route("/metrics", get(health::metrics))
+        .route("/metrics", get(health::metrics));
+
+    #[cfg(feature = "chaos")]
+    let app = app
+        .route("/_chaos", get(chaos::status))
+        .route("/_chaos/enable", post(chaos::enable))
+        .route("/_chaos/disable", post(chaos::disable));
+
+    let app = app
         .fallback(any(server::handler))
         .with_state(store)
         .layer(middleware::from_fn(server::kinesis_413_middleware));

--- a/src/main.rs
+++ b/src/main.rs
@@ -864,7 +864,7 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
         .unwrap_or_default();
 
     let defaults = StoreOptions::default();
-    let mut options = resolve_store_options(&args, &file_cfg, &defaults).unwrap_or_else(|err| {
+    let options = resolve_store_options(&args, &file_cfg, &defaults).unwrap_or_else(|err| {
         eprintln!("{err}");
         process::exit(1);
     });
@@ -892,9 +892,11 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
     };
 
     #[cfg(feature = "chaos")]
-    {
+    let options = {
+        let mut options = options;
         options.chaos = chaos;
-    }
+        options
+    };
     let port = resolve(args.port, file_cfg.port, || 4567);
     let max_request_body_mb = resolve(args.max_request_body_mb, file_cfg.max_request_body_mb, || 7);
     let log_level: String = resolve(args.log_level, file_cfg.log_level, || "info".into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use axum::extract::DefaultBodyLimit;
 use clap::{Args, Parser, Subcommand};
+#[cfg(feature = "chaos")]
+use ferrokinesis::chaos::{ChaosConfig, load_chaos_config};
 use ferrokinesis::config::{FileConfig, load_config};
 use ferrokinesis::store::{
     DEFAULT_DURABLE_SNAPSHOT_INTERVAL_SECS, DurableStateOptions, StoreOptions,
@@ -118,6 +120,17 @@ struct ServeArgs {
     /// Hard cap on retained serialized record bytes
     #[arg(long, env = "FERROKINESIS_MAX_RETAINED_BYTES", value_parser = clap::value_parser!(u64).range(1..))]
     max_retained_bytes: Option<u64>,
+
+    /// Enable chaos scenarios loaded from --chaos-config
+    #[cfg(feature = "chaos")]
+    #[arg(long, env = "FERROKINESIS_CHAOS",
+          default_missing_value = "true", num_args = 0..=1)]
+    chaos: Option<bool>,
+
+    /// Path to the JSON chaos configuration file
+    #[cfg(feature = "chaos")]
+    #[arg(long, env = "FERROKINESIS_CHAOS_CONFIG")]
+    chaos_config: Option<PathBuf>,
 
     /// Log level (off, error, warn, info, debug, trace)
     #[arg(long, env = "FERROKINESIS_LOG_LEVEL",
@@ -412,6 +425,36 @@ fn shutdown_tracing(bootstrap: &TracingBootstrap) {
     }
 }
 
+#[cfg(feature = "chaos")]
+fn resolve_chaos_inputs(
+    cli_enabled: Option<bool>,
+    file_enabled: Option<bool>,
+    cli_path: Option<PathBuf>,
+    file_path: Option<PathBuf>,
+) -> Result<(bool, Option<PathBuf>), String> {
+    let enabled = resolve(cli_enabled, file_enabled, || false);
+    let path = cli_path.or(file_path);
+    if enabled && path.is_none() {
+        Err("chaos requires --chaos-config or chaos_config in the main config file".into())
+    } else {
+        Ok((enabled, path))
+    }
+}
+
+#[cfg(feature = "chaos")]
+fn load_startup_chaos_config(enabled: bool, path: Option<PathBuf>) -> Result<ChaosConfig, String> {
+    match path {
+        Some(path) => {
+            let mut config = load_chaos_config(&path).map_err(|err| err.to_string())?;
+            if !enabled {
+                config.disable_all();
+            }
+            Ok(config)
+        }
+        None => Ok(ChaosConfig::default()),
+    }
+}
+
 fn resolve_store_options(
     args: &ServeArgs,
     file_cfg: &FileConfig,
@@ -481,6 +524,8 @@ fn resolve_store_options(
         }),
         durable,
         max_retained_bytes,
+        #[cfg(feature = "chaos")]
+        chaos: ChaosConfig::default(),
         aws_account_id: resolve(args.account_id.clone(), file_cfg.account_id.clone(), || {
             defaults.aws_account_id.clone()
         }),
@@ -819,10 +864,37 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
         .unwrap_or_default();
 
     let defaults = StoreOptions::default();
-    let options = resolve_store_options(&args, &file_cfg, &defaults).unwrap_or_else(|err| {
+    let mut options = resolve_store_options(&args, &file_cfg, &defaults).unwrap_or_else(|err| {
         eprintln!("{err}");
         process::exit(1);
     });
+
+    #[cfg(feature = "chaos")]
+    let chaos_inputs = match resolve_chaos_inputs(
+        args.chaos,
+        file_cfg.chaos,
+        args.chaos_config.clone(),
+        file_cfg.chaos_config.clone(),
+    ) {
+        Ok(inputs) => inputs,
+        Err(err) => {
+            eprintln!("{err}");
+            return ExitCode::FAILURE;
+        }
+    };
+    #[cfg(feature = "chaos")]
+    let chaos = match load_startup_chaos_config(chaos_inputs.0, chaos_inputs.1.clone()) {
+        Ok(config) => config,
+        Err(err) => {
+            eprintln!("{err}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    #[cfg(feature = "chaos")]
+    {
+        options.chaos = chaos;
+    }
     let port = resolve(args.port, file_cfg.port, || 4567);
     let max_request_body_mb = resolve(args.max_request_body_mb, file_cfg.max_request_body_mb, || 7);
     let log_level: String = resolve(args.log_level, file_cfg.log_level, || "info".into());
@@ -1060,6 +1132,10 @@ mod tests {
             state_dir: None,
             snapshot_interval_secs: None,
             max_retained_bytes: None,
+            #[cfg(feature = "chaos")]
+            chaos: None,
+            #[cfg(feature = "chaos")]
+            chaos_config: None,
             log_level: None,
             log_format: None,
             otlp_endpoint: None,
@@ -1184,5 +1260,23 @@ mod tests {
             normalize_otlp_http_endpoint("http://127.0.0.1:4318/custom").unwrap(),
             "http://127.0.0.1:4318/custom"
         );
+    }
+
+    #[cfg(feature = "chaos")]
+    #[test]
+    fn resolve_chaos_inputs_requires_config_when_enabled() {
+        let err = resolve_chaos_inputs(Some(true), None, None, None).unwrap_err();
+        assert!(err.contains("chaos requires"));
+    }
+
+    #[cfg(feature = "chaos")]
+    #[test]
+    fn resolve_chaos_inputs_accepts_file_backed_paths() {
+        let (enabled, path) =
+            resolve_chaos_inputs(Some(true), None, None, Some(PathBuf::from("chaos.json")))
+                .unwrap();
+
+        assert!(enabled);
+        assert_eq!(path, Some(PathBuf::from("chaos.json")));
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -500,6 +500,25 @@ pub async fn handler(
             );
         }
 
+        #[cfg(feature = "chaos")]
+        let request_chaos_plan = store.chaos_request_plan(operation);
+
+        #[cfg(feature = "chaos")]
+        if let Some(ref err) = request_chaos_plan.terminal_error {
+            if request_chaos_plan.latency_ms > 0 {
+                crate::runtime::sleep_ms(request_chaos_plan.latency_ms).await;
+            }
+            let response =
+                log_and_send_error(&request_span, &response_headers, response_content_type, err);
+            let error_type = err.body.error_type.clone();
+            return complete(
+                Some(operation),
+                None,
+                response,
+                Some(error_type.as_str()),
+            );
+        }
+
         // Handle SubscribeToShard separately (streaming response)
         if operation == Operation::SubscribeToShard {
             #[cfg(not(target_arch = "wasm32"))]
@@ -544,6 +563,10 @@ pub async fn handler(
                     .get("x-amzn-ErrorType")
                     .and_then(|value| value.to_str().ok())
                     .map(str::to_owned);
+                #[cfg(feature = "chaos")]
+                if request_chaos_plan.latency_ms > 0 {
+                    crate::runtime::sleep_ms(request_chaos_plan.latency_ms).await;
+                }
                 return complete(
                     Some(operation),
                     None,
@@ -561,6 +584,10 @@ pub async fn handler(
                 let response =
                     log_and_send_error(&request_span, &response_headers, response_content_type, &err);
                 let error_type = err.body.error_type.clone();
+                #[cfg(feature = "chaos")]
+                if request_chaos_plan.latency_ms > 0 {
+                    crate::runtime::sleep_ms(request_chaos_plan.latency_ms).await;
+                }
                 return complete(
                     Some(operation),
                     None,
@@ -571,9 +598,33 @@ pub async fn handler(
         }
 
         // Execute action
-        let dispatch_result = actions::dispatch(&store, operation, data)
-            .instrument(request_span.clone())
-            .await;
+        #[cfg(feature = "chaos")]
+        let mut put_records_chaos_affected = false;
+        let dispatch_result = if operation == Operation::PutRecords {
+            #[cfg(feature = "chaos")]
+            {
+                match actions::put_records::execute_with_outcome(&store, data)
+                    .instrument(request_span.clone())
+                    .await
+                {
+                    Ok(outcome) => {
+                        put_records_chaos_affected = outcome.chaos_affected;
+                        Ok(outcome.body)
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+            #[cfg(not(feature = "chaos"))]
+            {
+                actions::dispatch(&store, operation, data)
+                    .instrument(request_span.clone())
+                    .await
+            }
+        } else {
+            actions::dispatch(&store, operation, data)
+                .instrument(request_span.clone())
+                .await
+        };
 
         // Build response first (borrows result), then move result into the mirror
         let (response, error_type, mirrorable_result) = match dispatch_result {
@@ -600,10 +651,21 @@ pub async fn handler(
             }
         };
 
+        #[cfg(feature = "chaos")]
+        let skip_mirror = request_chaos_plan.chaos_affected || put_records_chaos_affected;
+        #[cfg(not(feature = "chaos"))]
+        let skip_mirror = false;
+
+        #[cfg(feature = "chaos")]
+        if request_chaos_plan.latency_ms > 0 {
+            crate::runtime::sleep_ms(request_chaos_plan.latency_ms).await;
+        }
+
         // Mirror write operations (fire-and-forget) — result moved, not cloned
         #[cfg(feature = "mirror")]
         if let Some(Extension(ref mirror)) = mirror
             && Mirror::should_mirror(&operation)
+            && !skip_mirror
         {
             match mirrorable_result {
                 Ok(result) => {
@@ -620,7 +682,7 @@ pub async fn handler(
         }
         #[cfg(not(feature = "mirror"))]
         {
-            let _ = (mirror, mirrorable_result);
+            let _ = (mirror, mirrorable_result, skip_mirror);
         }
 
         complete(

--- a/src/store.rs
+++ b/src/store.rs
@@ -577,11 +577,6 @@ impl Store {
             persistence: None,
             #[cfg(feature = "chaos")]
             chaos,
-            inner,
-            metrics,
-            health,
-            #[cfg(not(target_arch = "wasm32"))]
-            persistence: None,
             #[cfg(feature = "server")]
             capture_writer,
         };

--- a/src/store.rs
+++ b/src/store.rs
@@ -28,6 +28,8 @@ use crate::types::{
     StoredRecord, Stream, StreamStatus,
 };
 use crate::util::current_time_ms;
+#[cfg(feature = "chaos")]
+use crate::{chaos, chaos::ChaosController};
 use dashmap::DashMap;
 use num_bigint::BigUint;
 use num_traits::One;
@@ -252,6 +254,9 @@ pub struct StoreOptions {
     pub durable: Option<DurableStateOptions>,
     /// Hard cap on retained serialized record bytes.
     pub max_retained_bytes: Option<u64>,
+    /// Chaos/fault-injection configuration compiled behind the `chaos` feature.
+    #[cfg(feature = "chaos")]
+    pub chaos: chaos::ChaosConfig,
     /// Simulated AWS account ID (12 digits). Defaults to `"000000000000"`.
     pub aws_account_id: String,
     /// Simulated AWS region. Defaults to `"us-east-1"`.
@@ -272,6 +277,8 @@ impl Default for StoreOptions {
             enforce_limits: false,
             durable: None,
             max_retained_bytes: None,
+            #[cfg(feature = "chaos")]
+            chaos: chaos::ChaosConfig::default(),
             aws_account_id: "000000000000".to_string(),
             aws_region: "us-east-1".to_string(),
         }
@@ -467,6 +474,8 @@ pub struct Store {
     health: Arc<StoreHealthState>,
     #[cfg(not(target_arch = "wasm32"))]
     persistence: Option<Arc<PersistenceState>>,
+    #[cfg(feature = "chaos")]
+    chaos: Arc<ChaosController>,
     /// Optional capture writer for recording PutRecord/PutRecords calls.
     #[cfg(feature = "server")]
     pub(crate) capture_writer: Option<crate::capture::CaptureWriter>,
@@ -542,6 +551,8 @@ impl Store {
             durable_ok: AtomicBool::new(true),
             last_error: StdRwLock::new(None),
         });
+        #[cfg(feature = "chaos")]
+        let chaos = Arc::new(ChaosController::new(options.chaos.clone()));
 
         let inner = Arc::new(StoreInner {
             streams: DashMap::new(),
@@ -559,6 +570,13 @@ impl Store {
             options,
             aws_account_id,
             aws_region,
+            inner,
+            metrics,
+            health,
+            #[cfg(not(target_arch = "wasm32"))]
+            persistence: None,
+            #[cfg(feature = "chaos")]
+            chaos,
             inner,
             metrics,
             health,
@@ -1162,6 +1180,38 @@ impl Store {
                 transitions.remove(&key);
             }
         }
+    }
+
+    #[cfg(feature = "chaos")]
+    pub(crate) fn chaos_status(&self) -> chaos::ChaosStatus {
+        self.chaos.status()
+    }
+
+    #[cfg(feature = "chaos")]
+    pub(crate) fn set_chaos_enabled(
+        &self,
+        ids: Option<&[String]>,
+        enabled: bool,
+    ) -> Result<chaos::ChaosStatus, chaos::ChaosApiError> {
+        self.chaos.set_enabled(ids, enabled)
+    }
+
+    #[cfg(feature = "chaos")]
+    pub(crate) fn chaos_request_plan(
+        &self,
+        operation: crate::actions::Operation,
+    ) -> chaos::RequestPlan {
+        self.chaos.request_plan(operation)
+    }
+
+    #[cfg(feature = "chaos")]
+    pub(crate) fn chaos_put_records_failures(
+        &self,
+        stream_name: &str,
+        allocations: &[SequenceAllocation],
+    ) -> Vec<Option<chaos::PutRecordsFailure>> {
+        self.chaos
+            .put_records_failures(stream_name, &self.aws_account_id, allocations)
     }
 
     // --- Stream operations ---

--- a/tests/chaos.rs
+++ b/tests/chaos.rs
@@ -1,0 +1,276 @@
+#![cfg(feature = "chaos")]
+
+mod common;
+
+use common::*;
+use ferrokinesis::capture::{CaptureWriter, read_capture_file};
+use ferrokinesis::chaos::load_chaos_config;
+use ferrokinesis::store::StoreOptions;
+use reqwest::Method;
+use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
+use serde_json::{Value, json};
+use std::time::{Duration, Instant};
+use tempfile::NamedTempFile;
+
+fn load_test_chaos_config(config: Value) -> ferrokinesis::chaos::ChaosConfig {
+    let file = NamedTempFile::new().unwrap();
+    std::fs::write(file.path(), serde_json::to_vec(&config).unwrap()).unwrap();
+    load_chaos_config(file.path()).unwrap()
+}
+
+fn chaos_options(config: Value) -> StoreOptions {
+    StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        shard_limit: 50,
+        chaos: load_test_chaos_config(config),
+        ..Default::default()
+    }
+}
+
+async fn chaos_status(server: &TestServer) -> Value {
+    let res = server
+        .raw_request(Method::GET, "/_chaos", HeaderMap::new(), vec![])
+        .await;
+    assert_eq!(res.status(), 200);
+    res.json().await.unwrap()
+}
+
+async fn chaos_toggle(server: &TestServer, path: &str, body: Value) -> reqwest::Response {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    server
+        .raw_request(
+            Method::POST,
+            path,
+            headers,
+            serde_json::to_vec(&body).unwrap(),
+        )
+        .await
+}
+
+#[tokio::test]
+async fn chaos_runtime_api_can_toggle_scenarios() {
+    let server = TestServer::with_options(chaos_options(json!({
+        "seed": 7,
+        "scenarios": [
+            {"id": "fail", "type": "error_rate", "rate": 1.0, "operations": ["CreateStream"]},
+            {"id": "slow", "type": "latency", "p99_add_ms": 250, "operations": ["ListStreams"]}
+        ]
+    })))
+    .await;
+
+    let body = chaos_status(&server).await;
+    assert_eq!(body["scenarios"][0]["enabled"], false);
+    assert_eq!(body["scenarios"][1]["enabled"], false);
+
+    let res = chaos_toggle(&server, "/_chaos/enable", json!({"ids": ["slow"]})).await;
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["scenarios"][0]["enabled"], false);
+    assert_eq!(body["scenarios"][1]["enabled"], true);
+
+    let res = chaos_toggle(&server, "/_chaos/enable", json!({"ids": ["missing"]})).await;
+    assert_eq!(res.status(), 400);
+
+    let res = chaos_toggle(&server, "/_chaos/disable", json!({})).await;
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["scenarios"][0]["enabled"], false);
+    assert_eq!(body["scenarios"][1]["enabled"], false);
+}
+
+#[tokio::test]
+async fn chaos_error_rate_can_return_internal_failure() {
+    let server = TestServer::with_options(chaos_options(json!({
+        "seed": 11,
+        "scenarios": [
+            {
+                "id": "fail",
+                "type": "error_rate",
+                "rate": 1.0,
+                "enabled": true,
+                "operations": ["CreateStream"],
+                "error": "InternalFailure"
+            }
+        ]
+    })))
+    .await;
+
+    let res = server
+        .request(
+            "CreateStream",
+            &json!({"StreamName": "chaos-internal", "ShardCount": 1}),
+        )
+        .await;
+    assert_eq!(res.status(), 500);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["__type"], "InternalFailure");
+}
+
+#[tokio::test]
+async fn chaos_error_rate_can_return_service_unavailable() {
+    let server = TestServer::with_options(chaos_options(json!({
+        "seed": 13,
+        "scenarios": [
+            {
+                "id": "outage",
+                "type": "error_rate",
+                "rate": 1.0,
+                "enabled": true,
+                "operations": ["ListStreams"],
+                "error": "ServiceUnavailable"
+            }
+        ]
+    })))
+    .await;
+
+    let res = server.request("ListStreams", &json!({})).await;
+    assert_eq!(res.status(), 503);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["__type"], "ServiceUnavailable");
+}
+
+#[tokio::test]
+async fn chaos_throughput_burst_recovers_between_windows() {
+    let server = TestServer::with_options(chaos_options(json!({
+        "seed": 17,
+        "scenarios": [
+            {
+                "id": "burst",
+                "type": "throughput_burst",
+                "enabled": false,
+                "burst_duration_ms": 80,
+                "burst_interval_ms": 200
+            }
+        ]
+    })))
+    .await;
+    let name = "chaos-burst";
+    server.create_stream(name, 1).await;
+
+    let res = chaos_toggle(&server, "/_chaos/enable", json!({"ids": ["burst"]})).await;
+    assert_eq!(res.status(), 200);
+
+    let first = server
+        .request(
+            "PutRecord",
+            &json!({
+                "StreamName": name,
+                "Data": "YQ==",
+                "PartitionKey": "pk"
+            }),
+        )
+        .await;
+    assert_eq!(first.status(), 400);
+    let body: Value = first.json().await.unwrap();
+    assert_eq!(body["__type"], "ProvisionedThroughputExceededException");
+
+    tokio::time::sleep(Duration::from_millis(140)).await;
+
+    let second = server
+        .request(
+            "PutRecord",
+            &json!({
+                "StreamName": name,
+                "Data": "Yg==",
+                "PartitionKey": "pk"
+            }),
+        )
+        .await;
+    assert_eq!(second.status(), 200);
+}
+
+#[tokio::test]
+async fn chaos_latency_injects_noticeable_delay() {
+    let server = TestServer::with_options(chaos_options(json!({
+        "seed": 19,
+        "scenarios": [
+            {
+                "id": "slow",
+                "type": "latency",
+                "enabled": true,
+                "p99_add_ms": 150,
+                "operations": ["ListStreams"]
+            }
+        ]
+    })))
+    .await;
+
+    let mut delayed = false;
+    for _ in 0..400 {
+        let started = Instant::now();
+        let res = server.request("ListStreams", &json!({})).await;
+        assert_eq!(res.status(), 200);
+        if started.elapsed() >= Duration::from_millis(100) {
+            delayed = true;
+            break;
+        }
+    }
+
+    assert!(delayed, "expected at least one delayed response");
+}
+
+#[tokio::test]
+async fn chaos_partial_failure_preserves_failed_records_and_skips_capture() {
+    let capture_file = NamedTempFile::new().unwrap();
+    let writer = CaptureWriter::new(capture_file.path(), false).unwrap();
+    let server = TestServer::with_capture(
+        chaos_options(json!({
+            "seed": 23,
+            "scenarios": [
+                {
+                    "id": "partial",
+                    "type": "partial_failure",
+                    "enabled": true,
+                    "rate": 1.0,
+                    "error": "ProvisionedThroughputExceededException"
+                }
+            ]
+        })),
+        writer,
+    )
+    .await;
+    let name = "chaos-partial";
+    server.create_stream(name, 1).await;
+
+    let res = server
+        .request(
+            "PutRecords",
+            &json!({
+                "StreamName": name,
+                "Records": [
+                    {"Data": "YQ==", "PartitionKey": "pk-1"},
+                    {"Data": "Yg==", "PartitionKey": "pk-2"},
+                    {"Data": "Yw==", "PartitionKey": "pk-3"}
+                ]
+            }),
+        )
+        .await;
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["FailedRecordCount"], 3);
+    let records = body["Records"].as_array().unwrap();
+    assert_eq!(records.len(), 3);
+    for record in records {
+        assert_eq!(
+            record["ErrorCode"],
+            "ProvisionedThroughputExceededException"
+        );
+        assert!(record.get("SequenceNumber").is_none());
+    }
+
+    let desc = server.describe_stream(name).await;
+    let shard_id = desc["StreamDescription"]["Shards"][0]["ShardId"]
+        .as_str()
+        .unwrap();
+    let iterator = server
+        .get_shard_iterator(name, shard_id, "TRIM_HORIZON")
+        .await;
+    let records = server.get_records(&iterator).await;
+    assert_eq!(records["Records"], Value::Array(vec![]));
+
+    let captured = read_capture_file(capture_file.path()).unwrap();
+    assert!(captured.is_empty());
+}

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -53,6 +53,29 @@ async fn health_endpoints_do_not_require_auth() {
     }
 }
 
+#[cfg(not(feature = "chaos"))]
+#[tokio::test]
+async fn chaos_routes_are_absent_without_feature() {
+    let server = TestServer::new().await;
+    let res = server
+        .raw_request(Method::GET, "/_chaos", HeaderMap::new(), vec![])
+        .await;
+    assert_eq!(res.status(), 403);
+}
+
+#[cfg(feature = "chaos")]
+#[tokio::test]
+async fn chaos_status_route_returns_empty_config_when_unset() {
+    let server = TestServer::new().await;
+    let res = server
+        .raw_request(Method::GET, "/_chaos", HeaderMap::new(), vec![])
+        .await;
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["seed"], 0);
+    assert_eq!(body["scenarios"], Value::Array(vec![]));
+}
+
 #[tokio::test]
 async fn post_health_returns_method_not_allowed() {
     let server = TestServer::new().await;


### PR DESCRIPTION
## Summary
- add a feature-gated `chaos` subsystem with JSON config loading, runtime scenario toggles, and `/_chaos` operational endpoints
- inject request-level chaos faults in the server path and add `PutRecords` partial failures inside the action implementation
- cover the new feature gate and runtime behavior with targeted health and chaos integration tests

## Why
- issue #58 asks for an opt-in chaos mode that can simulate outages, throttling, latency, and partial batch failures without changing default server behavior
- keeping the feature behind `chaos = ["server"]` preserves the existing default surface area and avoids exposing the runtime API in builds that do not opt in

## Validation
- `cargo test --no-run`
- `cargo test --features chaos --no-run`
- `cargo test --test health chaos_routes_are_absent_without_feature`
- `cargo test --features chaos --test health chaos_status_route_returns_empty_config_when_unset`
- `cargo test --features chaos --test chaos`
- `cargo test --features chaos resolve_chaos_inputs`

Part of #58.