### PR TITLE
feat: add ferro companion CLI (#153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           save-if: false
       - name: Format
         run: cargo fmt --all -- --check
-      - name: Lint (TLS)
-        run: cargo clippy --features tls -- -D warnings
+      - name: Lint
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   test-default:
     name: Test (default)
@@ -39,9 +39,9 @@ jobs:
           shared-key: check
           save-if: false
       - name: Test
-        run: cargo test
+        run: cargo test --workspace
       - name: Doc tests
-        run: cargo test --doc
+        run: cargo test --workspace --doc
 
   test-tls:
     name: Test (TLS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Format
         run: cargo fmt --all -- --check
       - name: Lint
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Test
-        run: cargo test
+        run: cargo test --workspace
 
   build:
     name: Build (${{ matrix.name }})
@@ -70,17 +70,24 @@ jobs:
         run: pip3 install cargo-zigbuild ziglang
       - name: Build (zigbuild)
         if: runner.os == 'Linux'
-        run: cargo zigbuild --release --target ${{ matrix.target }}
+        run: cargo zigbuild --release --target ${{ matrix.target }} -p ferrokinesis --bin ferrokinesis -p ferrokinesis-cli --bin ferro
       - name: Build (native)
         if: runner.os != 'Linux'
-        run: cargo build --release --target ${{ matrix.target }}
-      - name: Rename binary
-        run: cp target/${{ matrix.target }}/release/ferrokinesis${{ matrix.ext }} ferrokinesis-${{ matrix.name }}${{ matrix.ext }}
-      - name: Upload binary
+        run: cargo build --release --target ${{ matrix.target }} -p ferrokinesis --bin ferrokinesis -p ferrokinesis-cli --bin ferro
+      - name: Rename binaries
+        run: |
+          cp target/${{ matrix.target }}/release/ferrokinesis${{ matrix.ext }} ferrokinesis-${{ matrix.name }}${{ matrix.ext }}
+          cp target/${{ matrix.target }}/release/ferro${{ matrix.ext }} ferro-${{ matrix.name }}${{ matrix.ext }}
+      - name: Upload ferrokinesis binary
         uses: actions/upload-artifact@v4
         with:
           name: ferrokinesis-${{ matrix.name }}
           path: ferrokinesis-${{ matrix.name }}${{ matrix.ext }}
+      - name: Upload ferro binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ferro-${{ matrix.name }}
+          path: ferro-${{ matrix.name }}${{ matrix.ext }}
 
   upload-assets:
     name: Upload Assets
@@ -94,7 +101,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          pattern: ferrokinesis-*
+          merge-multiple: true
       - name: Generate checksums
         run: |
           cd artifacts
@@ -135,16 +142,28 @@ jobs:
         with:
           name: ferrokinesis-linux-amd64
           path: docker-context/amd64
+      - name: Download ferro linux-amd64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: ferro-linux-amd64
+          path: docker-context/amd64
       - name: Download linux-arm64 binary
         uses: actions/download-artifact@v4
         with:
           name: ferrokinesis-linux-arm64
           path: docker-context/arm64
+      - name: Download ferro linux-arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: ferro-linux-arm64
+          path: docker-context/arm64
       - name: Prepare binaries
         run: |
           mv docker-context/amd64/ferrokinesis-linux-amd64 docker-context/amd64/ferrokinesis
+          mv docker-context/amd64/ferro-linux-amd64 docker-context/amd64/ferro
           mv docker-context/arm64/ferrokinesis-linux-arm64 docker-context/arm64/ferrokinesis
-          chmod +x docker-context/*/ferrokinesis
+          mv docker-context/arm64/ferro-linux-arm64 docker-context/arm64/ferro
+          chmod +x docker-context/*/ferrokinesis docker-context/*/ferro
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -208,6 +227,12 @@ jobs:
             -d '{}')
           echo "ListStreams response: $RESPONSE"
           echo "$RESPONSE" | grep -q "smoke-test"
+
+          # Companion CLI is present in the image and can talk to the server
+          FERRO_OUTPUT=$(docker exec ferrokinesis-smoke /ferro --endpoint http://127.0.0.1:4567 streams list)
+          echo "ferro streams list output:"
+          echo "$FERRO_OUTPUT"
+          echo "$FERRO_OUTPUT" | grep -q "smoke-test"
 
           # Cleanup
           docker stop ferrokinesis-smoke && docker rm ferrokinesis-smoke

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferrokinesis-cli"
+version = "0.6.0"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-types",
+ "axum",
+ "base64",
+ "bytes",
+ "chrono",
+ "clap",
+ "ferrokinesis",
+ "ferrokinesis-core",
+ "futures-util",
+ "hex",
+ "humantime",
+ "reqwest",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "ferrokinesis-core"
 version = "0.6.0"
 dependencies = [
@@ -1774,6 +1797,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +1879,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2193,6 +2223,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -2762,6 +2798,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.37",
+ "socket2 0.6.3",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +3017,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2933,13 +3026,17 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2955,6 +3052,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3008,6 +3111,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.10",
  "subtle",
@@ -3032,6 +3136,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3537,6 +3642,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4151,6 +4271,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4180,6 +4313,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = [".", "crates/ferrokinesis-core", "crates/ferrokinesis-wasm"]
+members = [
+    ".",
+    "crates/ferro-cli",
+    "crates/ferrokinesis-core",
+    "crates/ferrokinesis-wasm",
+]
 
 [workspace.package]
 version = "0.6.0"
@@ -77,7 +82,6 @@ mirror = [
 ]
 mirror-aws-config = ["mirror", "dep:aws-config"]
 loadtest = ["rt", "dep:goose", "tokio/rt-multi-thread"]
-replay = ["server", "dep:reqwest"]
 tls = ["server", "dep:axum-server", "dep:rcgen", "dep:rustls"]
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM scratch
 ARG TARGETARCH
 COPY ${TARGETARCH}/ferrokinesis /ferrokinesis
+COPY ${TARGETARCH}/ferro /ferro
 EXPOSE 4567
 # Run as nobody (UID 65534) to avoid running as root.
 USER 65534

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Options:
   -h, --help                 Print help
 ```
 
+`ferro --json tail ...` is for bounded reads and returns a JSON array. Use `--limit` or `--no-follow` to bound the run, and use `--ndjson` for streaming tails.
+
 ```
 $ ferrokinesis --help
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![docs.rs](https://docs.rs/ferrokinesis/badge.svg)](https://docs.rs/ferrokinesis)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A local AWS Kinesis mock server for testing, written in Rust.
+A local AWS Kinesis mock server for testing, written in Rust, with a companion `ferro` CLI for local stream workflows.
 
 ## Browser Demo
 
@@ -26,6 +26,7 @@ npm --prefix demo run dev
 ## Features
 
 - Pure Rust implementation
+- Companion `ferro` CLI for streams, consumers, puts, tails, replay, and raw API calls
 - Fully in-memory storage using [DashMap](https://github.com/xacrimon/dashmap) + per-stream `RwLock` with lock-free per-shard sequence generation
 - Implements all 39 Kinesis Data Streams API operations
 - Supports both JSON and CBOR content types
@@ -48,21 +49,30 @@ Download pre-built binaries from [GitHub Releases](https://github.com/mandrean/f
 ```sh
 # macOS (Apple Silicon)
 curl -L https://github.com/mandrean/ferrokinesis/releases/latest/download/ferrokinesis-macos-arm64 -o ferrokinesis
-chmod +x ferrokinesis
+curl -L https://github.com/mandrean/ferrokinesis/releases/latest/download/ferro-macos-arm64 -o ferro
+chmod +x ferrokinesis ferro
 
 # macOS (Intel)
 curl -L https://github.com/mandrean/ferrokinesis/releases/latest/download/ferrokinesis-macos-amd64 -o ferrokinesis
-chmod +x ferrokinesis
+curl -L https://github.com/mandrean/ferrokinesis/releases/latest/download/ferro-macos-amd64 -o ferro
+chmod +x ferrokinesis ferro
 
 # Linux (amd64)
 curl -L https://github.com/mandrean/ferrokinesis/releases/latest/download/ferrokinesis-linux-amd64 -o ferrokinesis
-chmod +x ferrokinesis
+curl -L https://github.com/mandrean/ferrokinesis/releases/latest/download/ferro-linux-amd64 -o ferro
+chmod +x ferrokinesis ferro
 ```
 
 ### Cargo
 
 ```sh
 cargo install ferrokinesis
+```
+
+The companion CLI ships in GitHub release assets and can also be installed from a checkout of this repository:
+
+```sh
+cargo install --path crates/ferro-cli --locked
 ```
 
 To enable traffic mirroring, install with one of the mirror feature sets:
@@ -106,6 +116,8 @@ npm --prefix demo run build
 docker run -p 4567:4567 ghcr.io/mandrean/ferrokinesis
 ```
 
+The container image includes both `/ferrokinesis` and `/ferro`.
+
 ## Quick Start
 
 Start the server:
@@ -114,30 +126,48 @@ Start the server:
 docker run -p 4567:4567 ghcr.io/mandrean/ferrokinesis
 ```
 
-Example using `aws` CLI:
+Example using `ferro`:
 
 ```sh
-# Create a stream with 2 shards
-aws kinesis create-stream \
-    --stream-name example-stream \
-    --shard-count 2 \
-    --endpoint-url http://localhost:4567 \
-    --region us-east-1
+# Create a stream with 2 shards and wait until it is ACTIVE
+ferro streams create example-stream --shards 2 --wait
 
 # Publish a record
-aws kinesis put-record \
-    --stream-name example-stream \
-    --partition-key pk1 \
-    --data $(echo -n "hello world" | base64) \
-    --endpoint-url http://localhost:4567 \
-    --region us-east-1
+ferro put example-stream "hello world" --partition-key pk1
+
+# Tail from the beginning and stop after one record
+ferro tail example-stream --from trim-horizon --limit 1 --no-follow
 ```
 
-See the full example with get-records and cleanup: [`examples/aws-cli/quickstart.sh`](examples/aws-cli/quickstart.sh)
-
-More examples using [Rust](examples/rust/src/main.rs), [Python](examples/python/quickstart.py), [Node.js](examples/node/quickstart.mjs), [Go](examples/go/quickstart.go), and [Java](examples/java/src/main/java/example/Quickstart.java) are available in the [`examples/`](examples/) directory.
+The AWS CLI and SDK examples still work unchanged. See [`examples/aws-cli/quickstart.sh`](examples/aws-cli/quickstart.sh) for the raw AWS CLI flow, or browse the rest of [`examples/`](examples/) for Rust, Python, Node.js, Go, and Java clients.
 
 ## Usage
+
+```
+$ ferro --help
+
+Companion CLI for ferrokinesis
+
+Usage: ferro [OPTIONS] <COMMAND>
+
+Commands:
+  streams
+  shards
+  consumers
+  put
+  tail
+  replay
+  api
+  health
+  help       Print this message or the help of the given subcommand(s)
+
+Options:
+      --endpoint <ENDPOINT>  ferrokinesis endpoint [env: FERROKINESIS_ENDPOINT=] [default: http://127.0.0.1:4567]
+      --insecure             Skip TLS certificate validation
+      --json                 Print machine-readable JSON
+      --ndjson               Print newline-delimited JSON when the command emits multiple records
+  -h, --help                 Print help
+```
 
 ```
 $ ferrokinesis --help
@@ -180,6 +210,20 @@ Options:
           [env: FERROKINESIS_RETENTION_CHECK_INTERVAL_SECS=]
   -h, --help
           Print help
+```
+
+## Capture And Replay
+
+Capture write traffic from the server:
+
+```sh
+ferrokinesis --capture capture.ndjson
+```
+
+Replay that capture through the companion CLI:
+
+```sh
+ferro replay capture.ndjson --stream example-stream --speed max
 ```
 
 ## Mirror Credentials

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Options:
   -h, --help                 Print help
 ```
 
-`ferro --json tail ...` is for bounded reads and returns a JSON array. Use `--limit` or `--no-follow` to bound the run, and use `--ndjson` for streaming tails.
+`ferro --json tail ...` is for bounded reads and returns a JSON array. Use `--limit` or `--no-follow` to bound the run. `--no-follow` drains what is currently available and then exits, while `--ndjson` is the streaming mode for long-lived tails.
 
 ```
 $ ferrokinesis --help

--- a/crates/ferro-cli/Cargo.toml
+++ b/crates/ferro-cli/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "ferrokinesis-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "Companion CLI for the ferrokinesis Kinesis emulator"
+
+[[bin]]
+name = "ferro"
+path = "src/main.rs"
+
+[dependencies]
+aws-smithy-eventstream = "0.60"
+aws-smithy-types = "1.4"
+base64 = "0.22"
+bytes = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+clap = { version = "4", features = ["derive", "env"] }
+ferrokinesis-core = { path = "../ferrokinesis-core", version = "0.6.0" }
+futures-util = "0.3"
+hex = "0.4"
+humantime = "2"
+reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls", "stream"] }
+serde_json = "1"
+thiserror = "2.0.18"
+tokio = { version = "1", features = ["io-std", "macros", "rt-multi-thread", "signal", "sync", "time"] }
+
+[dev-dependencies]
+axum = { version = "0.8", default-features = false }
+ferrokinesis = { path = "../..", default-features = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde_json = "1"
+tempfile = "3"
+tokio = { version = "1", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "time"] }

--- a/crates/ferro-cli/src/client.rs
+++ b/crates/ferro-cli/src/client.rs
@@ -1,0 +1,166 @@
+use ferrokinesis_core::constants::{CONTENT_TYPE_JSON, KINESIS_API};
+use ferrokinesis_core::operation::Operation;
+use reqwest::StatusCode;
+use serde_json::Value;
+use std::time::Duration;
+
+const AUTHORIZATION: &str = "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=abcd1234";
+const AMZ_DATE: &str = "20150101T000000Z";
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    Api(#[from] ApiError),
+    #[error("{0}")]
+    InvalidInput(String),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid endpoint {0:?}: must start with http:// or https://")]
+    InvalidEndpoint(String),
+    #[error("event stream error: {0}")]
+    EventStream(String),
+}
+
+#[derive(Debug)]
+pub struct ApiError {
+    pub status: StatusCode,
+    pub error_type: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.message.is_empty() {
+            write!(f, "{} ({})", self.error_type, self.status)
+        } else {
+            write!(f, "{}: {} ({})", self.error_type, self.message, self.status)
+        }
+    }
+}
+
+impl std::error::Error for ApiError {}
+
+#[derive(Clone, Debug)]
+pub struct ApiClient {
+    endpoint: String,
+    client: reqwest::Client,
+}
+
+impl ApiClient {
+    pub fn new(endpoint: &str, insecure: bool) -> Result<Self> {
+        if !endpoint.starts_with("http://") && !endpoint.starts_with("https://") {
+            return Err(Error::InvalidEndpoint(endpoint.to_string()));
+        }
+
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .danger_accept_invalid_certs(insecure)
+            .build()?;
+
+        Ok(Self {
+            endpoint: endpoint.trim_end_matches('/').to_string(),
+            client,
+        })
+    }
+
+    pub async fn call(&self, operation: Operation, body: &Value) -> Result<Value> {
+        let response = self
+            .call_response(operation, body, Some(Duration::from_secs(30)))
+            .await?;
+        self.decode_json(response).await
+    }
+
+    pub async fn call_response(
+        &self,
+        operation: Operation,
+        body: &Value,
+        timeout: Option<Duration>,
+    ) -> Result<reqwest::Response> {
+        let mut request = self
+            .client
+            .post(&self.endpoint)
+            .header("Content-Type", CONTENT_TYPE_JSON)
+            .header(
+                "X-Amz-Target",
+                format!("{KINESIS_API}.{}", operation.as_str()),
+            )
+            .header("Authorization", AUTHORIZATION)
+            .header("X-Amz-Date", AMZ_DATE)
+            .json(body);
+
+        if let Some(timeout) = timeout {
+            request = request.timeout(timeout);
+        }
+
+        let response = request.send().await?;
+        if response.status().is_success() {
+            Ok(response)
+        } else {
+            Err(self.decode_api_error(response).await.into())
+        }
+    }
+
+    pub async fn get_health(&self) -> Result<String> {
+        let response = self
+            .client
+            .get(format!("{}/_health/ready", self.endpoint))
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            Ok(response.text().await?)
+        } else {
+            Err(self.decode_api_error(response).await.into())
+        }
+    }
+
+    async fn decode_json(&self, response: reqwest::Response) -> Result<Value> {
+        let bytes = response.bytes().await?;
+        if bytes.is_empty() {
+            Ok(Value::Null)
+        } else {
+            Ok(serde_json::from_slice(&bytes)?)
+        }
+    }
+
+    async fn decode_api_error(&self, response: reqwest::Response) -> ApiError {
+        let status = response.status();
+        let bytes = match response.bytes().await {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                return ApiError {
+                    status,
+                    error_type: "RequestFailed".into(),
+                    message: error.to_string(),
+                };
+            }
+        };
+
+        let value = serde_json::from_slice::<Value>(&bytes).ok();
+        let error_type = value
+            .as_ref()
+            .and_then(|value| value.get("__type"))
+            .and_then(Value::as_str)
+            .unwrap_or("RequestFailed")
+            .to_string();
+        let message = value
+            .as_ref()
+            .and_then(|value| value.get("message").or_else(|| value.get("Message")))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| String::from_utf8_lossy(&bytes).trim().to_string());
+
+        ApiError {
+            status,
+            error_type,
+            message,
+        }
+    }
+}

--- a/crates/ferro-cli/src/main.rs
+++ b/crates/ferro-cli/src/main.rs
@@ -358,7 +358,6 @@ struct EfoTailConfig {
 #[derive(Debug)]
 struct EfoSessionResult {
     continuation_sequence_number: Option<String>,
-    emitted_records: bool,
     terminal_end_of_shard: bool,
 }
 
@@ -1244,10 +1243,6 @@ async fn run_efo_shard_loop(
                 })
             })
             .unwrap_or_else(|| iterator_spec.starting_position());
-
-        // Keep the compiler honest about the single-session contract without
-        // forcing a branch in the reconnect path.
-        let _ = result.emitted_records;
     }
 }
 
@@ -1275,7 +1270,6 @@ async fn run_efo_shard_session(
     let mut stream_body = response.bytes_stream();
     let mut buffer = BytesMut::new();
     let mut continuation_sequence_number = None;
-    let mut emitted_records = false;
     let mut terminal_end_of_shard = false;
 
     while let Some(chunk) = stream_body.next().await {
@@ -1304,9 +1298,10 @@ async fn run_efo_shard_session(
                         .as_array()
                         .cloned()
                         .unwrap_or_default();
-                    if let Some(records) = payload["Records"].as_array() {
+                    let records = payload["Records"].as_array();
+                    let saw_records = records.is_some_and(|records| !records.is_empty());
+                    if let Some(records) = records {
                         for record in records {
-                            emitted_records = true;
                             let event = TailEvent::Record(TailRecord {
                                 stream: stream.clone(),
                                 shard_id: shard_id.clone(),
@@ -1327,10 +1322,9 @@ async fn run_efo_shard_session(
                     }
                     terminal_end_of_shard = !child_shards.is_empty();
 
-                    if !follow && emitted_records {
+                    if !follow && !saw_records {
                         return Ok(EfoSessionResult {
                             continuation_sequence_number,
-                            emitted_records,
                             terminal_end_of_shard,
                         });
                     }
@@ -1353,7 +1347,6 @@ async fn run_efo_shard_session(
 
     Ok(EfoSessionResult {
         continuation_sequence_number,
-        emitted_records,
         terminal_end_of_shard,
     })
 }

--- a/crates/ferro-cli/src/main.rs
+++ b/crates/ferro-cli/src/main.rs
@@ -13,6 +13,7 @@ use ferrokinesis_core::operation::Operation;
 use futures_util::StreamExt;
 use serde_json::{Value, json};
 use std::io::Cursor;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::str::FromStr;
@@ -228,7 +229,7 @@ struct TailArgs {
     shard_ids: Vec<String>,
 
     #[arg(long)]
-    limit: Option<usize>,
+    limit: Option<NonZeroUsize>,
 
     #[arg(long, value_parser = parse_duration, default_value = "500ms")]
     poll_interval: Duration,
@@ -352,6 +353,13 @@ struct PollingTailConfig {
 struct EfoTailConfig {
     tail: TailConfig,
     consumer_arn: String,
+}
+
+#[derive(Debug)]
+struct EfoSessionResult {
+    continuation_sequence_number: Option<String>,
+    emitted_records: bool,
+    terminal_end_of_shard: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -692,6 +700,7 @@ async fn run_put(client: &ApiClient, output_mode: OutputMode, args: PutArgs) -> 
 
 async fn run_tail(client: &ApiClient, output_mode: OutputMode, args: TailArgs) -> Result<()> {
     let stream = args.stream.clone();
+    let limit = args.limit.map(NonZeroUsize::get);
     let iterator_spec = IteratorSpec {
         from: args.from,
         sequence_number: args.sequence_number.clone(),
@@ -706,7 +715,7 @@ async fn run_tail(client: &ApiClient, output_mode: OutputMode, args: TailArgs) -
         (false, false) => true,
         (true, true) => unreachable!("clap enforces conflicting tail follow flags"),
     };
-    validate_tail_output_mode(output_mode, follow, args.limit)?;
+    validate_tail_output_mode(output_mode, follow, limit)?;
     let shard_ids = resolve_shard_ids(client, &stream, &args.shard_ids).await?;
     let tail_config = TailConfig {
         output_mode,
@@ -714,7 +723,7 @@ async fn run_tail(client: &ApiClient, output_mode: OutputMode, args: TailArgs) -
         shard_ids,
         iterator_spec,
         follow,
-        limit: args.limit,
+        limit,
         decode: args.decode,
     };
 
@@ -1156,7 +1165,7 @@ async fn tail_efo(client: &ApiClient, config: EfoTailConfig) -> Result<()> {
         let consumer_arn = consumer_arn.clone();
         let iterator_spec = iterator_spec.clone();
         handles.push(tokio::spawn(async move {
-            if let Err(error) = run_efo_shard(
+            if let Err(error) = run_efo_shard_loop(
                 client,
                 stream,
                 shard_id,
@@ -1202,7 +1211,7 @@ async fn tail_efo(client: &ApiClient, config: EfoTailConfig) -> Result<()> {
     finish_tail_output(output_mode, json_records)
 }
 
-async fn run_efo_shard(
+async fn run_efo_shard_loop(
     client: ApiClient,
     stream: String,
     shard_id: String,
@@ -1211,13 +1220,53 @@ async fn run_efo_shard(
     follow: bool,
     tx: mpsc::UnboundedSender<TailEvent>,
 ) -> Result<()> {
+    let mut starting_position = iterator_spec.starting_position();
+    loop {
+        let result = run_efo_shard_session(
+            client.clone(),
+            stream.clone(),
+            shard_id.clone(),
+            consumer_arn.clone(),
+            starting_position.clone(),
+            follow,
+            tx.clone(),
+        )
+        .await?;
+        if !follow || result.terminal_end_of_shard {
+            return Ok(());
+        }
+        starting_position = result
+            .continuation_sequence_number
+            .map(|sequence_number| {
+                json!({
+                    "Type": constants::SHARD_ITERATOR_AT_SEQUENCE_NUMBER,
+                    "SequenceNumber": sequence_number,
+                })
+            })
+            .unwrap_or_else(|| iterator_spec.starting_position());
+
+        // Keep the compiler honest about the single-session contract without
+        // forcing a branch in the reconnect path.
+        let _ = result.emitted_records;
+    }
+}
+
+async fn run_efo_shard_session(
+    client: ApiClient,
+    stream: String,
+    shard_id: String,
+    consumer_arn: String,
+    starting_position: Value,
+    follow: bool,
+    tx: mpsc::UnboundedSender<TailEvent>,
+) -> Result<EfoSessionResult> {
     let response = client
         .call_response(
             Operation::SubscribeToShard,
             &json!({
                 constants::CONSUMER_ARN: consumer_arn,
                 constants::SHARD_ID: shard_id,
-                constants::STARTING_POSITION: iterator_spec.starting_position(),
+                constants::STARTING_POSITION: starting_position,
             }),
             None,
         )
@@ -1225,7 +1274,9 @@ async fn run_efo_shard(
 
     let mut stream_body = response.bytes_stream();
     let mut buffer = BytesMut::new();
-    let mut saw_event = false;
+    let mut continuation_sequence_number = None;
+    let mut emitted_records = false;
+    let mut terminal_end_of_shard = false;
 
     while let Some(chunk) = stream_body.next().await {
         let chunk = chunk?;
@@ -1244,10 +1295,18 @@ async fn run_efo_shard(
                         )));
                     }
 
-                    saw_event = true;
                     let payload = serde_json::from_slice::<Value>(message.payload())?;
+                    continuation_sequence_number = payload["ContinuationSequenceNumber"]
+                        .as_str()
+                        .map(str::to_string)
+                        .or(continuation_sequence_number);
+                    let child_shards = payload["ChildShards"]
+                        .as_array()
+                        .cloned()
+                        .unwrap_or_default();
                     if let Some(records) = payload["Records"].as_array() {
                         for record in records {
+                            emitted_records = true;
                             let event = TailEvent::Record(TailRecord {
                                 stream: stream.clone(),
                                 shard_id: shard_id.clone(),
@@ -1266,9 +1325,14 @@ async fn run_efo_shard(
                             let _ = tx.send(event);
                         }
                     }
+                    terminal_end_of_shard = !child_shards.is_empty();
 
-                    if !follow {
-                        return Ok(());
+                    if !follow && emitted_records {
+                        return Ok(EfoSessionResult {
+                            continuation_sequence_number,
+                            emitted_records,
+                            terminal_end_of_shard,
+                        });
                     }
                 }
                 Some("exception") => {
@@ -1287,11 +1351,11 @@ async fn run_efo_shard(
         }
     }
 
-    if !follow && !saw_event {
-        return Ok(());
-    }
-
-    Ok(())
+    Ok(EfoSessionResult {
+        continuation_sequence_number,
+        emitted_records,
+        terminal_end_of_shard,
+    })
 }
 
 async fn get_shard_iterator(

--- a/crates/ferro-cli/src/main.rs
+++ b/crates/ferro-cli/src/main.rs
@@ -1,0 +1,1544 @@
+mod client;
+
+use aws_smithy_eventstream::frame::read_message_from;
+use aws_smithy_types::event_stream::{HeaderValue, Message};
+use base64::Engine;
+use bytes::BytesMut;
+use chrono::{TimeZone, Utc};
+use clap::{ArgAction, ArgGroup, Args, Parser, Subcommand, ValueEnum};
+use client::{ApiClient, Error, Result};
+use ferrokinesis_core::capture::read_capture_file;
+use ferrokinesis_core::constants;
+use ferrokinesis_core::operation::Operation;
+use futures_util::StreamExt;
+use serde_json::{Value, json};
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+
+#[derive(Parser, Debug)]
+#[command(name = "ferro")]
+#[command(about = "Companion CLI for ferrokinesis")]
+struct Cli {
+    /// ferrokinesis endpoint
+    #[arg(
+        long,
+        global = true,
+        env = "FERROKINESIS_ENDPOINT",
+        default_value = "http://127.0.0.1:4567"
+    )]
+    endpoint: String,
+
+    /// Skip TLS certificate validation
+    #[arg(long, global = true)]
+    insecure: bool,
+
+    /// Print machine-readable JSON
+    #[arg(long, global = true, conflicts_with = "ndjson")]
+    json: bool,
+
+    /// Print newline-delimited JSON when the command emits multiple records
+    #[arg(long, global = true, conflicts_with = "json")]
+    ndjson: bool,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    Streams(StreamsArgs),
+    Shards(ShardsArgs),
+    Consumers(ConsumersArgs),
+    Put(PutArgs),
+    Tail(TailArgs),
+    Replay(ReplayArgs),
+    Api(ApiArgs),
+    Health,
+}
+
+#[derive(Args, Debug)]
+struct StreamsArgs {
+    #[command(subcommand)]
+    command: StreamsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum StreamsCommand {
+    List(StreamsListArgs),
+    Create(StreamsCreateArgs),
+    Describe(StreamsDescribeArgs),
+    Delete(StreamsDeleteArgs),
+}
+
+#[derive(Args, Debug)]
+struct StreamsListArgs {
+    #[arg(long)]
+    limit: Option<usize>,
+}
+
+#[derive(Args, Debug)]
+struct StreamsCreateArgs {
+    stream: String,
+
+    #[arg(long, default_value_t = 1)]
+    shards: u32,
+
+    #[arg(long)]
+    wait: bool,
+
+    #[arg(long, value_parser = parse_duration, default_value = "30s")]
+    timeout: Duration,
+}
+
+#[derive(Args, Debug)]
+struct StreamsDescribeArgs {
+    stream: String,
+}
+
+#[derive(Args, Debug)]
+struct StreamsDeleteArgs {
+    stream: String,
+
+    #[arg(long)]
+    wait: bool,
+
+    #[arg(long, value_parser = parse_duration, default_value = "30s")]
+    timeout: Duration,
+}
+
+#[derive(Args, Debug)]
+struct ShardsArgs {
+    #[command(subcommand)]
+    command: ShardsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ShardsCommand {
+    List(ShardsListArgs),
+}
+
+#[derive(Args, Debug)]
+struct ShardsListArgs {
+    stream: String,
+
+    #[arg(long)]
+    limit: Option<usize>,
+}
+
+#[derive(Args, Debug)]
+struct ConsumersArgs {
+    #[command(subcommand)]
+    command: ConsumersCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ConsumersCommand {
+    List(ConsumersListArgs),
+    Register(ConsumerRegisterArgs),
+    Describe(ConsumerDescribeArgs),
+    Deregister(ConsumerDeregisterArgs),
+}
+
+#[derive(Args, Debug)]
+struct ConsumersListArgs {
+    stream: String,
+}
+
+#[derive(Args, Debug)]
+struct ConsumerRegisterArgs {
+    stream: String,
+    consumer: String,
+}
+
+#[derive(Args, Debug)]
+struct ConsumerDescribeArgs {
+    stream: String,
+    consumer: String,
+}
+
+#[derive(Args, Debug)]
+struct ConsumerDeregisterArgs {
+    stream: String,
+    consumer: String,
+}
+
+#[derive(Args, Debug)]
+#[command(group(
+    ArgGroup::new("input")
+        .required(true)
+        .args(["data", "file", "stdin"])
+))]
+struct PutArgs {
+    stream: String,
+
+    data: Option<String>,
+
+    #[arg(long)]
+    partition_key: String,
+
+    #[arg(long)]
+    file: Option<PathBuf>,
+
+    #[arg(long)]
+    stdin: bool,
+
+    #[arg(long)]
+    base64: bool,
+
+    #[arg(long)]
+    explicit_hash_key: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum TailFrom {
+    Latest,
+    TrimHorizon,
+    AtSequence,
+    AfterSequence,
+    AtTimestamp,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum DecodeMode {
+    Auto,
+    Utf8,
+    Base64,
+    Hex,
+    None,
+}
+
+#[derive(Args, Debug)]
+struct TailArgs {
+    stream: String,
+
+    #[arg(long, value_enum, default_value_t = TailFrom::Latest)]
+    from: TailFrom,
+
+    #[arg(long)]
+    sequence_number: Option<String>,
+
+    #[arg(long)]
+    timestamp: Option<String>,
+
+    #[arg(long = "shard")]
+    shard_ids: Vec<String>,
+
+    #[arg(long)]
+    limit: Option<usize>,
+
+    #[arg(long, value_parser = parse_duration, default_value = "500ms")]
+    poll_interval: Duration,
+
+    #[arg(long, value_enum, default_value_t = DecodeMode::Auto)]
+    decode: DecodeMode,
+
+    #[arg(long, action = ArgAction::SetTrue)]
+    follow: bool,
+
+    #[arg(long = "no-follow", action = ArgAction::SetTrue)]
+    no_follow: bool,
+
+    #[arg(long)]
+    consumer: Option<String>,
+}
+
+#[derive(Args, Debug)]
+struct ReplayArgs {
+    file: PathBuf,
+
+    #[arg(long)]
+    stream: Option<String>,
+
+    #[arg(long, default_value = "1x")]
+    speed: String,
+
+    #[arg(long)]
+    limit: Option<usize>,
+
+    #[arg(long)]
+    fail_fast: bool,
+}
+
+#[derive(Args, Debug)]
+struct ApiArgs {
+    #[command(subcommand)]
+    command: ApiCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ApiCommand {
+    Call(ApiCallArgs),
+}
+
+#[derive(Args, Debug)]
+#[command(group(
+    ArgGroup::new("body_input")
+        .required(false)
+        .args(["body", "body_file", "stdin"])
+))]
+struct ApiCallArgs {
+    operation: String,
+
+    #[arg(long)]
+    body: Option<String>,
+
+    #[arg(long = "body-file")]
+    body_file: Option<PathBuf>,
+
+    #[arg(long)]
+    stdin: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OutputMode {
+    Human,
+    Json,
+    Ndjson,
+}
+
+#[derive(Clone, Debug)]
+struct TailRecord {
+    stream: String,
+    shard_id: String,
+    partition_key: String,
+    sequence_number: String,
+    approximate_arrival_timestamp: Option<f64>,
+    data: String,
+}
+
+#[derive(Debug)]
+enum TailEvent {
+    Record(TailRecord),
+    Error(String),
+}
+
+#[derive(Clone, Debug)]
+struct IteratorSpec {
+    from: TailFrom,
+    sequence_number: Option<String>,
+    timestamp_seconds: Option<f64>,
+    latest_fallback_timestamp: f64,
+}
+
+#[derive(Clone, Debug)]
+struct PollShardState {
+    shard_id: String,
+    iterator: String,
+    last_sequence_number: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct TailConfig {
+    output_mode: OutputMode,
+    stream: String,
+    shard_ids: Vec<String>,
+    iterator_spec: IteratorSpec,
+    follow: bool,
+    limit: Option<usize>,
+    decode: DecodeMode,
+}
+
+#[derive(Clone, Debug)]
+struct PollingTailConfig {
+    tail: TailConfig,
+    poll_interval: Duration,
+}
+
+#[derive(Clone, Debug)]
+struct EfoTailConfig {
+    tail: TailConfig,
+    consumer_arn: String,
+}
+
+#[derive(Clone, Debug)]
+enum ReplaySpeed {
+    Max,
+    Multiplier(f64),
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result<()> {
+    let cli = Cli::parse();
+    let output_mode = if cli.json {
+        OutputMode::Json
+    } else if cli.ndjson {
+        OutputMode::Ndjson
+    } else {
+        OutputMode::Human
+    };
+    let client = ApiClient::new(&cli.endpoint, cli.insecure)?;
+
+    match cli.command {
+        Command::Streams(args) => run_streams(&client, output_mode, args).await,
+        Command::Shards(args) => run_shards(&client, output_mode, args).await,
+        Command::Consumers(args) => run_consumers(&client, output_mode, args).await,
+        Command::Put(args) => run_put(&client, output_mode, args).await,
+        Command::Tail(args) => run_tail(&client, output_mode, args).await,
+        Command::Replay(args) => run_replay(&client, output_mode, args).await,
+        Command::Api(args) => run_api(&client, output_mode, args).await,
+        Command::Health => run_health(&client, output_mode).await,
+    }
+}
+
+async fn run_streams(client: &ApiClient, output_mode: OutputMode, args: StreamsArgs) -> Result<()> {
+    match args.command {
+        StreamsCommand::List(args) => {
+            let mut streams = list_all_streams(client).await?;
+            if let Some(limit) = args.limit {
+                streams.truncate(limit);
+            }
+
+            if output_mode == OutputMode::Human {
+                for stream in streams {
+                    println!("{stream}");
+                }
+            } else if output_mode == OutputMode::Ndjson {
+                for stream in streams {
+                    println!(
+                        "{}",
+                        serde_json::to_string(&json!({ "StreamName": stream }))?
+                    );
+                }
+            } else {
+                println!(
+                    "{}",
+                    serde_json::to_string(&json!({ "StreamNames": streams }))?
+                );
+            }
+            Ok(())
+        }
+        StreamsCommand::Create(args) => {
+            client
+                .call(
+                    Operation::CreateStream,
+                    &json!({
+                        constants::STREAM_NAME: args.stream,
+                        constants::SHARD_COUNT: args.shards,
+                    }),
+                )
+                .await?;
+            if args.wait {
+                wait_for_stream_active(client, &args.stream, args.timeout).await?;
+            }
+
+            if output_mode == OutputMode::Human {
+                if args.wait {
+                    println!("created {}", args.stream);
+                } else {
+                    println!("create requested for {}", args.stream);
+                }
+            } else {
+                emit_single_value(
+                    output_mode,
+                    &json!({
+                        "StreamName": args.stream,
+                        "ShardCount": args.shards,
+                        "Waited": args.wait,
+                    }),
+                )?;
+            }
+            Ok(())
+        }
+        StreamsCommand::Describe(args) => {
+            let summary = stream_summary(client, &args.stream).await?;
+            if output_mode == OutputMode::Human {
+                println!(
+                    "StreamName: {}",
+                    summary["StreamName"].as_str().unwrap_or(&args.stream)
+                );
+                println!("StreamARN: {}", summary["StreamARN"].as_str().unwrap_or(""));
+                println!("Status: {}", summary["StreamStatus"].as_str().unwrap_or(""));
+                println!(
+                    "Mode: {}",
+                    summary["StreamModeDetails"]["StreamMode"]
+                        .as_str()
+                        .unwrap_or("")
+                );
+                println!(
+                    "RetentionHours: {}",
+                    summary["RetentionPeriodHours"].as_i64().unwrap_or_default()
+                );
+                println!(
+                    "Encryption: {}",
+                    summary["EncryptionType"].as_str().unwrap_or("")
+                );
+                println!(
+                    "OpenShardCount: {}",
+                    summary["OpenShardCount"].as_i64().unwrap_or_default()
+                );
+                println!(
+                    "ConsumerCount: {}",
+                    summary["ConsumerCount"].as_i64().unwrap_or_default()
+                );
+            } else {
+                emit_single_value(output_mode, &summary)?;
+            }
+            Ok(())
+        }
+        StreamsCommand::Delete(args) => {
+            client
+                .call(
+                    Operation::DeleteStream,
+                    &json!({
+                        constants::STREAM_NAME: args.stream,
+                    }),
+                )
+                .await?;
+            if args.wait {
+                wait_for_stream_deleted(client, &args.stream, args.timeout).await?;
+            }
+
+            if output_mode == OutputMode::Human {
+                if args.wait {
+                    println!("deleted {}", args.stream);
+                } else {
+                    println!("delete requested for {}", args.stream);
+                }
+            } else {
+                emit_single_value(
+                    output_mode,
+                    &json!({
+                        "StreamName": args.stream,
+                        "Waited": args.wait,
+                    }),
+                )?;
+            }
+            Ok(())
+        }
+    }
+}
+
+async fn run_shards(client: &ApiClient, output_mode: OutputMode, args: ShardsArgs) -> Result<()> {
+    match args.command {
+        ShardsCommand::List(args) => {
+            let mut shards = list_all_shards(client, &args.stream).await?;
+            if let Some(limit) = args.limit {
+                shards.truncate(limit);
+            }
+
+            if output_mode == OutputMode::Human {
+                for shard in &shards {
+                    let shard_id = shard["ShardId"].as_str().unwrap_or("");
+                    let start = shard["SequenceNumberRange"]["StartingSequenceNumber"]
+                        .as_str()
+                        .unwrap_or("");
+                    let end = shard["SequenceNumberRange"]["EndingSequenceNumber"]
+                        .as_str()
+                        .unwrap_or("OPEN");
+                    println!("{shard_id}\t{start}\t{end}");
+                }
+            } else if output_mode == OutputMode::Ndjson {
+                emit_ndjson_values(shards.iter())?;
+            } else {
+                emit_single_value(output_mode, &json!({ "Shards": shards }))?;
+            }
+            Ok(())
+        }
+    }
+}
+
+async fn run_consumers(
+    client: &ApiClient,
+    output_mode: OutputMode,
+    args: ConsumersArgs,
+) -> Result<()> {
+    match args.command {
+        ConsumersCommand::List(args) => {
+            let stream_arn = stream_arn(client, &args.stream).await?;
+            let consumers = list_consumers(client, &stream_arn).await?;
+
+            if output_mode == OutputMode::Human {
+                for consumer in &consumers {
+                    println!(
+                        "{}\t{}\t{}",
+                        consumer["ConsumerName"].as_str().unwrap_or(""),
+                        consumer["ConsumerStatus"].as_str().unwrap_or(""),
+                        consumer["ConsumerARN"].as_str().unwrap_or("")
+                    );
+                }
+            } else if output_mode == OutputMode::Ndjson {
+                emit_ndjson_values(consumers.iter())?;
+            } else {
+                emit_single_value(output_mode, &json!({ "Consumers": consumers }))?;
+            }
+            Ok(())
+        }
+        ConsumersCommand::Register(args) => {
+            let stream_arn = stream_arn(client, &args.stream).await?;
+            let value = client
+                .call(
+                    Operation::RegisterStreamConsumer,
+                    &json!({
+                        constants::STREAM_ARN: stream_arn,
+                        constants::CONSUMER_NAME: args.consumer,
+                    }),
+                )
+                .await?;
+            let consumer = value["Consumer"].clone();
+
+            if output_mode == OutputMode::Human {
+                println!(
+                    "registered {}\t{}\t{}",
+                    consumer["ConsumerName"].as_str().unwrap_or(""),
+                    consumer["ConsumerStatus"].as_str().unwrap_or(""),
+                    consumer["ConsumerARN"].as_str().unwrap_or("")
+                );
+            } else {
+                emit_single_value(output_mode, &consumer)?;
+            }
+            Ok(())
+        }
+        ConsumersCommand::Describe(args) => {
+            let stream_arn = stream_arn(client, &args.stream).await?;
+            let consumer = describe_consumer(client, &stream_arn, &args.consumer).await?;
+            if output_mode == OutputMode::Human {
+                println!(
+                    "ConsumerName: {}",
+                    consumer["ConsumerName"].as_str().unwrap_or("")
+                );
+                println!(
+                    "ConsumerARN: {}",
+                    consumer["ConsumerARN"].as_str().unwrap_or("")
+                );
+                println!(
+                    "Status: {}",
+                    consumer["ConsumerStatus"].as_str().unwrap_or("")
+                );
+                println!(
+                    "StreamARN: {}",
+                    consumer["StreamARN"].as_str().unwrap_or("")
+                );
+            } else {
+                emit_single_value(output_mode, &consumer)?;
+            }
+            Ok(())
+        }
+        ConsumersCommand::Deregister(args) => {
+            let stream_arn = stream_arn(client, &args.stream).await?;
+            client
+                .call(
+                    Operation::DeregisterStreamConsumer,
+                    &json!({
+                        constants::STREAM_ARN: stream_arn,
+                        constants::CONSUMER_NAME: args.consumer,
+                    }),
+                )
+                .await?;
+            if output_mode == OutputMode::Human {
+                println!("deregister requested for {}", args.consumer);
+            } else {
+                emit_single_value(
+                    output_mode,
+                    &json!({
+                        "ConsumerName": args.consumer,
+                    }),
+                )?;
+            }
+            Ok(())
+        }
+    }
+}
+
+async fn run_put(client: &ApiClient, output_mode: OutputMode, args: PutArgs) -> Result<()> {
+    let bytes = read_bytes_input(args.data, args.file, args.stdin)?;
+    let data = if args.base64 {
+        String::from_utf8(bytes)
+            .map_err(|_| Error::InvalidInput("base64 input must be valid UTF-8".into()))?
+    } else {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    };
+
+    let mut body = json!({
+        constants::STREAM_NAME: args.stream,
+        constants::PARTITION_KEY: args.partition_key,
+        constants::DATA: data,
+    });
+    if let Some(explicit_hash_key) = args.explicit_hash_key {
+        body[constants::EXPLICIT_HASH_KEY] = Value::String(explicit_hash_key);
+    }
+
+    let response = client.call(Operation::PutRecord, &body).await?;
+    if output_mode == OutputMode::Human {
+        println!(
+            "sequence={} shard={}",
+            response["SequenceNumber"].as_str().unwrap_or(""),
+            response["ShardId"].as_str().unwrap_or("")
+        );
+    } else {
+        emit_single_value(output_mode, &response)?;
+    }
+    Ok(())
+}
+
+async fn run_tail(client: &ApiClient, output_mode: OutputMode, args: TailArgs) -> Result<()> {
+    let stream = args.stream.clone();
+    let iterator_spec = IteratorSpec {
+        from: args.from,
+        sequence_number: args.sequence_number.clone(),
+        timestamp_seconds: parse_optional_timestamp(args.timestamp.as_deref())?,
+        latest_fallback_timestamp: Utc::now().timestamp_millis() as f64 / 1000.0,
+    };
+    validate_iterator_spec(&iterator_spec)?;
+
+    let follow = !args.no_follow;
+    let shard_ids = resolve_shard_ids(client, &stream, &args.shard_ids).await?;
+    let tail_config = TailConfig {
+        output_mode,
+        stream,
+        shard_ids,
+        iterator_spec,
+        follow,
+        limit: args.limit,
+        decode: args.decode,
+    };
+
+    if let Some(consumer_name) = args.consumer {
+        let stream_arn = stream_arn(client, &tail_config.stream).await?;
+        let consumer = describe_consumer_with_hint(client, &stream_arn, &consumer_name).await?;
+        tail_efo(
+            client,
+            EfoTailConfig {
+                tail: tail_config,
+                consumer_arn: consumer["ConsumerARN"].as_str().unwrap_or("").to_string(),
+            },
+        )
+        .await
+    } else {
+        tail_polling(
+            client,
+            PollingTailConfig {
+                tail: tail_config,
+                poll_interval: args.poll_interval,
+            },
+        )
+        .await
+    }
+}
+
+async fn run_replay(client: &ApiClient, output_mode: OutputMode, args: ReplayArgs) -> Result<()> {
+    let speed = parse_replay_speed(&args.speed)?;
+    let mut records = read_capture_file(&args.file)?;
+    if records.is_empty() {
+        if output_mode == OutputMode::Human {
+            println!("capture file is empty, nothing to replay");
+        } else {
+            emit_single_value(output_mode, &json!({ "ReplayCount": 0 }))?;
+        }
+        return Ok(());
+    }
+
+    records.sort_by_key(|record| record.ts);
+    if let Some(limit) = args.limit {
+        records.truncate(limit);
+    }
+
+    let mut replayed = 0usize;
+    let start = Instant::now();
+    for (index, record) in records.iter().enumerate() {
+        if let ReplaySpeed::Multiplier(multiplier) = speed
+            && index > 0
+        {
+            let delta_ms = record.ts.saturating_sub(records[index - 1].ts);
+            if delta_ms > 0 {
+                let sleep_ms = (delta_ms as f64 / multiplier) as u64;
+                if sleep_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+                }
+            }
+        }
+
+        let mut body = json!({
+            constants::STREAM_NAME: args.stream.as_deref().unwrap_or(&record.stream),
+            constants::DATA: record.data,
+            constants::PARTITION_KEY: record.partition_key,
+        });
+        if let Some(explicit_hash_key) = record.explicit_hash_key.as_ref() {
+            body[constants::EXPLICIT_HASH_KEY] = Value::String(explicit_hash_key.clone());
+        }
+
+        match client.call(Operation::PutRecord, &body).await {
+            Ok(_) => replayed += 1,
+            Err(error) => {
+                eprintln!("record {}/{} failed: {error}", index + 1, records.len());
+                if args.fail_fast {
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    if output_mode == OutputMode::Human {
+        println!("replayed {replayed} records in {elapsed:.2}s");
+    } else {
+        emit_single_value(
+            output_mode,
+            &json!({
+                "ReplayCount": replayed,
+                "ElapsedSeconds": elapsed,
+            }),
+        )?;
+    }
+    Ok(())
+}
+
+async fn run_api(client: &ApiClient, output_mode: OutputMode, args: ApiArgs) -> Result<()> {
+    match args.command {
+        ApiCommand::Call(args) => {
+            let operation = Operation::from_str(&args.operation).map_err(|_| {
+                Error::InvalidInput(format!("unknown operation {}", args.operation))
+            })?;
+            if operation == Operation::SubscribeToShard {
+                return Err(Error::InvalidInput(
+                    "SubscribeToShard is streaming; use `ferro tail --consumer <name>` instead"
+                        .into(),
+                ));
+            }
+
+            let body = read_json_input(args.body, args.body_file, args.stdin)?;
+            let response = client.call(operation, &body).await?;
+            if output_mode == OutputMode::Human {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else {
+                emit_single_value(output_mode, &response)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+async fn run_health(client: &ApiClient, output_mode: OutputMode) -> Result<()> {
+    let body = client.get_health().await?;
+    if output_mode == OutputMode::Human {
+        println!("{}", body.trim());
+    } else {
+        emit_single_value(output_mode, &json!({ "status": body.trim() }))?;
+    }
+    Ok(())
+}
+
+async fn list_all_streams(client: &ApiClient) -> Result<Vec<String>> {
+    let mut stream_names = Vec::new();
+    let mut start: Option<String> = None;
+
+    loop {
+        let mut body = json!({});
+        if let Some(start_name) = start.as_ref() {
+            body[constants::EXCLUSIVE_START_STREAM_NAME] = Value::String(start_name.clone());
+        }
+        let response = client.call(Operation::ListStreams, &body).await?;
+        let names = response["StreamNames"].as_array().ok_or_else(|| {
+            Error::InvalidInput("ListStreams response missing StreamNames".into())
+        })?;
+        if names.is_empty() {
+            break;
+        }
+        for name in names {
+            if let Some(name) = name.as_str() {
+                stream_names.push(name.to_string());
+            }
+        }
+        let has_more = response["HasMoreStreams"].as_bool().unwrap_or(false);
+        if !has_more {
+            break;
+        }
+        start = stream_names.last().cloned();
+    }
+
+    Ok(stream_names)
+}
+
+async fn list_all_shards(client: &ApiClient, stream: &str) -> Result<Vec<Value>> {
+    let mut shards = Vec::new();
+    let mut next_token: Option<String> = None;
+
+    loop {
+        let body = if let Some(token) = next_token.as_ref() {
+            json!({
+                constants::NEXT_TOKEN: token,
+                constants::MAX_RESULTS: 1000,
+            })
+        } else {
+            json!({
+                constants::STREAM_NAME: stream,
+                constants::MAX_RESULTS: 1000,
+            })
+        };
+
+        let response = client.call(Operation::ListShards, &body).await?;
+        if let Some(items) = response["Shards"].as_array() {
+            shards.extend(items.iter().cloned());
+        }
+        next_token = response[constants::NEXT_TOKEN].as_str().map(str::to_string);
+        if next_token.is_none() {
+            break;
+        }
+    }
+
+    Ok(shards)
+}
+
+async fn list_consumers(client: &ApiClient, stream_arn: &str) -> Result<Vec<Value>> {
+    let response = client
+        .call(
+            Operation::ListStreamConsumers,
+            &json!({
+                constants::STREAM_ARN: stream_arn,
+                constants::MAX_RESULTS: 10000,
+            }),
+        )
+        .await?;
+    Ok(response["Consumers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default())
+}
+
+async fn stream_summary(client: &ApiClient, stream: &str) -> Result<Value> {
+    let response = client
+        .call(
+            Operation::DescribeStreamSummary,
+            &json!({
+                constants::STREAM_NAME: stream,
+            }),
+        )
+        .await?;
+    Ok(response["StreamDescriptionSummary"].clone())
+}
+
+async fn stream_arn(client: &ApiClient, stream: &str) -> Result<String> {
+    stream_summary(client, stream).await?["StreamARN"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::InvalidInput(format!(
+                "DescribeStreamSummary returned no StreamARN for {stream}"
+            ))
+        })
+}
+
+async fn describe_consumer(client: &ApiClient, stream_arn: &str, consumer: &str) -> Result<Value> {
+    let response = client
+        .call(
+            Operation::DescribeStreamConsumer,
+            &json!({
+                constants::STREAM_ARN: stream_arn,
+                constants::CONSUMER_NAME: consumer,
+            }),
+        )
+        .await?;
+    Ok(response["ConsumerDescription"].clone())
+}
+
+async fn describe_consumer_with_hint(
+    client: &ApiClient,
+    stream_arn: &str,
+    consumer: &str,
+) -> Result<Value> {
+    match describe_consumer(client, stream_arn, consumer).await {
+        Ok(value) => Ok(value),
+        Err(Error::Api(api_error)) if api_error.error_type == constants::RESOURCE_NOT_FOUND => {
+            Err(Error::InvalidInput(format!(
+                "consumer {consumer} not found; run `ferro consumers register <stream> {consumer}` first"
+            )))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn wait_for_stream_active(client: &ApiClient, stream: &str, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let summary = stream_summary(client, stream).await?;
+        if summary["StreamStatus"].as_str() == Some("ACTIVE") {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(Error::InvalidInput(format!(
+                "timed out waiting for stream {stream} to become ACTIVE"
+            )));
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+async fn wait_for_stream_deleted(
+    client: &ApiClient,
+    stream: &str,
+    timeout: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match stream_summary(client, stream).await {
+            Ok(_) => {}
+            Err(Error::Api(api_error)) if api_error.error_type == constants::RESOURCE_NOT_FOUND => {
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        }
+
+        if Instant::now() >= deadline {
+            return Err(Error::InvalidInput(format!(
+                "timed out waiting for stream {stream} to be deleted"
+            )));
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+async fn resolve_shard_ids(
+    client: &ApiClient,
+    stream: &str,
+    requested: &[String],
+) -> Result<Vec<String>> {
+    if !requested.is_empty() {
+        return Ok(requested.to_vec());
+    }
+
+    let shards = list_all_shards(client, stream).await?;
+    let shard_ids = shards
+        .iter()
+        .filter_map(|shard| shard["ShardId"].as_str().map(str::to_string))
+        .collect::<Vec<_>>();
+    if shard_ids.is_empty() {
+        return Err(Error::InvalidInput(format!(
+            "stream {stream} has no shards"
+        )));
+    }
+    Ok(shard_ids)
+}
+
+async fn tail_polling(client: &ApiClient, config: PollingTailConfig) -> Result<()> {
+    let PollingTailConfig {
+        tail:
+            TailConfig {
+                output_mode,
+                stream,
+                shard_ids,
+                iterator_spec,
+                follow,
+                limit,
+                decode,
+            },
+        poll_interval,
+    } = config;
+    let mut shards = Vec::with_capacity(shard_ids.len());
+    for shard_id in shard_ids {
+        let iterator =
+            get_shard_iterator(client, &stream, &shard_id, &iterator_spec, None, false).await?;
+        shards.push(PollShardState {
+            shard_id,
+            iterator,
+            last_sequence_number: None,
+        });
+    }
+
+    let mut printed = 0usize;
+    loop {
+        let mut saw_records = false;
+        for shard in &mut shards {
+            let mut refreshed = false;
+            let response = loop {
+                match client
+                    .call(
+                        Operation::GetRecords,
+                        &json!({
+                            constants::SHARD_ITERATOR: shard.iterator,
+                        }),
+                    )
+                    .await
+                {
+                    Ok(response) => break response,
+                    Err(Error::Api(api_error))
+                        if api_error.error_type == constants::EXPIRED_ITERATOR && !refreshed =>
+                    {
+                        shard.iterator = get_shard_iterator(
+                            client,
+                            &stream,
+                            &shard.shard_id,
+                            &iterator_spec,
+                            shard.last_sequence_number.as_deref(),
+                            true,
+                        )
+                        .await?;
+                        refreshed = true;
+                    }
+                    Err(error) => return Err(error),
+                }
+            };
+
+            if let Some(iterator) = response["NextShardIterator"].as_str() {
+                shard.iterator = iterator.to_string();
+            }
+
+            let records = response["Records"].as_array().cloned().unwrap_or_default();
+            if !records.is_empty() {
+                saw_records = true;
+            }
+            for record in records {
+                let tail_record = TailRecord {
+                    stream: stream.clone(),
+                    shard_id: shard.shard_id.clone(),
+                    partition_key: record["PartitionKey"].as_str().unwrap_or("").to_string(),
+                    sequence_number: record["SequenceNumber"].as_str().unwrap_or("").to_string(),
+                    approximate_arrival_timestamp: record["ApproximateArrivalTimestamp"].as_f64(),
+                    data: record["Data"].as_str().unwrap_or("").to_string(),
+                };
+                emit_tail_record(output_mode, &tail_record, decode)?;
+                printed += 1;
+                shard.last_sequence_number = Some(tail_record.sequence_number.clone());
+                if limit.is_some_and(|limit| printed >= limit) {
+                    return Ok(());
+                }
+            }
+        }
+
+        if !follow && !saw_records {
+            return Ok(());
+        }
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => return Ok(()),
+            _ = tokio::time::sleep(poll_interval) => {}
+        }
+    }
+}
+
+async fn tail_efo(client: &ApiClient, config: EfoTailConfig) -> Result<()> {
+    let EfoTailConfig {
+        tail:
+            TailConfig {
+                output_mode,
+                stream,
+                shard_ids,
+                iterator_spec,
+                follow,
+                limit,
+                decode,
+            },
+        consumer_arn,
+    } = config;
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut handles = Vec::with_capacity(shard_ids.len());
+
+    for shard_id in shard_ids {
+        let tx = tx.clone();
+        let error_tx = tx.clone();
+        let client = client.clone();
+        let stream = stream.clone();
+        let consumer_arn = consumer_arn.clone();
+        let iterator_spec = iterator_spec.clone();
+        handles.push(tokio::spawn(async move {
+            if let Err(error) = run_efo_shard(
+                client,
+                stream,
+                shard_id,
+                consumer_arn,
+                iterator_spec,
+                follow,
+                tx,
+            )
+            .await
+            {
+                let _ = error_tx.send(TailEvent::Error(error.to_string()));
+            }
+        }));
+    }
+    drop(tx);
+
+    let mut printed = 0usize;
+    while let Some(event) = rx.recv().await {
+        match event {
+            TailEvent::Record(record) => {
+                emit_tail_record(output_mode, &record, decode)?;
+                printed += 1;
+                if limit.is_some_and(|limit| printed >= limit) {
+                    for handle in &handles {
+                        handle.abort();
+                    }
+                    break;
+                }
+            }
+            TailEvent::Error(error) => {
+                for handle in &handles {
+                    handle.abort();
+                }
+                return Err(Error::EventStream(error));
+            }
+        }
+    }
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+
+    Ok(())
+}
+
+async fn run_efo_shard(
+    client: ApiClient,
+    stream: String,
+    shard_id: String,
+    consumer_arn: String,
+    iterator_spec: IteratorSpec,
+    follow: bool,
+    tx: mpsc::UnboundedSender<TailEvent>,
+) -> Result<()> {
+    let response = client
+        .call_response(
+            Operation::SubscribeToShard,
+            &json!({
+                constants::CONSUMER_ARN: consumer_arn,
+                constants::SHARD_ID: shard_id,
+                constants::STARTING_POSITION: iterator_spec.starting_position(),
+            }),
+            None,
+        )
+        .await?;
+
+    let mut stream_body = response.bytes_stream();
+    let mut buffer = BytesMut::new();
+    let mut saw_event = false;
+
+    while let Some(chunk) = stream_body.next().await {
+        let chunk = chunk?;
+        buffer.extend_from_slice(&chunk);
+        while let Some(message) = pop_event_message(&mut buffer)? {
+            match header_value(&message, ":message-type") {
+                Some("initial-response") => {}
+                Some("event") => {
+                    let event_type = header_value(&message, ":event-type").unwrap_or_default();
+                    if event_type == "initial-response" {
+                        continue;
+                    }
+                    if event_type != "SubscribeToShardEvent" {
+                        return Err(Error::EventStream(format!(
+                            "unexpected event type {event_type}"
+                        )));
+                    }
+
+                    saw_event = true;
+                    let payload = serde_json::from_slice::<Value>(message.payload())?;
+                    if let Some(records) = payload["Records"].as_array() {
+                        for record in records {
+                            let event = TailEvent::Record(TailRecord {
+                                stream: stream.clone(),
+                                shard_id: shard_id.clone(),
+                                partition_key: record["PartitionKey"]
+                                    .as_str()
+                                    .unwrap_or("")
+                                    .to_string(),
+                                sequence_number: record["SequenceNumber"]
+                                    .as_str()
+                                    .unwrap_or("")
+                                    .to_string(),
+                                approximate_arrival_timestamp:
+                                    record["ApproximateArrivalTimestamp"].as_f64(),
+                                data: record["Data"].as_str().unwrap_or("").to_string(),
+                            });
+                            let _ = tx.send(event);
+                        }
+                    }
+
+                    if !follow {
+                        return Ok(());
+                    }
+                }
+                Some("exception") => {
+                    return Err(Error::EventStream(format!(
+                        "{}: {}",
+                        header_value(&message, ":exception-type")
+                            .unwrap_or("SubscribeToShardException"),
+                        serde_json::from_slice::<Value>(message.payload())
+                            .ok()
+                            .and_then(|value| value["message"].as_str().map(str::to_string))
+                            .unwrap_or_else(|| "stream exception".into())
+                    )));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if !follow && !saw_event {
+        return Ok(());
+    }
+
+    Ok(())
+}
+
+async fn get_shard_iterator(
+    client: &ApiClient,
+    stream: &str,
+    shard_id: &str,
+    iterator_spec: &IteratorSpec,
+    last_sequence_number: Option<&str>,
+    expired_refresh: bool,
+) -> Result<String> {
+    let mut body = json!({
+        constants::STREAM_NAME: stream,
+        constants::SHARD_ID: shard_id,
+    });
+
+    if let Some(last_sequence_number) = last_sequence_number {
+        body[constants::SHARD_ITERATOR_TYPE] =
+            Value::String(constants::SHARD_ITERATOR_AFTER_SEQUENCE_NUMBER.to_string());
+        body[constants::SEQUENCE_NUMBER] = Value::String(last_sequence_number.to_string());
+    } else {
+        let iterator_type = if expired_refresh && iterator_spec.from == TailFrom::Latest {
+            constants::SHARD_ITERATOR_AT_TIMESTAMP
+        } else {
+            iterator_spec.iterator_type()
+        };
+        body[constants::SHARD_ITERATOR_TYPE] = Value::String(iterator_type.to_string());
+        if let Some(sequence_number) = iterator_spec.sequence_number.as_ref()
+            && iterator_type != constants::SHARD_ITERATOR_AT_TIMESTAMP
+        {
+            body[constants::SEQUENCE_NUMBER] = Value::String(sequence_number.clone());
+        }
+        if iterator_type == constants::SHARD_ITERATOR_AT_TIMESTAMP {
+            body[constants::TIMESTAMP] = json!(
+                iterator_spec
+                    .timestamp_seconds
+                    .unwrap_or(iterator_spec.latest_fallback_timestamp)
+            );
+        } else if let Some(timestamp_seconds) = iterator_spec.timestamp_seconds {
+            body[constants::TIMESTAMP] = json!(timestamp_seconds);
+        }
+    }
+
+    let response = client.call(Operation::GetShardIterator, &body).await?;
+    response[constants::SHARD_ITERATOR]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::InvalidInput(format!(
+                "GetShardIterator returned no iterator for {shard_id}"
+            ))
+        })
+}
+
+impl IteratorSpec {
+    fn iterator_type(&self) -> &'static str {
+        match self.from {
+            TailFrom::Latest => constants::SHARD_ITERATOR_LATEST,
+            TailFrom::TrimHorizon => constants::SHARD_ITERATOR_TRIM_HORIZON,
+            TailFrom::AtSequence => constants::SHARD_ITERATOR_AT_SEQUENCE_NUMBER,
+            TailFrom::AfterSequence => constants::SHARD_ITERATOR_AFTER_SEQUENCE_NUMBER,
+            TailFrom::AtTimestamp => constants::SHARD_ITERATOR_AT_TIMESTAMP,
+        }
+    }
+
+    fn starting_position(&self) -> Value {
+        let mut position = json!({
+            "Type": self.iterator_type(),
+        });
+        if let Some(sequence_number) = self.sequence_number.as_ref() {
+            position["SequenceNumber"] = Value::String(sequence_number.clone());
+        }
+        if let Some(timestamp_seconds) = self.timestamp_seconds {
+            position["Timestamp"] = json!(timestamp_seconds);
+        }
+        position
+    }
+}
+
+fn validate_iterator_spec(spec: &IteratorSpec) -> Result<()> {
+    match spec.from {
+        TailFrom::AtSequence | TailFrom::AfterSequence if spec.sequence_number.is_none() => {
+            Err(Error::InvalidInput(
+                "--sequence-number is required for --from at-sequence and --from after-sequence"
+                    .into(),
+            ))
+        }
+        TailFrom::AtTimestamp if spec.timestamp_seconds.is_none() => Err(Error::InvalidInput(
+            "--timestamp is required for --from at-timestamp".into(),
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn emit_tail_record(
+    output_mode: OutputMode,
+    record: &TailRecord,
+    decode: DecodeMode,
+) -> Result<()> {
+    let payload = decode_payload(&record.data, decode);
+    match output_mode {
+        OutputMode::Human => {
+            let timestamp = format_timestamp(record.approximate_arrival_timestamp);
+            println!(
+                "{}\t{}\t{}\t{}\t{}",
+                timestamp, record.shard_id, record.sequence_number, record.partition_key, payload
+            );
+        }
+        OutputMode::Json | OutputMode::Ndjson => {
+            let value = json!({
+                "StreamName": record.stream,
+                "ShardId": record.shard_id,
+                "SequenceNumber": record.sequence_number,
+                "PartitionKey": record.partition_key,
+                "ApproximateArrivalTimestamp": record.approximate_arrival_timestamp,
+                "Data": record.data,
+                "Decoded": payload,
+            });
+            emit_single_value(OutputMode::Ndjson, &value)?;
+        }
+    }
+    Ok(())
+}
+
+fn decode_payload(data: &str, decode: DecodeMode) -> String {
+    match decode {
+        DecodeMode::None => String::new(),
+        DecodeMode::Base64 => data.to_string(),
+        DecodeMode::Hex => base64::engine::general_purpose::STANDARD
+            .decode(data)
+            .map(hex::encode)
+            .unwrap_or_else(|_| data.to_string()),
+        DecodeMode::Utf8 => base64::engine::general_purpose::STANDARD
+            .decode(data)
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .unwrap_or_else(|_| data.to_string()),
+        DecodeMode::Auto => match base64::engine::general_purpose::STANDARD.decode(data) {
+            Ok(bytes) => match String::from_utf8(bytes) {
+                Ok(value) => value,
+                Err(_) => data.to_string(),
+            },
+            Err(_) => data.to_string(),
+        },
+    }
+}
+
+fn format_timestamp(timestamp: Option<f64>) -> String {
+    timestamp
+        .map(|timestamp| (timestamp * 1000.0) as i64)
+        .and_then(|millis| Utc.timestamp_millis_opt(millis).single())
+        .map(|timestamp| timestamp.to_rfc3339())
+        .unwrap_or_else(|| "-".into())
+}
+
+fn emit_single_value(output_mode: OutputMode, value: &Value) -> Result<()> {
+    match output_mode {
+        OutputMode::Human => println!("{}", serde_json::to_string_pretty(value)?),
+        OutputMode::Json | OutputMode::Ndjson => println!("{}", serde_json::to_string(value)?),
+    }
+    Ok(())
+}
+
+fn emit_ndjson_values<'a>(values: impl IntoIterator<Item = &'a Value>) -> Result<()> {
+    for value in values {
+        println!("{}", serde_json::to_string(value)?);
+    }
+    Ok(())
+}
+
+fn read_bytes_input(data: Option<String>, file: Option<PathBuf>, stdin: bool) -> Result<Vec<u8>> {
+    use std::io::Read as _;
+
+    if let Some(data) = data {
+        Ok(data.into_bytes())
+    } else if let Some(path) = file {
+        Ok(std::fs::read(path)?)
+    } else if stdin {
+        let mut stdin = std::io::stdin();
+        let mut bytes = Vec::new();
+        stdin.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    } else {
+        Err(Error::InvalidInput("missing input".into()))
+    }
+}
+
+fn read_json_input(body: Option<String>, body_file: Option<PathBuf>, stdin: bool) -> Result<Value> {
+    use std::io::Read as _;
+
+    let bytes = if let Some(body) = body {
+        body.into_bytes()
+    } else if let Some(path) = body_file {
+        std::fs::read(path)?
+    } else if stdin {
+        let mut stdin = std::io::stdin();
+        let mut bytes = Vec::new();
+        stdin.read_to_end(&mut bytes)?;
+        bytes
+    } else {
+        b"{}".to_vec()
+    };
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+fn parse_duration(value: &str) -> std::result::Result<Duration, String> {
+    humantime::parse_duration(value).map_err(|error| error.to_string())
+}
+
+fn parse_optional_timestamp(value: Option<&str>) -> Result<Option<f64>> {
+    value
+        .map(|value| {
+            chrono::DateTime::parse_from_rfc3339(value)
+                .map(|timestamp| timestamp.timestamp_millis() as f64 / 1000.0)
+                .map_err(|error| {
+                    Error::InvalidInput(format!("invalid RFC3339 timestamp {value:?}: {error}"))
+                })
+        })
+        .transpose()
+}
+
+fn parse_replay_speed(value: &str) -> Result<ReplaySpeed> {
+    if value == "max" {
+        return Ok(ReplaySpeed::Max);
+    }
+    let value = value
+        .strip_suffix('x')
+        .ok_or_else(|| Error::InvalidInput(format!("invalid replay speed {value:?}")))?;
+    let multiplier = value
+        .parse::<f64>()
+        .map_err(|_| Error::InvalidInput(format!("invalid replay speed {value:?}")))?;
+    if multiplier <= 0.0 {
+        return Err(Error::InvalidInput(format!(
+            "invalid replay speed {:?}: multiplier must be > 0",
+            value
+        )));
+    }
+    Ok(ReplaySpeed::Multiplier(multiplier))
+}
+
+fn pop_event_message(buffer: &mut BytesMut) -> Result<Option<Message>> {
+    if buffer.len() < 4 {
+        return Ok(None);
+    }
+    let total_len = u32::from_be_bytes(buffer[..4].try_into().expect("length prefix")) as usize;
+    if buffer.len() < total_len {
+        return Ok(None);
+    }
+
+    let frame = buffer.split_to(total_len).freeze();
+    let mut cursor = Cursor::new(frame.as_ref());
+    Ok(Some(
+        read_message_from(&mut cursor).map_err(|error| Error::EventStream(error.to_string()))?,
+    ))
+}
+
+fn header_value<'a>(message: &'a Message, name: &str) -> Option<&'a str> {
+    message
+        .headers()
+        .iter()
+        .find(|header| header.name().as_str() == name)
+        .and_then(|header| match header.value() {
+            HeaderValue::String(value) => Some(value.as_str()),
+            _ => None,
+        })
+}

--- a/crates/ferro-cli/src/main.rs
+++ b/crates/ferro-cli/src/main.rs
@@ -236,10 +236,10 @@ struct TailArgs {
     #[arg(long, value_enum, default_value_t = DecodeMode::Auto)]
     decode: DecodeMode,
 
-    #[arg(long, action = ArgAction::SetTrue)]
+    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "no_follow")]
     follow: bool,
 
-    #[arg(long = "no-follow", action = ArgAction::SetTrue)]
+    #[arg(long = "no-follow", action = ArgAction::SetTrue, conflicts_with = "follow")]
     no_follow: bool,
 
     #[arg(long)]
@@ -654,8 +654,14 @@ async fn run_consumers(
 }
 
 async fn run_put(client: &ApiClient, output_mode: OutputMode, args: PutArgs) -> Result<()> {
+    let trim_base64_whitespace = args.base64 && (args.file.is_some() || args.stdin);
     let bytes = read_bytes_input(args.data, args.file, args.stdin)?;
     let data = if args.base64 {
+        let bytes = if trim_base64_whitespace {
+            trim_ascii_whitespace(&bytes).to_vec()
+        } else {
+            bytes
+        };
         String::from_utf8(bytes)
             .map_err(|_| Error::InvalidInput("base64 input must be valid UTF-8".into()))?
     } else {
@@ -694,7 +700,13 @@ async fn run_tail(client: &ApiClient, output_mode: OutputMode, args: TailArgs) -
     };
     validate_iterator_spec(&iterator_spec)?;
 
-    let follow = !args.no_follow;
+    let follow = match (args.follow, args.no_follow) {
+        (true, false) => true,
+        (false, true) => false,
+        (false, false) => true,
+        (true, true) => unreachable!("clap enforces conflicting tail follow flags"),
+    };
+    validate_tail_output_mode(output_mode, follow, args.limit)?;
     let shard_ids = resolve_shard_ids(client, &stream, &args.shard_ids).await?;
     let tail_config = TailConfig {
         output_mode,
@@ -1037,6 +1049,7 @@ async fn tail_polling(client: &ApiClient, config: PollingTailConfig) -> Result<(
         poll_interval,
     } = config;
     let mut shards = Vec::with_capacity(shard_ids.len());
+    let mut json_records = Vec::new();
     for shard_id in shard_ids {
         let iterator =
             get_shard_iterator(client, &stream, &shard_id, &iterator_spec, None, false).await?;
@@ -1098,20 +1111,20 @@ async fn tail_polling(client: &ApiClient, config: PollingTailConfig) -> Result<(
                     approximate_arrival_timestamp: record["ApproximateArrivalTimestamp"].as_f64(),
                     data: record["Data"].as_str().unwrap_or("").to_string(),
                 };
-                emit_tail_record(output_mode, &tail_record, decode)?;
+                handle_tail_record(output_mode, &mut json_records, &tail_record, decode)?;
                 printed += 1;
                 shard.last_sequence_number = Some(tail_record.sequence_number.clone());
                 if limit.is_some_and(|limit| printed >= limit) {
-                    return Ok(());
+                    return finish_tail_output(output_mode, json_records);
                 }
             }
         }
 
         if !follow && !saw_records {
-            return Ok(());
+            return finish_tail_output(output_mode, json_records);
         }
         tokio::select! {
-            _ = tokio::signal::ctrl_c() => return Ok(()),
+            _ = tokio::signal::ctrl_c() => return finish_tail_output(output_mode, json_records),
             _ = tokio::time::sleep(poll_interval) => {}
         }
     }
@@ -1133,6 +1146,7 @@ async fn tail_efo(client: &ApiClient, config: EfoTailConfig) -> Result<()> {
     } = config;
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut handles = Vec::with_capacity(shard_ids.len());
+    let mut json_records = Vec::new();
 
     for shard_id in shard_ids {
         let tx = tx.clone();
@@ -1163,7 +1177,7 @@ async fn tail_efo(client: &ApiClient, config: EfoTailConfig) -> Result<()> {
     while let Some(event) = rx.recv().await {
         match event {
             TailEvent::Record(record) => {
-                emit_tail_record(output_mode, &record, decode)?;
+                handle_tail_record(output_mode, &mut json_records, &record, decode)?;
                 printed += 1;
                 if limit.is_some_and(|limit| printed >= limit) {
                     for handle in &handles {
@@ -1185,7 +1199,7 @@ async fn tail_efo(client: &ApiClient, config: EfoTailConfig) -> Result<()> {
         let _ = handle.await;
     }
 
-    Ok(())
+    finish_tail_output(output_mode, json_records)
 }
 
 async fn run_efo_shard(
@@ -1371,34 +1385,73 @@ fn validate_iterator_spec(spec: &IteratorSpec) -> Result<()> {
     }
 }
 
+fn validate_tail_output_mode(
+    output_mode: OutputMode,
+    follow: bool,
+    limit: Option<usize>,
+) -> Result<()> {
+    if output_mode == OutputMode::Json && follow && limit.is_none() {
+        return Err(Error::InvalidInput(
+            "--json tail requires a bounded run; use --limit or --no-follow, or use --ndjson for streaming output"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn handle_tail_record(
+    output_mode: OutputMode,
+    json_records: &mut Vec<Value>,
+    record: &TailRecord,
+    decode: DecodeMode,
+) -> Result<()> {
+    if output_mode == OutputMode::Json {
+        json_records.push(tail_record_value(record, decode));
+        Ok(())
+    } else {
+        emit_tail_record(output_mode, record, decode)
+    }
+}
+
+fn finish_tail_output(output_mode: OutputMode, json_records: Vec<Value>) -> Result<()> {
+    if output_mode == OutputMode::Json {
+        emit_single_value(OutputMode::Json, &Value::Array(json_records))?;
+    }
+    Ok(())
+}
+
 fn emit_tail_record(
     output_mode: OutputMode,
     record: &TailRecord,
     decode: DecodeMode,
 ) -> Result<()> {
-    let payload = decode_payload(&record.data, decode);
     match output_mode {
         OutputMode::Human => {
+            let payload = decode_payload(&record.data, decode);
             let timestamp = format_timestamp(record.approximate_arrival_timestamp);
             println!(
                 "{}\t{}\t{}\t{}\t{}",
                 timestamp, record.shard_id, record.sequence_number, record.partition_key, payload
             );
         }
-        OutputMode::Json | OutputMode::Ndjson => {
-            let value = json!({
-                "StreamName": record.stream,
-                "ShardId": record.shard_id,
-                "SequenceNumber": record.sequence_number,
-                "PartitionKey": record.partition_key,
-                "ApproximateArrivalTimestamp": record.approximate_arrival_timestamp,
-                "Data": record.data,
-                "Decoded": payload,
-            });
-            emit_single_value(OutputMode::Ndjson, &value)?;
+        OutputMode::Ndjson => {
+            emit_single_value(OutputMode::Ndjson, &tail_record_value(record, decode))?
         }
+        OutputMode::Json => unreachable!("JSON tail output should be buffered before emission"),
     }
     Ok(())
+}
+
+fn tail_record_value(record: &TailRecord, decode: DecodeMode) -> Value {
+    json!({
+        "StreamName": record.stream,
+        "ShardId": record.shard_id,
+        "SequenceNumber": record.sequence_number,
+        "PartitionKey": record.partition_key,
+        "ApproximateArrivalTimestamp": record.approximate_arrival_timestamp,
+        "Data": record.data,
+        "Decoded": decode_payload(&record.data, decode),
+    })
 }
 
 fn decode_payload(data: &str, decode: DecodeMode) -> String {
@@ -1461,6 +1514,19 @@ fn read_bytes_input(data: Option<String>, file: Option<PathBuf>, stdin: bool) ->
     } else {
         Err(Error::InvalidInput("missing input".into()))
     }
+}
+
+fn trim_ascii_whitespace(bytes: &[u8]) -> &[u8] {
+    let start = bytes
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .unwrap_or(bytes.len());
+    let end = bytes
+        .iter()
+        .rposition(|byte| !byte.is_ascii_whitespace())
+        .map(|index| index + 1)
+        .unwrap_or(start);
+    &bytes[start..end]
 }
 
 fn read_json_input(body: Option<String>, body_file: Option<PathBuf>, stdin: bool) -> Result<Value> {

--- a/crates/ferro-cli/tests/cli.rs
+++ b/crates/ferro-cli/tests/cli.rs
@@ -8,6 +8,10 @@ use std::process::Stdio;
 use tempfile::NamedTempFile;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
+fn parse_tail_json(stdout: &[u8]) -> Vec<Value> {
+    serde_json::from_slice(stdout).unwrap()
+}
+
 #[tokio::test]
 async fn streams_create_list_describe_and_delete() {
     let server = TestServer::new().await;
@@ -175,6 +179,57 @@ async fn put_supports_text_file_stdin_and_base64() {
         .unwrap();
     assert!(output.status.success());
 
+    let base64_file = NamedTempFile::new().unwrap();
+    tokio::fs::write(base64_file.path(), b"YjY0LWZpbGUK\n")
+        .await
+        .unwrap();
+    let output = ferro_command(&server)
+        .args([
+            "put",
+            "puts",
+            "--file",
+            base64_file.path().to_str().unwrap(),
+            "--base64",
+            "--partition-key",
+            "pk5",
+        ])
+        .output()
+        .await
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let mut child = ferro_command(&server)
+        .args([
+            "put",
+            "puts",
+            "--stdin",
+            "--base64",
+            "--partition-key",
+            "pk6",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"YjY0LXN0ZGluCg==\n")
+        .await
+        .unwrap();
+    let output = child.wait_with_output().await.unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
     let iterator = server
         .get_shard_iterator("puts", "shardId-000000000000", "TRIM_HORIZON")
         .await;
@@ -182,11 +237,13 @@ async fn put_supports_text_file_stdin_and_base64() {
         .as_array()
         .unwrap()
         .clone();
-    assert_eq!(records.len(), 4);
+    assert_eq!(records.len(), 6);
     assert_eq!(records[0]["Data"], "aGVsbG8=");
     assert_eq!(records[1]["Data"], "ZnJvbS1maWxl");
     assert_eq!(records[2]["Data"], "ZnJvbS1zdGRpbg==");
     assert_eq!(records[3]["Data"], "YjY0");
+    assert_eq!(records[4]["Data"], "YjY0LWZpbGUK");
+    assert_eq!(records[5]["Data"], "YjY0LXN0ZGluCg==");
 }
 
 #[tokio::test]
@@ -226,9 +283,10 @@ async fn tail_polling_reads_record_and_honors_limit() {
         "{}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let body: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(body["PartitionKey"], "pk1");
-    assert_eq!(body["Data"], "aGVsbG8=");
+    let body = parse_tail_json(&output.stdout);
+    assert_eq!(body.len(), 1);
+    assert_eq!(body[0]["PartitionKey"], "pk1");
+    assert_eq!(body[0]["Data"], "aGVsbG8=");
 }
 
 #[tokio::test]
@@ -277,8 +335,9 @@ async fn tail_polling_refreshes_expired_iterator() {
         "{}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let body: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(body["PartitionKey"], "pk-exp");
+    let body = parse_tail_json(&output.stdout);
+    assert_eq!(body.len(), 1);
+    assert_eq!(body[0]["PartitionKey"], "pk-exp");
 }
 
 #[tokio::test]
@@ -329,8 +388,41 @@ async fn tail_efo_reads_records_and_missing_consumer_is_helpful() {
         "{}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let body: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(body["PartitionKey"], "pk-efo");
+    let body = parse_tail_json(&output.stdout);
+    assert_eq!(body.len(), 1);
+    assert_eq!(body[0]["PartitionKey"], "pk-efo");
+}
+
+#[tokio::test]
+async fn tail_json_rejects_unbounded_follow() {
+    let server = TestServer::new().await;
+    server.create_stream("tail-json", 1).await;
+
+    let output = ferro_command(&server)
+        .args(["--json", "tail", "tail-json"])
+        .output()
+        .await
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--ndjson"));
+    assert!(stderr.contains("--limit") || stderr.contains("--no-follow"));
+}
+
+#[tokio::test]
+async fn tail_follow_flags_conflict() {
+    let server = TestServer::new().await;
+    server.create_stream("tail-conflict", 1).await;
+
+    let output = ferro_command(&server)
+        .args(["tail", "tail-conflict", "--follow", "--no-follow"])
+        .output()
+        .await
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("cannot be used with"));
 }
 
 #[tokio::test]

--- a/crates/ferro-cli/tests/cli.rs
+++ b/crates/ferro-cli/tests/cli.rs
@@ -451,6 +451,107 @@ async fn tail_efo_resubscribes_after_session_rollover() {
 }
 
 #[tokio::test]
+async fn tail_efo_no_follow_returns_prompt_empty_snapshot() {
+    let server = TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        subscribe_to_shard_session_ms: 5_000,
+        ..Default::default()
+    })
+    .await;
+    server.create_stream("efo-empty", 1).await;
+    server.register_consumer("efo-empty", "reader").await;
+    server.wait_for_consumer_active("efo-empty", "reader").await;
+
+    let child = ferro_command(&server)
+        .args([
+            "--json",
+            "tail",
+            "efo-empty",
+            "--consumer",
+            "reader",
+            "--from",
+            "trim-horizon",
+            "--no-follow",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let output = tokio::time::timeout(
+        tokio::time::Duration::from_secs(1),
+        child.wait_with_output(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body = parse_tail_json(&output.stdout);
+    assert!(body.is_empty());
+}
+
+#[tokio::test]
+async fn tail_efo_no_follow_drains_backlog_across_multiple_event_frames() {
+    let server = TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        subscribe_to_shard_event_record_limit: 1,
+        subscribe_to_shard_session_ms: 5_000,
+        ..Default::default()
+    })
+    .await;
+    server.create_stream("efo-backlog", 1).await;
+    server.register_consumer("efo-backlog", "reader").await;
+    server
+        .wait_for_consumer_active("efo-backlog", "reader")
+        .await;
+    server.put_record("efo-backlog", "b25l", "pk-1").await;
+    server.put_record("efo-backlog", "dHdv", "pk-2").await;
+    server.put_record("efo-backlog", "dGhyZWU=", "pk-3").await;
+
+    let child = ferro_command(&server)
+        .args([
+            "--json",
+            "tail",
+            "efo-backlog",
+            "--consumer",
+            "reader",
+            "--from",
+            "trim-horizon",
+            "--no-follow",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let output = tokio::time::timeout(
+        tokio::time::Duration::from_secs(5),
+        child.wait_with_output(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body = parse_tail_json(&output.stdout);
+    assert_eq!(body.len(), 3);
+    assert_eq!(body[0]["PartitionKey"], "pk-1");
+    assert_eq!(body[1]["PartitionKey"], "pk-2");
+    assert_eq!(body[2]["PartitionKey"], "pk-3");
+}
+
+#[tokio::test]
 async fn tail_json_rejects_unbounded_follow() {
     let server = TestServer::new().await;
     server.create_stream("tail-json", 1).await;

--- a/crates/ferro-cli/tests/cli.rs
+++ b/crates/ferro-cli/tests/cli.rs
@@ -1,0 +1,484 @@
+mod common;
+
+use common::{TestServer, ferro_command};
+use ferrokinesis::store::StoreOptions;
+use ferrokinesis_core::capture::{CaptureOp, CaptureRecord};
+use serde_json::Value;
+use std::process::Stdio;
+use tempfile::NamedTempFile;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+#[tokio::test]
+async fn streams_create_list_describe_and_delete() {
+    let server = TestServer::new().await;
+
+    let output = ferro_command(&server)
+        .args(["streams", "create", "cli-stream", "--wait"])
+        .output()
+        .await
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = ferro_command(&server)
+        .args(["streams", "list"])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("cli-stream"));
+
+    let output = ferro_command(&server)
+        .args(["--json", "streams", "describe", "cli-stream"])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+    let body: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(body["StreamName"], "cli-stream");
+    assert_eq!(body["StreamStatus"], "ACTIVE");
+
+    let output = ferro_command(&server)
+        .args(["streams", "delete", "cli-stream", "--wait"])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+
+    let output = ferro_command(&server)
+        .args(["streams", "list"])
+        .output()
+        .await
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("cli-stream"));
+}
+
+#[tokio::test]
+async fn shards_and_consumers_commands_work() {
+    let server = TestServer::new().await;
+    server.create_stream("topology", 2).await;
+
+    let output = ferro_command(&server)
+        .args(["--ndjson", "shards", "list", "topology"])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.lines().count(), 2);
+
+    let output = ferro_command(&server)
+        .args(["consumers", "register", "topology", "c1"])
+        .output()
+        .await
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    server.wait_for_consumer_active("topology", "c1").await;
+
+    let output = ferro_command(&server)
+        .args(["--json", "consumers", "list", "topology"])
+        .output()
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(body["Consumers"].as_array().unwrap().len(), 1);
+
+    let output = ferro_command(&server)
+        .args(["--json", "consumers", "describe", "topology", "c1"])
+        .output()
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(body["ConsumerName"], "c1");
+    assert_eq!(body["ConsumerStatus"], "ACTIVE");
+
+    let output = ferro_command(&server)
+        .args(["consumers", "deregister", "topology", "c1"])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+}
+
+#[tokio::test]
+async fn put_supports_text_file_stdin_and_base64() {
+    let server = TestServer::new().await;
+    server.create_stream("puts", 1).await;
+
+    let output = ferro_command(&server)
+        .args(["put", "puts", "hello", "--partition-key", "pk1"])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+
+    let file = NamedTempFile::new().unwrap();
+    tokio::fs::write(file.path(), b"from-file").await.unwrap();
+    let output = ferro_command(&server)
+        .args([
+            "put",
+            "puts",
+            "--file",
+            file.path().to_str().unwrap(),
+            "--partition-key",
+            "pk2",
+        ])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+
+    let mut child = ferro_command(&server)
+        .args(["put", "puts", "--stdin", "--partition-key", "pk3"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"from-stdin")
+        .await
+        .unwrap();
+    let output = child.wait_with_output().await.unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = ferro_command(&server)
+        .args([
+            "put",
+            "puts",
+            "YjY0",
+            "--base64",
+            "--partition-key",
+            "pk4",
+            "--explicit-hash-key",
+            "12345",
+        ])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+
+    let iterator = server
+        .get_shard_iterator("puts", "shardId-000000000000", "TRIM_HORIZON")
+        .await;
+    let records = server.get_records(&iterator).await["Records"]
+        .as_array()
+        .unwrap()
+        .clone();
+    assert_eq!(records.len(), 4);
+    assert_eq!(records[0]["Data"], "aGVsbG8=");
+    assert_eq!(records[1]["Data"], "ZnJvbS1maWxl");
+    assert_eq!(records[2]["Data"], "ZnJvbS1zdGRpbg==");
+    assert_eq!(records[3]["Data"], "YjY0");
+}
+
+#[tokio::test]
+async fn tail_polling_reads_record_and_honors_limit() {
+    let server = TestServer::new().await;
+    server.create_stream("tail-stream", 1).await;
+
+    let child = ferro_command(&server)
+        .args([
+            "--json",
+            "tail",
+            "tail-stream",
+            "--from",
+            "trim-horizon",
+            "--limit",
+            "1",
+            "--poll-interval",
+            "100ms",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+    server.put_record("tail-stream", "aGVsbG8=", "pk1").await;
+
+    let output = tokio::time::timeout(
+        tokio::time::Duration::from_secs(10),
+        child.wait_with_output(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(body["PartitionKey"], "pk1");
+    assert_eq!(body["Data"], "aGVsbG8=");
+}
+
+#[tokio::test]
+async fn tail_polling_refreshes_expired_iterator() {
+    let server = TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        iterator_ttl_seconds: 1,
+        ..Default::default()
+    })
+    .await;
+    server.create_stream("tail-expire", 1).await;
+
+    let child = ferro_command(&server)
+        .args([
+            "--json",
+            "tail",
+            "tail-expire",
+            "--from",
+            "latest",
+            "--limit",
+            "1",
+            "--poll-interval",
+            "1500ms",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(3200)).await;
+    server
+        .put_record("tail-expire", "cmVmcmVzaA==", "pk-exp")
+        .await;
+
+    let output = tokio::time::timeout(
+        tokio::time::Duration::from_secs(12),
+        child.wait_with_output(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(body["PartitionKey"], "pk-exp");
+}
+
+#[tokio::test]
+async fn tail_efo_reads_records_and_missing_consumer_is_helpful() {
+    let server = TestServer::new().await;
+    server.create_stream("efo-stream", 1).await;
+
+    let output = ferro_command(&server)
+        .args(["tail", "efo-stream", "--consumer", "missing"])
+        .output()
+        .await
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("consumers register"));
+
+    server.register_consumer("efo-stream", "reader").await;
+    server
+        .wait_for_consumer_active("efo-stream", "reader")
+        .await;
+
+    let child = ferro_command(&server)
+        .args([
+            "--json",
+            "tail",
+            "efo-stream",
+            "--consumer",
+            "reader",
+            "--limit",
+            "1",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+    server.put_record("efo-stream", "ZWZv", "pk-efo").await;
+
+    let output = tokio::time::timeout(
+        tokio::time::Duration::from_secs(5),
+        child.wait_with_output(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(body["PartitionKey"], "pk-efo");
+}
+
+#[tokio::test]
+async fn replay_supports_stream_override_and_skip_bad_lines() {
+    let server = TestServer::new().await;
+    server.create_stream("replay-target", 1).await;
+
+    let capture = NamedTempFile::new().unwrap();
+    let lines = [
+        serde_json::to_string(&CaptureRecord {
+            op: CaptureOp::PutRecord,
+            ts: 1,
+            stream: "ignored".into(),
+            partition_key: "pk1".into(),
+            data: "aGVsbG8=".into(),
+            explicit_hash_key: None,
+            sequence_number: "1".into(),
+            shard_id: "shardId-000000000000".into(),
+        })
+        .unwrap(),
+        "{bad json}".into(),
+    ];
+    tokio::fs::write(capture.path(), lines.join("\n"))
+        .await
+        .unwrap();
+
+    let output = ferro_command(&server)
+        .args([
+            "replay",
+            capture.path().to_str().unwrap(),
+            "--stream",
+            "replay-target",
+        ])
+        .output()
+        .await
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let iterator = server
+        .get_shard_iterator("replay-target", "shardId-000000000000", "TRIM_HORIZON")
+        .await;
+    let records = server.get_records(&iterator).await["Records"]
+        .as_array()
+        .unwrap()
+        .clone();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["PartitionKey"], "pk1");
+}
+
+#[tokio::test]
+async fn replay_fail_fast_propagates_errors() {
+    let server = TestServer::new().await;
+    let capture = NamedTempFile::new().unwrap();
+    let line = serde_json::to_string(&CaptureRecord {
+        op: CaptureOp::PutRecord,
+        ts: 1,
+        stream: "missing-stream".into(),
+        partition_key: "pk1".into(),
+        data: "aGVsbG8=".into(),
+        explicit_hash_key: None,
+        sequence_number: "1".into(),
+        shard_id: "shardId-000000000000".into(),
+    })
+    .unwrap();
+    tokio::fs::write(capture.path(), format!("{line}\n"))
+        .await
+        .unwrap();
+
+    let output = ferro_command(&server)
+        .args(["replay", capture.path().to_str().unwrap(), "--fail-fast"])
+        .output()
+        .await
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("ResourceNotFoundException"));
+}
+
+#[tokio::test]
+async fn api_call_and_health_work() {
+    let server = TestServer::new().await;
+    server.create_stream("api-stream", 1).await;
+
+    let output = ferro_command(&server)
+        .args(["--json", "api", "call", "ListStreams"])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+    let body: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        body["StreamNames"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "api-stream")
+    );
+
+    let output = ferro_command(&server)
+        .args(["api", "call", "SubscribeToShard"])
+        .output()
+        .await
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("tail --consumer"));
+
+    let output = ferro_command(&server)
+        .args(["health"])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+}
+
+#[tokio::test]
+async fn tail_ndjson_emits_one_object_per_line() {
+    let server = TestServer::new().await;
+    server.create_stream("tail-ndjson", 1).await;
+
+    let mut child = ferro_command(&server)
+        .args([
+            "--ndjson",
+            "tail",
+            "tail-ndjson",
+            "--from",
+            "trim-horizon",
+            "--limit",
+            "1",
+        ])
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+    server
+        .put_record("tail-ndjson", "bmRqc29u", "pk-json")
+        .await;
+
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout).lines();
+    let line = tokio::time::timeout(tokio::time::Duration::from_secs(10), reader.next_line())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    let body: Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(body["PartitionKey"], "pk-json");
+}

--- a/crates/ferro-cli/tests/cli.rs
+++ b/crates/ferro-cli/tests/cli.rs
@@ -365,6 +365,8 @@ async fn tail_efo_reads_records_and_missing_consumer_is_helpful() {
             "efo-stream",
             "--consumer",
             "reader",
+            "--from",
+            "trim-horizon",
             "--limit",
             "1",
         ])
@@ -373,7 +375,7 @@ async fn tail_efo_reads_records_and_missing_consumer_is_helpful() {
         .spawn()
         .unwrap();
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
     server.put_record("efo-stream", "ZWZv", "pk-efo").await;
 
     let output = tokio::time::timeout(
@@ -394,6 +396,61 @@ async fn tail_efo_reads_records_and_missing_consumer_is_helpful() {
 }
 
 #[tokio::test]
+async fn tail_efo_resubscribes_after_session_rollover() {
+    let server = TestServer::with_options(StoreOptions {
+        create_stream_ms: 0,
+        delete_stream_ms: 0,
+        update_stream_ms: 0,
+        subscribe_to_shard_session_ms: 250,
+        ..Default::default()
+    })
+    .await;
+    server.create_stream("efo-rollover", 1).await;
+    server.register_consumer("efo-rollover", "reader").await;
+    server
+        .wait_for_consumer_active("efo-rollover", "reader")
+        .await;
+
+    let child = ferro_command(&server)
+        .args([
+            "--json",
+            "tail",
+            "efo-rollover",
+            "--consumer",
+            "reader",
+            "--from",
+            "trim-horizon",
+            "--limit",
+            "1",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(700)).await;
+    server
+        .put_record("efo-rollover", "cm9sbG92ZXI=", "pk-rollover")
+        .await;
+
+    let output = tokio::time::timeout(
+        tokio::time::Duration::from_secs(5),
+        child.wait_with_output(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body = parse_tail_json(&output.stdout);
+    assert_eq!(body.len(), 1);
+    assert_eq!(body[0]["PartitionKey"], "pk-rollover");
+}
+
+#[tokio::test]
 async fn tail_json_rejects_unbounded_follow() {
     let server = TestServer::new().await;
     server.create_stream("tail-json", 1).await;
@@ -408,6 +465,22 @@ async fn tail_json_rejects_unbounded_follow() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("--ndjson"));
     assert!(stderr.contains("--limit") || stderr.contains("--no-follow"));
+}
+
+#[tokio::test]
+async fn tail_limit_zero_is_rejected_by_clap() {
+    let server = TestServer::new().await;
+    let output = ferro_command(&server)
+        .args(["tail", "tail-zero", "--limit", "0"])
+        .output()
+        .await
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--limit"));
+    assert!(stderr.contains("0"));
+    assert!(stderr.contains("non-zero") || stderr.contains("zero"));
 }
 
 #[tokio::test]

--- a/crates/ferro-cli/tests/common.rs
+++ b/crates/ferro-cli/tests/common.rs
@@ -1,0 +1,192 @@
+use ferrokinesis::store::StoreOptions;
+use reqwest::Client;
+use serde_json::{Value, json};
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tokio::process::Command;
+
+pub const AMZ_JSON: &str = "application/x-amz-json-1.1";
+pub const VERSION: &str = "Kinesis_20131202";
+
+pub struct TestServer {
+    pub addr: SocketAddr,
+    pub client: Client,
+}
+
+impl TestServer {
+    pub async fn new() -> Self {
+        Self::with_options(StoreOptions {
+            create_stream_ms: 0,
+            delete_stream_ms: 0,
+            update_stream_ms: 0,
+            shard_limit: 50,
+            ..Default::default()
+        })
+        .await
+    }
+
+    pub async fn with_options(options: StoreOptions) -> Self {
+        let (app, _store) = ferrokinesis::create_app(options);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        Self {
+            addr,
+            client: Client::new(),
+        }
+    }
+
+    pub fn url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    pub async fn request(&self, target: &str, data: &Value) -> reqwest::Response {
+        self.client
+            .post(self.url())
+            .header("Content-Type", AMZ_JSON)
+            .header("X-Amz-Target", format!("{VERSION}.{target}"))
+            .header(
+                "Authorization",
+                "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=abcd1234",
+            )
+            .header("X-Amz-Date", "20150101T000000Z")
+            .body(serde_json::to_vec(data).unwrap())
+            .send()
+            .await
+            .unwrap()
+    }
+
+    pub async fn create_stream(&self, name: &str, shard_count: u32) {
+        let response = self
+            .request(
+                "CreateStream",
+                &json!({
+                    "StreamName": name,
+                    "ShardCount": shard_count,
+                }),
+            )
+            .await;
+        assert_eq!(response.status(), 200);
+    }
+
+    pub async fn put_record(&self, stream: &str, data: &str, partition_key: &str) {
+        let response = self
+            .request(
+                "PutRecord",
+                &json!({
+                    "StreamName": stream,
+                    "Data": data,
+                    "PartitionKey": partition_key,
+                }),
+            )
+            .await;
+        assert_eq!(response.status(), 200);
+    }
+
+    pub async fn describe_stream_summary(&self, stream: &str) -> Value {
+        let response = self
+            .request(
+                "DescribeStreamSummary",
+                &json!({
+                    "StreamName": stream,
+                }),
+            )
+            .await;
+        assert_eq!(response.status(), 200);
+        response.json::<Value>().await.unwrap()
+    }
+
+    pub async fn stream_arn(&self, stream: &str) -> String {
+        self.describe_stream_summary(stream).await["StreamDescriptionSummary"]["StreamARN"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    pub async fn register_consumer(&self, stream: &str, consumer: &str) -> String {
+        let stream_arn = self.stream_arn(stream).await;
+        let response = self
+            .request(
+                "RegisterStreamConsumer",
+                &json!({
+                    "StreamARN": stream_arn,
+                    "ConsumerName": consumer,
+                }),
+            )
+            .await;
+        assert_eq!(response.status(), 200);
+        response.json::<Value>().await.unwrap()["Consumer"]["ConsumerARN"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    pub async fn wait_for_consumer_active(&self, stream: &str, consumer: &str) {
+        let stream_arn = self.stream_arn(stream).await;
+        for _ in 0..20 {
+            let response = self
+                .request(
+                    "DescribeStreamConsumer",
+                    &json!({
+                        "StreamARN": stream_arn,
+                        "ConsumerName": consumer,
+                    }),
+                )
+                .await;
+            if response.status() == 200 {
+                let body = response.json::<Value>().await.unwrap();
+                if body["ConsumerDescription"]["ConsumerStatus"].as_str() == Some("ACTIVE") {
+                    return;
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        }
+        panic!("consumer did not become ACTIVE");
+    }
+
+    pub async fn get_shard_iterator(
+        &self,
+        stream: &str,
+        shard_id: &str,
+        iterator_type: &str,
+    ) -> String {
+        let response = self
+            .request(
+                "GetShardIterator",
+                &json!({
+                    "StreamName": stream,
+                    "ShardId": shard_id,
+                    "ShardIteratorType": iterator_type,
+                }),
+            )
+            .await;
+        assert_eq!(response.status(), 200);
+        response.json::<Value>().await.unwrap()["ShardIterator"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    pub async fn get_records(&self, iterator: &str) -> Value {
+        let response = self
+            .request(
+                "GetRecords",
+                &json!({
+                    "ShardIterator": iterator,
+                }),
+            )
+            .await;
+        assert_eq!(response.status(), 200);
+        response.json::<Value>().await.unwrap()
+    }
+}
+
+pub fn ferro_command(server: &TestServer) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ferro"));
+    command.env("FERROKINESIS_ENDPOINT", server.url());
+    command
+}

--- a/crates/ferrokinesis-core/src/capture.rs
+++ b/crates/ferrokinesis-core/src/capture.rs
@@ -1,0 +1,62 @@
+use alloc::string::String;
+#[cfg(feature = "std")]
+use alloc::vec::Vec;
+use serde::{Deserialize, Serialize};
+
+/// The capture operation type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CaptureOp {
+    /// A single `PutRecord` call.
+    PutRecord,
+    /// A `PutRecords` batch call.
+    PutRecords,
+}
+
+/// Owned capture record used for deserialization (replay) and tests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaptureRecord {
+    /// Which operation produced this record.
+    pub op: CaptureOp,
+    /// Timestamp in milliseconds since epoch.
+    pub ts: u64,
+    /// Stream name the record was written to.
+    pub stream: String,
+    /// Partition key (possibly scrubbed).
+    pub partition_key: String,
+    /// Record data (base64-encoded).
+    pub data: String,
+    /// Explicit hash key, if provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explicit_hash_key: Option<String>,
+    /// Sequence number from the response (informational).
+    pub sequence_number: String,
+    /// Shard ID from the response (informational).
+    pub shard_id: String,
+}
+
+/// Reads an NDJSON capture file into a `Vec<CaptureRecord>`.
+///
+/// Blank lines are silently skipped. Malformed lines are logged and skipped.
+///
+/// Note: loads the entire file into memory. For very large capture files,
+/// consider a streaming approach in the future.
+#[cfg(feature = "std")]
+pub fn read_capture_file(path: &std::path::Path) -> std::io::Result<Vec<CaptureRecord>> {
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut records = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<CaptureRecord>(&line) {
+            Ok(record) => records.push(record),
+            Err(error) => eprintln!("capture: skipping malformed line: {error}"),
+        }
+    }
+    Ok(records)
+}

--- a/crates/ferrokinesis-core/src/lib.rs
+++ b/crates/ferrokinesis-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate alloc;
 
+pub mod capture;
 pub mod constants;
 pub mod error;
 pub mod operation;

--- a/crates/ferrokinesis-core/src/operation.rs
+++ b/crates/ferrokinesis-core/src/operation.rs
@@ -190,6 +190,51 @@ impl FromStr for Operation {
 }
 
 impl Operation {
+    /// Returns the canonical operation name used in `X-Amz-Target`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Operation::AddTagsToStream => "AddTagsToStream",
+            Operation::CreateStream => "CreateStream",
+            Operation::DecreaseStreamRetentionPeriod => "DecreaseStreamRetentionPeriod",
+            Operation::DeleteResourcePolicy => "DeleteResourcePolicy",
+            Operation::DeleteStream => "DeleteStream",
+            Operation::DeregisterStreamConsumer => "DeregisterStreamConsumer",
+            Operation::DescribeAccountSettings => "DescribeAccountSettings",
+            Operation::DescribeLimits => "DescribeLimits",
+            Operation::DescribeStream => "DescribeStream",
+            Operation::DescribeStreamConsumer => "DescribeStreamConsumer",
+            Operation::DescribeStreamSummary => "DescribeStreamSummary",
+            Operation::DisableEnhancedMonitoring => "DisableEnhancedMonitoring",
+            Operation::EnableEnhancedMonitoring => "EnableEnhancedMonitoring",
+            Operation::GetRecords => "GetRecords",
+            Operation::GetResourcePolicy => "GetResourcePolicy",
+            Operation::GetShardIterator => "GetShardIterator",
+            Operation::IncreaseStreamRetentionPeriod => "IncreaseStreamRetentionPeriod",
+            Operation::ListShards => "ListShards",
+            Operation::ListStreamConsumers => "ListStreamConsumers",
+            Operation::ListStreams => "ListStreams",
+            Operation::ListTagsForResource => "ListTagsForResource",
+            Operation::ListTagsForStream => "ListTagsForStream",
+            Operation::MergeShards => "MergeShards",
+            Operation::PutRecord => "PutRecord",
+            Operation::PutRecords => "PutRecords",
+            Operation::PutResourcePolicy => "PutResourcePolicy",
+            Operation::RegisterStreamConsumer => "RegisterStreamConsumer",
+            Operation::RemoveTagsFromStream => "RemoveTagsFromStream",
+            Operation::SplitShard => "SplitShard",
+            Operation::StartStreamEncryption => "StartStreamEncryption",
+            Operation::StopStreamEncryption => "StopStreamEncryption",
+            Operation::SubscribeToShard => "SubscribeToShard",
+            Operation::TagResource => "TagResource",
+            Operation::UntagResource => "UntagResource",
+            Operation::UpdateAccountSettings => "UpdateAccountSettings",
+            Operation::UpdateMaxRecordSize => "UpdateMaxRecordSize",
+            Operation::UpdateShardCount => "UpdateShardCount",
+            Operation::UpdateStreamMode => "UpdateStreamMode",
+            Operation::UpdateStreamWarmThroughput => "UpdateStreamWarmThroughput",
+        }
+    }
+
     /// Returns the validation rules for this operation.
     pub fn validation_rules(&self) -> Vec<(&'static str, FieldDef)> {
         use validation::rules;

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -177,6 +177,7 @@ fn build_store_options(
         iterator_ttl_seconds: options
             .iterator_ttl_seconds
             .unwrap_or(defaults.iterator_ttl_seconds),
+        subscribe_to_shard_session_ms: defaults.subscribe_to_shard_session_ms,
         retention_check_interval_secs: options
             .retention_check_interval_secs
             .unwrap_or(defaults.retention_check_interval_secs),

--- a/crates/ferrokinesis-wasm/src/lib.rs
+++ b/crates/ferrokinesis-wasm/src/lib.rs
@@ -177,6 +177,7 @@ fn build_store_options(
         iterator_ttl_seconds: options
             .iterator_ttl_seconds
             .unwrap_or(defaults.iterator_ttl_seconds),
+        subscribe_to_shard_event_record_limit: defaults.subscribe_to_shard_event_record_limit,
         subscribe_to_shard_session_ms: defaults.subscribe_to_shard_session_ms,
         retention_check_interval_secs: options
             .retention_check_interval_secs

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,8 @@
 
 Runnable examples showing how to use ferrokinesis with various AWS SDKs.
 
+If you want a lighter local workflow, the release assets also ship the `ferro` companion CLI for creating streams, putting records, tailing traffic, and replaying captures against the same local server.
+
 ## Prerequisites
 
 1. A running ferrokinesis instance:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,6 +5,14 @@ git_tag_name = "v{{ version }}"
 git_release_name = "v{{ version }}"
 
 [[package]]
+name = "ferrokinesis-cli"
+release = false
+publish = false
+git_release_enable = false
+git_tag_enable = false
+changelog_update = false
+
+[[package]]
 name = "ferrokinesis-core"
 # still published to crates.io at the shared workspace version,
 # but no separate GitHub release or git tag (e.g. ferrokinesis-core-v0.x.x)

--- a/src/actions/subscribe_to_shard.rs
+++ b/src/actions/subscribe_to_shard.rs
@@ -11,8 +11,6 @@ use serde_json::{Value, json};
 
 /// Poll interval for new records
 const POLL_INTERVAL_MS: u64 = 200;
-/// Maximum number of records per SubscribeToShard event
-const SUBSCRIBE_EVENT_RECORD_LIMIT: usize = 10_000;
 
 /// Execute SubscribeToShard. Returns a streaming Body instead of JSON.
 /// `content_type` determines whether event payloads are JSON or CBOR-encoded.
@@ -181,6 +179,7 @@ pub async fn execute_streaming(
     let stream_name = stream_name.to_string();
     let shard_id = shard_id.to_string();
     let is_cbor = content_type == constants::CONTENT_TYPE_CBOR;
+    let event_record_limit = store.options.subscribe_to_shard_event_record_limit;
     let max_subscription_ms = store.options.subscribe_to_shard_session_ms;
 
     let stream = async_stream::stream! {
@@ -207,7 +206,7 @@ pub async fn execute_streaming(
             let range_start = format!("{}/{}", sequence::shard_ix_to_hex(shard_ix), current_seq);
             let range_end = sequence::shard_ix_to_hex(shard_ix + 1);
             let range_records = store
-                .get_records_range_limited(&stream_name, &range_start, &range_end, SUBSCRIBE_EVENT_RECORD_LIMIT)
+                .get_records_range_limited(&stream_name, &range_start, &range_end, event_record_limit)
                 .await;
 
             let mut records: Vec<ResponseRecord<'_>> = Vec::with_capacity(range_records.len());

--- a/src/actions/subscribe_to_shard.rs
+++ b/src/actions/subscribe_to_shard.rs
@@ -9,8 +9,6 @@ use axum::body::Body;
 use bytes::Bytes;
 use serde_json::{Value, json};
 
-/// Maximum subscription duration (5 minutes)
-const MAX_SUBSCRIPTION_MS: u64 = 300_000;
 /// Poll interval for new records
 const POLL_INTERVAL_MS: u64 = 200;
 /// Maximum number of records per SubscribeToShard event
@@ -183,6 +181,7 @@ pub async fn execute_streaming(
     let stream_name = stream_name.to_string();
     let shard_id = shard_id.to_string();
     let is_cbor = content_type == constants::CONTENT_TYPE_CBOR;
+    let max_subscription_ms = store.options.subscribe_to_shard_session_ms;
 
     let stream = async_stream::stream! {
         let mut current_seq = start_seq;
@@ -193,8 +192,7 @@ pub async fn execute_streaming(
         loop {
             let now = current_time_ms();
 
-            // Check 5-minute timeout
-            if now - start_time >= MAX_SUBSCRIPTION_MS {
+            if now - start_time >= max_subscription_ms {
                 break;
             }
 

--- a/src/bin/wasi.rs
+++ b/src/bin/wasi.rs
@@ -227,6 +227,7 @@ impl WasiConfig {
                     "FERROKINESIS_ITERATOR_TTL_SECONDS",
                 )?
                 .unwrap_or(defaults.iterator_ttl_seconds),
+                subscribe_to_shard_session_ms: defaults.subscribe_to_shard_session_ms,
                 retention_check_interval_secs: read_parsed_env(
                     &mut read,
                     "FERROKINESIS_RETENTION_CHECK_INTERVAL_SECS",

--- a/src/bin/wasi.rs
+++ b/src/bin/wasi.rs
@@ -227,6 +227,8 @@ impl WasiConfig {
                     "FERROKINESIS_ITERATOR_TTL_SECONDS",
                 )?
                 .unwrap_or(defaults.iterator_ttl_seconds),
+                subscribe_to_shard_event_record_limit: defaults
+                    .subscribe_to_shard_event_record_limit,
                 subscribe_to_shard_session_ms: defaults.subscribe_to_shard_session_ms,
                 retention_check_interval_secs: read_parsed_env(
                     &mut read,

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,45 +1,15 @@
-//! Stream capture and replay support.
+//! Stream capture support and shared replay format helpers.
 //!
 //! [`CaptureWriter`] records PutRecord/PutRecords calls to NDJSON files.
 //! [`read_capture_file`] reads them back for replay.
 
-use serde::{Deserialize, Serialize};
+pub use ferrokinesis_core::capture::{CaptureOp, CaptureRecord, read_capture_file};
+use serde::Serialize;
 use std::borrow::Cow;
 use std::fs::{File, OpenOptions};
-use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-
-/// The capture operation type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum CaptureOp {
-    /// A single `PutRecord` call.
-    PutRecord,
-    /// A `PutRecords` batch call.
-    PutRecords,
-}
-
-/// Owned capture record used for deserialization (replay) and tests.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CaptureRecord {
-    /// Which operation produced this record.
-    pub op: CaptureOp,
-    /// Timestamp in milliseconds since epoch.
-    pub ts: u64,
-    /// Stream name the record was written to.
-    pub stream: String,
-    /// Partition key (possibly scrubbed).
-    pub partition_key: String,
-    /// Record data (base64-encoded).
-    pub data: String,
-    /// Explicit hash key, if provided.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub explicit_hash_key: Option<String>,
-    /// Sequence number from the response (informational).
-    pub sequence_number: String,
-    /// Shard ID from the response (informational).
-    pub shard_id: String,
-}
 
 /// Borrowing capture record for zero-copy serialization on the hot path.
 ///
@@ -141,32 +111,6 @@ impl CaptureWriter {
             tracing::warn!("capture: flush error: {e}");
         }
     }
-}
-
-/// Reads an NDJSON capture file into a `Vec<CaptureRecord>`.
-///
-/// Blank lines are silently skipped. Malformed lines are logged and skipped.
-///
-/// Note: loads the entire file into memory. For very large capture files,
-/// consider a streaming approach in the future.
-///
-/// Uses `eprintln!` because this runs in the replay subcommand, outside the
-/// tracing subscriber (same convention as health-check / generate-cert).
-pub fn read_capture_file(path: &Path) -> io::Result<Vec<CaptureRecord>> {
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
-    let mut records = Vec::new();
-    for line in reader.lines() {
-        let line = line?;
-        if line.trim().is_empty() {
-            continue;
-        }
-        match serde_json::from_str::<CaptureRecord>(&line) {
-            Ok(r) => records.push(r),
-            Err(e) => eprintln!("capture: skipping malformed line: {e}"),
-        }
-    }
-    Ok(records)
 }
 
 /// Deterministic anonymisation of a partition key.

--- a/src/main.rs
+++ b/src/main.rs
@@ -469,6 +469,7 @@ fn resolve_store_options(
             file_cfg.iterator_ttl_seconds,
             || defaults.iterator_ttl_seconds,
         ),
+        subscribe_to_shard_event_record_limit: defaults.subscribe_to_shard_event_record_limit,
         subscribe_to_shard_session_ms: defaults.subscribe_to_shard_session_ms,
         retention_check_interval_secs: resolve(
             args.retention_check_interval_secs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,10 +48,6 @@ enum Command {
     /// Run a health check against a running server (for Docker HEALTHCHECK)
     HealthCheck(HealthCheckArgs),
 
-    /// Replay captured PutRecord data against a running server
-    #[cfg(feature = "replay")]
-    Replay(ReplayArgs),
-
     /// Generate a self-signed TLS certificate and key
     #[cfg(feature = "tls")]
     GenerateCert(GenerateCertArgs),
@@ -518,41 +514,6 @@ struct HealthCheckArgs {
     tls: bool,
 }
 
-#[cfg(feature = "replay")]
-#[derive(Args, Debug)]
-struct ReplayArgs {
-    /// Path to the NDJSON capture file
-    #[arg(long)]
-    file: PathBuf,
-
-    /// Host of the target server
-    #[arg(long, default_value = "127.0.0.1")]
-    host: String,
-
-    /// Port of the target server
-    #[arg(long, default_value_t = 4567)]
-    port: u16,
-
-    /// Replay speed multiplier (e.g. "1x", "10x", "max")
-    #[arg(long, default_value = "1x")]
-    replay_speed: String,
-
-    /// Use TLS (HTTPS) when connecting to the target server
-    #[arg(long)]
-    tls: bool,
-
-    /// Skip TLS certificate verification (for self-signed certificates)
-    #[arg(long, requires = "tls")]
-    tls_insecure: bool,
-}
-
-#[cfg(feature = "replay")]
-#[derive(Debug)]
-enum ReplaySpeed {
-    Max,
-    Multiplier(f64),
-}
-
 #[cfg(feature = "tls")]
 #[derive(Args, Debug)]
 struct GenerateCertArgs {
@@ -575,8 +536,6 @@ fn main() -> ExitCode {
     match cli.command {
         Some(Command::HealthCheck(args)) => run_health_check(&args),
         Some(Command::Serve(args)) => run_serve(*args),
-        #[cfg(feature = "replay")]
-        Some(Command::Replay(args)) => run_replay(args),
         #[cfg(feature = "tls")]
         Some(Command::GenerateCert(args)) => run_generate_cert(&args),
         None => run_serve(cli.serve_args),
@@ -825,123 +784,6 @@ fn parse_health_response(reader: BufReader<impl std::io::Read>) -> ExitCode {
         eprintln!("health check failed: {status_line}");
         ExitCode::FAILURE
     }
-}
-
-#[cfg(feature = "replay")]
-#[tokio::main]
-async fn run_replay(args: ReplayArgs) -> ExitCode {
-    use ferrokinesis::constants;
-
-    let speed = match parse_replay_speed(&args.replay_speed) {
-        Ok(s) => s,
-        Err(()) => {
-            eprintln!(
-                "invalid replay speed {:?}: expected \"<N>x\" (e.g. \"1x\", \"10x\") or \"max\"",
-                args.replay_speed
-            );
-            return ExitCode::FAILURE;
-        }
-    };
-
-    let mut records = match ferrokinesis::capture::read_capture_file(&args.file) {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("failed to read capture file: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
-
-    if records.is_empty() {
-        println!("capture file is empty, nothing to replay");
-        return ExitCode::SUCCESS;
-    }
-
-    records.sort_by_key(|r| r.ts);
-
-    let scheme = if args.tls { "https" } else { "http" };
-    let base_url = format!("{scheme}://{}:{}", args.host, args.port);
-    let client = reqwest::Client::builder()
-        .danger_accept_invalid_certs(args.tls_insecure)
-        .connect_timeout(Duration::from_secs(10))
-        .timeout(Duration::from_secs(30))
-        .build()
-        .expect("failed to build HTTP client");
-    let total = records.len();
-    let start = std::time::Instant::now();
-
-    // Replay always uses individual PutRecord calls regardless of the original
-    // CaptureOp. Batching captured PutRecords back into PutRecords batches
-    // could be a future optimization.
-    for (i, record) in records.iter().enumerate() {
-        // Sleep based on timestamp delta
-        if let ReplaySpeed::Multiplier(multiplier) = speed
-            && i > 0
-        {
-            let delta_ms = record.ts.saturating_sub(records[i - 1].ts);
-            if delta_ms > 0 {
-                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                let sleep_ms = (delta_ms as f64 / multiplier) as u64;
-                if sleep_ms > 0 {
-                    tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
-                }
-            }
-        }
-
-        let mut body = serde_json::json!({
-            constants::STREAM_NAME: record.stream,
-            constants::DATA: record.data,
-            constants::PARTITION_KEY: record.partition_key,
-        });
-        if let Some(ref ehk) = record.explicit_hash_key {
-            body[constants::EXPLICIT_HASH_KEY] = serde_json::Value::String(ehk.clone());
-        }
-
-        let resp = client
-            .post(&base_url)
-            .header("Content-Type", constants::CONTENT_TYPE_JSON)
-            .header("X-Amz-Target", format!("{}.PutRecord", constants::KINESIS_API))
-            .header(
-                "Authorization",
-                "AWS4-HMAC-SHA256 Credential=AKID/20150101/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=abcd1234",
-            )
-            .header("X-Amz-Date", "20150101T000000Z")
-            .json(&body)
-            .send()
-            .await;
-
-        match resp {
-            Ok(r) if r.status().is_success() => {}
-            Ok(r) => {
-                let status = r.status();
-                let body = r.text().await.unwrap_or_default();
-                eprintln!("record {}/{total}: HTTP {status}: {body}", i + 1);
-            }
-            Err(e) => {
-                eprintln!("record {}/{total}: request failed: {e}", i + 1);
-            }
-        }
-    }
-
-    let elapsed = start.elapsed();
-    println!("replayed {total} records in {:.2}s", elapsed.as_secs_f64());
-    ExitCode::SUCCESS
-}
-
-/// Parse a replay speed string like "1x", "10x", "0.5x", or "max".
-/// Returns `Ok(ReplaySpeed)` on success, `Err(())` on invalid input.
-#[cfg(feature = "replay")]
-fn parse_replay_speed(s: &str) -> Result<ReplaySpeed, ()> {
-    if s == "max" {
-        return Ok(ReplaySpeed::Max);
-    }
-    let Some(s) = s.strip_suffix('x') else {
-        return Err(());
-    };
-    s.parse::<f64>()
-        .ok()
-        .filter(|v| *v > 0.0)
-        .map(ReplaySpeed::Multiplier)
-        .ok_or(())
 }
 
 async fn shutdown_signal() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -469,6 +469,7 @@ fn resolve_store_options(
             file_cfg.iterator_ttl_seconds,
             || defaults.iterator_ttl_seconds,
         ),
+        subscribe_to_shard_session_ms: defaults.subscribe_to_shard_session_ms,
         retention_check_interval_secs: resolve(
             args.retention_check_interval_secs,
             file_cfg.retention_check_interval_secs,

--- a/src/store.rs
+++ b/src/store.rs
@@ -237,6 +237,9 @@ pub struct StoreOptions {
     pub shard_limit: u32,
     /// Shard iterator TTL in seconds. Iterators older than this are expired. Defaults to `300`.
     pub iterator_ttl_seconds: u64,
+    /// Maximum number of records emitted in a single `SubscribeToShard` event.
+    /// Defaults to `10_000`.
+    pub subscribe_to_shard_event_record_limit: usize,
     /// Maximum lifetime of a single `SubscribeToShard` session in milliseconds.
     /// Defaults to `300_000` (5 minutes).
     pub subscribe_to_shard_session_ms: u64,
@@ -263,6 +266,7 @@ impl Default for StoreOptions {
             update_stream_ms: 500,
             shard_limit: 10,
             iterator_ttl_seconds: 300,
+            subscribe_to_shard_event_record_limit: 10_000,
             subscribe_to_shard_session_ms: 300_000,
             retention_check_interval_secs: 0,
             enforce_limits: false,

--- a/src/store.rs
+++ b/src/store.rs
@@ -237,6 +237,9 @@ pub struct StoreOptions {
     pub shard_limit: u32,
     /// Shard iterator TTL in seconds. Iterators older than this are expired. Defaults to `300`.
     pub iterator_ttl_seconds: u64,
+    /// Maximum lifetime of a single `SubscribeToShard` session in milliseconds.
+    /// Defaults to `300_000` (5 minutes).
+    pub subscribe_to_shard_session_ms: u64,
     /// Background retention-reaper check interval in seconds.
     /// Set to `0` (default) to disable the reaper.
     pub retention_check_interval_secs: u64,
@@ -260,6 +263,7 @@ impl Default for StoreOptions {
             update_stream_ms: 500,
             shard_limit: 10,
             iterator_ttl_seconds: 300,
+            subscribe_to_shard_session_ms: 300_000,
             retention_check_interval_secs: 0,
             enforce_limits: false,
             durable: None,


### PR DESCRIPTION
## Summary
- add the new `ferro` companion CLI workspace crate with streams, shards, consumers, put, tail, replay, health, and raw `api call` commands
- move the owned capture/replay model into `ferrokinesis-core` and remove the old server-side replay subcommand
- ship and document `ferro` through CI, release assets, and the Docker image

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_INCREMENTAL=0 cargo test --workspace`
- `cargo test --features tls`
- `cargo build -p ferrokinesis-core --no-default-features`
- `cargo test --no-default-features --lib`