### PR TITLE
docs: clarify mirror credential feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ chmod +x ferrokinesis
 cargo install ferrokinesis
 ```
 
+To enable traffic mirroring, install with one of the mirror feature sets:
+
+```sh
+# Mirror with static env-var credentials only
+cargo install ferrokinesis --features mirror
+
+# Mirror with the AWS provider chain (~/.aws/credentials, ~/.aws/config,
+# ECS task roles, EC2 IMDS, and IRSA/web identity)
+cargo install ferrokinesis --features mirror-aws-config
+```
+
 ### WASI Preview 2 (Experimental)
 
 Build the experimental WASI listener binary:
@@ -146,6 +157,14 @@ Options:
   -h, --help
           Print help
 ```
+
+## Mirror Credentials
+
+The mirror CLI and TOML settings stay the same across builds, but credential resolution depends on the feature set you compile in.
+
+- `--features mirror` keeps the lightweight path and reads only `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN`.
+- `--features mirror-aws-config` enables the refreshable AWS credential provider chain for `~/.aws/credentials`, `~/.aws/config`, ECS task roles, EC2 IMDS, and IRSA/web identity.
+- If no credentials are available at runtime, mirror requests are still forwarded, but they are sent unsigned.
 
 ## Health Check Endpoints
 

--- a/ferrokinesis.example.toml
+++ b/ferrokinesis.example.toml
@@ -65,7 +65,9 @@
 # [mirror]
 # Mirror PutRecord/PutRecords to another Kinesis-compatible endpoint.
 # Requests are forwarded async (fire-and-forget) after local processing completes.
-# Requires compiling with `--features mirror`.
+# Requires compiling with `--features mirror` for static env-var credentials only,
+# or `--features mirror-aws-config` for the refreshable AWS provider chain
+# (`~/.aws/credentials`, `~/.aws/config`, ECS task roles, EC2 IMDS, and IRSA/web identity).
 
 # Kinesis-compatible endpoint to mirror to (default: disabled)
 # CLI: --mirror-to | Env: FERROKINESIS_MIRROR_TO


### PR DESCRIPTION
## Summary
- document the two mirror feature builds in the installation section
- explain that the mirror CLI/TOML surface stays the same while credential resolution depends on `mirror` vs `mirror-aws-config`
- clarify in the example config that `mirror-aws-config` is required for the refreshable AWS provider chain (`~/.aws/credentials`, `~/.aws/config`, ECS task roles, EC2 IMDS, and IRSA/web identity)

## Why
Issue #177’s credential-chain implementation is already in the code, but the user-facing docs did not make the feature split obvious. This patch makes it clear when users need the lightweight env-var path versus the full AWS provider chain.

## Validation
- `CARGO_INCREMENTAL=0 cargo test --features mirror mirror:: -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test --features mirror-aws-config mirror:: -- --nocapture`