### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add ferro companion CLI ([#153](https://github.com/mandrean/ferrokinesis/pull/153)) ([#226](https://github.com/mandrean/ferrokinesis/pull/226))
 - *(observability)* bootstrap JSON logs and optional OTLP trace export ([#212](https://github.com/mandrean/ferrokinesis/pull/212))
 - add durable single-node state mode ([#203](https://github.com/mandrean/ferrokinesis/pull/203))
+- add PutRecords partial failure responses ([#200](https://github.com/mandrean/ferrokinesis/pull/200))
+- add optional shard write throttling ([#199](https://github.com/mandrean/ferrokinesis/pull/199))
+- add h2c support for plain listeners ([#197](https://github.com/mandrean/ferrokinesis/pull/197))
 
 ### Other
 
 - parallelize check workflow ([#225](https://github.com/mandrean/ferrokinesis/pull/225))
 - clarify mirror credential feature flags ([#214](https://github.com/mandrean/ferrokinesis/pull/214))
-- clarify mirror credential feature flags
+- update rand for security audit ([#202](https://github.com/mandrean/ferrokinesis/pull/202))
+- run workflows for stacked pull requests ([#205](https://github.com/mandrean/ferrokinesis/pull/205))
 
 ## [0.6.0](https://github.com/mandrean/ferrokinesis/compare/v0.5.0...v0.6.0) - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/mandrean/ferrokinesis/compare/v0.6.0...v0.7.0) - 2026-04-12
+
+### Added
+
+- add ferro companion CLI ([#153](https://github.com/mandrean/ferrokinesis/pull/153)) ([#226](https://github.com/mandrean/ferrokinesis/pull/226))
+- *(observability)* bootstrap JSON logs and optional OTLP trace export ([#212](https://github.com/mandrean/ferrokinesis/pull/212))
+- add durable single-node state mode ([#203](https://github.com/mandrean/ferrokinesis/pull/203))
+
+### Other
+
+- parallelize check workflow ([#225](https://github.com/mandrean/ferrokinesis/pull/225))
+- clarify mirror credential feature flags ([#214](https://github.com/mandrean/ferrokinesis/pull/214))
+- clarify mirror credential feature flags
+
 ## [0.6.0](https://github.com/mandrean/ferrokinesis/compare/v0.5.0...v0.6.0) - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrokinesis"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes",
  "async-stream",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "ferrokinesis-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "ferrokinesis-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes",
  "base64",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "ferrokinesis-wasm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "axum",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"
@@ -85,7 +85,7 @@ loadtest = ["rt", "dep:goose", "tokio/rt-multi-thread"]
 tls = ["server", "dep:axum-server", "dep:rcgen", "dep:rustls"]
 
 [dependencies]
-ferrokinesis-core = { path = "crates/ferrokinesis-core", version = "0.6.0" }
+ferrokinesis-core = { path = "crates/ferrokinesis-core", version = "0.7.0" }
 backon = { version = "1.6", default-features = false, features = ["tokio-sleep"], optional = true }
 aws-config = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "credentials-process"] }
 aws-credential-types = { version = "1", optional = true }

--- a/crates/ferro-cli/Cargo.toml
+++ b/crates/ferro-cli/Cargo.toml
@@ -18,7 +18,7 @@ base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { version = "4", features = ["derive", "env"] }
-ferrokinesis-core = { path = "../ferrokinesis-core", version = "0.6.0" }
+ferrokinesis-core = { path = "../ferrokinesis-core", version = "0.7.0" }
 futures-util = "0.3"
 hex = "0.4"
 humantime = "2"


### PR DESCRIPTION



## 🤖 New release

* `ferrokinesis-core`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `ferrokinesis`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)

### ⚠ `ferrokinesis` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FileConfig.enforce_limits in /tmp/.tmp9angMU/ferrokinesis/src/config.rs:76
  field FileConfig.state_dir in /tmp/.tmp9angMU/ferrokinesis/src/config.rs:78
  field FileConfig.snapshot_interval_secs in /tmp/.tmp9angMU/ferrokinesis/src/config.rs:80
  field FileConfig.max_retained_bytes in /tmp/.tmp9angMU/ferrokinesis/src/config.rs:82
  field FileConfig.log_format in /tmp/.tmp9angMU/ferrokinesis/src/config.rs:88
  field FileConfig.otlp_endpoint in /tmp/.tmp9angMU/ferrokinesis/src/config.rs:90
  field FileConfig.otlp_protocol in /tmp/.tmp9angMU/ferrokinesis/src/config.rs:92
  field FileConfig.otel_sample_ratio in /tmp/.tmp9angMU/ferrokinesis/src/config.rs:94
  field FileConfig.otel_service_name in /tmp/.tmp9angMU/ferrokinesis/src/config.rs:96
  field StoreOptions.subscribe_to_shard_event_record_limit in /tmp/.tmp9angMU/ferrokinesis/src/store.rs:242
  field StoreOptions.subscribe_to_shard_session_ms in /tmp/.tmp9angMU/ferrokinesis/src/store.rs:245
  field StoreOptions.enforce_limits in /tmp/.tmp9angMU/ferrokinesis/src/store.rs:250
  field StoreOptions.durable in /tmp/.tmp9angMU/ferrokinesis/src/store.rs:252
  field StoreOptions.max_retained_bytes in /tmp/.tmp9angMU/ferrokinesis/src/store.rs:254

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum ferrokinesis::capture::CaptureOp, previously in file /tmp/.tmpZrZyhm/ferrokinesis/src/capture.rs:15

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_missing.ron

Failed in:
  feature replay in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function ferrokinesis::capture::read_capture_file, previously in file /tmp/.tmpZrZyhm/ferrokinesis/src/capture.rs:155

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  ferrokinesis::server::handler now takes 7 parameters instead of 6, in /tmp/.tmp9angMU/ferrokinesis/src/server.rs:65

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct ferrokinesis::capture::CaptureRecord, previously in file /tmp/.tmpZrZyhm/ferrokinesis/src/capture.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `ferrokinesis`

<blockquote>

## [0.7.0](https://github.com/mandrean/ferrokinesis/compare/v0.6.0...v0.7.0) - 2026-04-12

### Added

- add ferro companion CLI ([#153](https://github.com/mandrean/ferrokinesis/pull/153)) ([#226](https://github.com/mandrean/ferrokinesis/pull/226))
- *(observability)* bootstrap JSON logs and optional OTLP trace export ([#212](https://github.com/mandrean/ferrokinesis/pull/212))
- add durable single-node state mode ([#203](https://github.com/mandrean/ferrokinesis/pull/203))
- add PutRecords partial failure responses ([#200](https://github.com/mandrean/ferrokinesis/pull/200))
- add optional shard write throttling ([#199](https://github.com/mandrean/ferrokinesis/pull/199))
- add h2c support for plain listeners ([#197](https://github.com/mandrean/ferrokinesis/pull/197))

### Other

- parallelize check workflow ([#225](https://github.com/mandrean/ferrokinesis/pull/225))
- clarify mirror credential feature flags ([#214](https://github.com/mandrean/ferrokinesis/pull/214))
- update rand for security audit ([#202](https://github.com/mandrean/ferrokinesis/pull/202))
- run workflows for stacked pull requests ([#205](https://github.com/mandrean/ferrokinesis/pull/205))

</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
