### PR TITLE
ci: parallelize check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  check:
-    name: Check
+  quality:
+    name: Quality
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
@@ -20,39 +20,117 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
+          shared-key: check
           save-if: false
       - name: Format
         run: cargo fmt --all -- --check
-      - name: Lint
-        run: cargo clippy -- -D warnings
+      - name: Lint (TLS)
+        run: cargo clippy --features tls -- -D warnings
+
+  test-default:
+    name: Test (default)
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust-toolchain
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check
+          save-if: false
       - name: Test
         run: cargo test
       - name: Doc tests
         run: cargo test --doc
+
+  test-tls:
+    name: Test (TLS)
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust-toolchain
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check
+          save-if: false
+      - name: Test (TLS)
+        run: cargo test --features tls
+
+  targets:
+    name: Targets
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust-toolchain
+        with:
+          targets: wasm32-unknown-unknown, wasm32-wasip2
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check
+          save-if: false
       - name: Core (no_std)
         run: cargo build -p ferrokinesis-core --no-default-features
       - name: Core (wasm32)
-        run: |
-          rustup target add wasm32-unknown-unknown
-          cargo build -p ferrokinesis-core --no-default-features --target wasm32-unknown-unknown
+        run: cargo build -p ferrokinesis-core --no-default-features --target wasm32-unknown-unknown
       - name: Ferrokinesis (native no-default-features lib)
         run: cargo test --no-default-features --lib
       - name: Ferrokinesis (wasm32 library)
         run: cargo check --target wasm32-unknown-unknown --no-default-features --features wasm
       - name: Ferrokinesis WASI binary
-        run: |
-          rustup target add wasm32-wasip2
-          cargo build --target wasm32-wasip2 --no-default-features --features wasi --bin ferrokinesis-wasi
+        run: cargo build --target wasm32-wasip2 --no-default-features --features wasi --bin ferrokinesis-wasi
+
+  wasm:
+    name: WASM
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust-toolchain
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check
+          save-if: false
       - name: Install wasm-pack
         run: cargo install wasm-pack
       - name: Ferrokinesis WASM wrapper
         run: cargo check -p ferrokinesis-wasm --target wasm32-unknown-unknown
       - name: WASM tests
         run: wasm-pack test --node crates/ferrokinesis-wasm
-      - name: Lint (TLS)
-        run: cargo clippy --features tls -- -D warnings
-      - name: Test (TLS)
-        run: cargo test --features tls
+
+  check:
+    name: Check
+    if: ${{ github.event_name != 'schedule' && always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - quality
+      - test-default
+      - test-tls
+      - targets
+      - wasm
+    steps:
+      - name: Verify required jobs passed
+        env:
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          TEST_DEFAULT_RESULT: ${{ needs.test-default.result }}
+          TEST_TLS_RESULT: ${{ needs.test-tls.result }}
+          TARGETS_RESULT: ${{ needs.targets.result }}
+          WASM_RESULT: ${{ needs.wasm.result }}
+        run: |
+          for result in \
+            "$QUALITY_RESULT" \
+            "$TEST_DEFAULT_RESULT" \
+            "$TEST_TLS_RESULT" \
+            "$TARGETS_RESULT" \
+            "$WASM_RESULT"; do
+            if [ "$result" != "success" ]; then
+              echo "::error::A required Check shard finished with result: $result"
+              exit 1
+            fi
+          done
 
   browser-demo:
     name: Browser Demo


### PR DESCRIPTION
## Summary
- parallelize the serialized `Check` workflow into coarse CI shards
- preserve the aggregate `Check` status so existing required checks keep working
- remove the redundant default `clippy` run and keep the TLS-enabled lint pass
